### PR TITLE
Use FQCN for action plugin modules and align copy behaviour

### DIFF
--- a/plugins/action/win_copy.py
+++ b/plugins/action/win_copy.py
@@ -260,7 +260,7 @@ class ActionModule(ActionBase):
         if content is not None:
             os.remove(content_tempfile)
 
-    def _copy_single_file(self, local_file, dest, source_rel, task_vars, tmp, backup):
+    def _copy_single_file(self, local_file, dest, source_rel, dest_rel, task_vars, tmp, backup):
         if self._play_context.check_mode:
             module_return = dict(changed=True)
             return module_return
@@ -281,7 +281,7 @@ class ActionModule(ActionBase):
         )
         copy_args.pop('content', None)
 
-        copy_result = self._execute_module(module_name="copy",
+        copy_result = self._execute_module(module_name="ansible.windows.win_copy",
                                            module_args=copy_args,
                                            task_vars=task_vars)
 
@@ -323,7 +323,7 @@ class ActionModule(ActionBase):
             )
         )
         copy_args.pop('content', None)
-        module_return = self._execute_module(module_name='copy',
+        module_return = self._execute_module(module_name='ansible.windows.win_copy',
                                              module_args=copy_args,
                                              task_vars=task_vars)
         shutil.rmtree(os.path.dirname(zip_path))
@@ -391,7 +391,9 @@ class ActionModule(ActionBase):
                 )
             )
             new_module_args.pop('content', None)
-            result.update(self._execute_module(module_args=new_module_args, task_vars=task_vars))
+            result.update(self._execute_module(module_name="ansible.windows.win_copy",
+                                               module_args=new_module_args,
+                                               task_vars=task_vars))
             return result
         # find_needle returns a path that may not have a trailing slash on a
         # directory so we need to find that out first and append at the end
@@ -483,7 +485,8 @@ class ActionModule(ActionBase):
         query_args.pop('src', None)
 
         query_args.pop('content', None)
-        query_return = self._execute_module(module_args=query_args,
+        query_return = self._execute_module(module_name="ansible.windows.win_copy",
+                                            module_args=query_args,
                                             task_vars=task_vars)
 
         if query_return.get('failed') is True:
@@ -497,7 +500,7 @@ class ActionModule(ActionBase):
             # we only need to copy 1 file, don't mess around with zips
             file_src = query_return['files'][0]['src']
             file_dest = query_return['files'][0]['dest']
-            result.update(self._copy_single_file(file_src, dest, file_dest,
+            result.update(self._copy_single_file(file_src, dest, original_basename, file_dest,
                                                  task_vars, self._connection._shell.tmpdir, backup))
             if result.get('failed') is True:
                 result['msg'] = "failed to copy file %s: %s" % (file_src, result['msg'])

--- a/plugins/action/win_template.py
+++ b/plugins/action/win_template.py
@@ -1,29 +1,177 @@
-# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2015, Michael DeHaan <michael.dehaan@gmail.com>
+# Copyright: (c) 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os
+import shutil
+import stat
+import tempfile
+
+from ansible import constants as C
+from ansible.config.manager import ensure_type
+from ansible.errors import AnsibleError, AnsibleFileNotFound, AnsibleAction, AnsibleActionFail
+from ansible.module_utils._text import to_bytes, to_text, to_native
+from ansible.module_utils.parsing.convert_bool import boolean
+from ansible.module_utils.six import string_types
 from ansible.plugins.action import ActionBase
-from ansible.plugins.action.template import ActionModule as TemplateActionModule
+from ansible.template import generate_ansible_template_vars
 
 
-# Even though TemplateActionModule inherits from ActionBase, we still need to
-# directly inherit from ActionBase to appease the plugin loader.
-class ActionModule(TemplateActionModule, ActionBase):
-    DEFAULT_NEWLINE_SEQUENCE = '\r\n'
+class ActionModule(ActionBase):
+
+    TRANSFERS_FILES = True
+
+    def run(self, tmp=None, task_vars=None):
+        ''' handler for template operations '''
+
+        if task_vars is None:
+            task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        # Options type validation
+        # stings
+        for s_type in ('src', 'dest', 'state', 'newline_sequence', 'variable_start_string', 'variable_end_string', 'block_start_string',
+                       'block_end_string'):
+            if s_type in self._task.args:
+                value = ensure_type(self._task.args[s_type], 'string')
+                if value is not None and not isinstance(value, string_types):
+                    raise AnsibleActionFail("%s is expected to be a string, but got %s instead" % (s_type, type(value)))
+                self._task.args[s_type] = value
+
+        # booleans
+        try:
+            trim_blocks = boolean(self._task.args.get('trim_blocks', True), strict=False)
+            lstrip_blocks = boolean(self._task.args.get('lstrip_blocks', False), strict=False)
+        except TypeError as e:
+            raise AnsibleActionFail(to_native(e))
+
+        # assign to local vars for ease of use
+        source = self._task.args.get('src', None)
+        dest = self._task.args.get('dest', None)
+        state = self._task.args.get('state', None)
+        newline_sequence = self._task.args.get('newline_sequence', "\r\n")
+        variable_start_string = self._task.args.get('variable_start_string', None)
+        variable_end_string = self._task.args.get('variable_end_string', None)
+        block_start_string = self._task.args.get('block_start_string', None)
+        block_end_string = self._task.args.get('block_end_string', None)
+        output_encoding = self._task.args.get('output_encoding', 'utf-8') or 'utf-8'
+
+        # Option `lstrip_blocks' was added in Jinja2 version 2.7.
+        if lstrip_blocks:
+            try:
+                import jinja2.defaults
+            except ImportError:
+                raise AnsibleError('Unable to import Jinja2 defaults for determining Jinja2 features.')
+
+            try:
+                jinja2.defaults.LSTRIP_BLOCKS
+            except AttributeError:
+                raise AnsibleError("Option `lstrip_blocks' is only available in Jinja2 versions >=2.7")
+
+        wrong_sequences = ["\\n", "\\r", "\\r\\n"]
+        allowed_sequences = ["\n", "\r", "\r\n"]
+
+        # We need to convert unescaped sequences to proper escaped sequences for Jinja2
+        if newline_sequence in wrong_sequences:
+            newline_sequence = allowed_sequences[wrong_sequences.index(newline_sequence)]
+
+        try:
+            # logical validation
+            if state is not None:
+                raise AnsibleActionFail("'state' cannot be specified on a template")
+            elif source is None or dest is None:
+                raise AnsibleActionFail("src and dest are required")
+            elif newline_sequence not in allowed_sequences:
+                raise AnsibleActionFail("newline_sequence needs to be one of: \n, \r or \r\n")
+            else:
+                try:
+                    source = self._find_needle('templates', source)
+                except AnsibleError as e:
+                    raise AnsibleActionFail(to_text(e))
+
+            # Get vault decrypted tmp file
+            try:
+                tmp_source = self._loader.get_real_file(source)
+            except AnsibleFileNotFound as e:
+                raise AnsibleActionFail("could not find src=%s, %s" % (source, to_text(e)))
+            b_tmp_source = to_bytes(tmp_source, errors='surrogate_or_strict')
+
+            # template the source data locally & get ready to transfer
+            try:
+                with open(b_tmp_source, 'rb') as f:
+                    try:
+                        template_data = to_text(f.read(), errors='surrogate_or_strict')
+                    except UnicodeError:
+                        raise AnsibleActionFail("Template source files must be utf-8 encoded")
+
+                # set jinja2 internal search path for includes
+                searchpath = task_vars.get('ansible_search_path', [])
+                searchpath.extend([self._loader._basedir, os.path.dirname(source)])
+
+                # We want to search into the 'templates' subdir of each search path in
+                # addition to our original search paths.
+                newsearchpath = []
+                for p in searchpath:
+                    newsearchpath.append(os.path.join(p, 'templates'))
+                    newsearchpath.append(p)
+                searchpath = newsearchpath
+
+                # add ansible 'template' vars
+                temp_vars = task_vars.copy()
+                temp_vars.update(generate_ansible_template_vars(source, dest))
+
+                with self._templar.set_temporary_context(searchpath=searchpath, newline_sequence=newline_sequence,
+                                                         block_start_string=block_start_string, block_end_string=block_end_string,
+                                                         variable_start_string=variable_start_string, variable_end_string=variable_end_string,
+                                                         trim_blocks=trim_blocks, lstrip_blocks=lstrip_blocks,
+                                                         available_variables=temp_vars):
+                    resultant = self._templar.do_template(template_data, preserve_trailing_newlines=True, escape_backslashes=False)
+            except AnsibleAction:
+                raise
+            except Exception as e:
+                raise AnsibleActionFail("%s: %s" % (type(e).__name__, to_text(e)))
+            finally:
+                self._loader.cleanup_tmp_file(b_tmp_source)
+
+            new_task = self._task.copy()
+
+            # remove 'template only' options:
+            for remove in ('newline_sequence', 'block_start_string', 'block_end_string', 'variable_start_string', 'variable_end_string',
+                           'trim_blocks', 'lstrip_blocks', 'output_encoding'):
+                new_task.args.pop(remove, None)
+
+            local_tempdir = tempfile.mkdtemp(dir=C.DEFAULT_LOCAL_TMP)
+
+            try:
+                result_file = os.path.join(local_tempdir, os.path.basename(source))
+                with open(to_bytes(result_file, errors='surrogate_or_strict'), 'wb') as f:
+                    f.write(to_bytes(resultant, encoding=output_encoding, errors='surrogate_or_strict'))
+
+                new_task.args.update(
+                    dict(
+                        src=result_file,
+                        dest=dest,
+                    ),
+                )
+                copy_action = self._shared_loader_obj.action_loader.get('ansible.windows.win_copy',
+                                                                        task=new_task,
+                                                                        connection=self._connection,
+                                                                        play_context=self._play_context,
+                                                                        loader=self._loader,
+                                                                        templar=self._templar,
+                                                                        shared_loader_obj=self._shared_loader_obj)
+                result.update(copy_action.run(task_vars=task_vars))
+            finally:
+                shutil.rmtree(to_bytes(local_tempdir, errors='surrogate_or_strict'))
+
+        except AnsibleAction as e:
+            result.update(e.result)
+        finally:
+            self._remove_tmp_path(self._connection._shell.tmpdir)
+
+        return result

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -21,7 +21,7 @@ class ActionModule(ActionBase):
     def _run_win_updates(self, module_args, task_vars, use_task):
         display.vvv("win_updates: running win_updates module")
         wrap_async = self._task.async_val
-        result = self._execute_module_with_become(module_name='win_updates',
+        result = self._execute_module_with_become(module_name='ansible.windows.win_updates',
                                                   module_args=module_args,
                                                   task_vars=task_vars,
                                                   wrap_async=wrap_async,
@@ -33,7 +33,7 @@ class ActionModule(ActionBase):
         reboot_args = {
             'reboot_timeout': reboot_timeout
         }
-        reboot_result = self._run_action_plugin('win_reboot', task_vars,
+        reboot_result = self._run_action_plugin('ansible.windows.win_reboot', task_vars,
                                                 module_args=reboot_args)
         if reboot_result.get('failed', False):
             raise AnsibleError(reboot_result['msg'])
@@ -59,7 +59,7 @@ class ActionModule(ActionBase):
 
             try:
                 shell_result = self._execute_module_with_become(
-                    module_name='win_shell', module_args=shell_module_args,
+                    module_name='ansible.windows.win_shell', module_args=shell_module_args,
                     task_vars=task_vars, wrap_async=False, use_task=use_task
                 )
                 display.vvv("win_updates: shell wait results: %s"

--- a/plugins/modules/win_template.py
+++ b/plugins/modules/win_template.py
@@ -13,6 +13,19 @@ DOCUMENTATION = r'''
 ---
 module: win_template
 short_description: Template a file out to a remote server
+description:
+- Templates are processed by the L(Jinja2 templating language,http://jinja.pocoo.org/docs/).
+- Documentation on the template formatting can be found in the
+  L(Template Designer Documentation,http://jinja.pocoo.org/docs/templates/).
+- Additional variables listed below can be used in templates.
+- C(ansible_managed) (configurable via the C(defaults) section of C(ansible.cfg)) contains a string which can be used to
+  describe the template name, host, modification time of the template file and the owner uid.
+- C(template_host) contains the node name of the template's machine.
+- C(template_uid) is the numeric user id of the owner.
+- C(template_path) is the path of the template.
+- C(template_fullpath) is the absolute path of the template.
+- C(template_destpath) is the path of the template on the remote system (added in 2.8).
+- C(template_run_date) is the date that the template was rendered.
 options:
   backup:
     description:
@@ -21,9 +34,84 @@ options:
       so you can get the original file back if you somehow clobbered it incorrectly.
     type: bool
     default: no
+  block_end_string:
+    description:
+    - The string marking the end of a block.
+    type: str
+    default: '%}'
+  block_start_string:
+    description:
+    - The string marking the beginning of a block.
+    type: str
+    default: '{%'
+  dest:
+    description:
+    - Location to render the template to on the remote machine.
+    type: path
+    required: yes
+  force:
+    description:
+    - Determine when the file is being transferred if the destination already exists.
+    - When set to C(yes), replace the remote file when contents are different than the source.
+    - When set to C(no), the file will only be transferred if the destination does not exist.
+    type: bool
+    default: yes
+  lstrip_blocks:
+    description:
+    - Determine when leading spaces and tabs should be stripped.
+    - When set to C(yes) leading spaces and tabs are stripped from the start of a line to a block.
+    - This functionality requires Jinja 2.7 or newer.
+    type: bool
+    default: no
   newline_sequence:
+    description:
+    - Specify the newline sequence to use for templating files.
+    type: str
+    choices: [ '\n', '\r', '\r\n' ]
     default: '\r\n'
+  output_encoding:
+    description:
+    - Overrides the encoding used to write the template file defined by C(dest).
+    - It defaults to C(utf-8), but any encoding supported by python can be used.
+    - The source template file must always be encoded using C(utf-8), for homogeneity.
+    type: str
+    default: utf-8
+  src:
+    description:
+    - Path of a Jinja2 formatted template on the Ansible controller.
+    - This can be a relative or an absolute path.
+    - The file must be encoded with C(utf-8) but I(output_encoding) can be used to control the encoding of the output
+      template.
+    type: path
+    required: yes
+  trim_blocks:
+    description:
+    - Determine when newlines should be removed from blocks.
+    - When set to C(yes) the first newline after a block is removed (block, not variable tag!).
+    type: bool
+    default: yes
+  variable_end_string:
+    description:
+    - The string marking the end of a print statement.
+    type: str
+    default: '}}'
+  variable_start_string:
+    description:
+    - The string marking the beginning of a print statement.
+    type: str
+    default: '{{'
 notes:
+- Including a string that uses a date in the template will result in the template being marked 'changed' each time.
+- Since Ansible 0.9, templates are loaded with C(trim_blocks=True).
+- >
+  Also, you can override jinja2 settings by adding a special header to template file.
+  i.e. C(#jinja2:variable_start_string:'[%', variable_end_string:'%]', trim_blocks: False)
+  which changes the variable interpolation markers to C([% var %]) instead of C({{ var }}).
+  This is the best way to prevent evaluation of things that look like, but should not be Jinja2.
+- Using raw/endraw in Jinja2 will not work as you expect because templates in Ansible are recursively
+  evaluated.
+- To find Byte Order Marks in files, use C(Format-Hex <file> -Count 16) on Windows, and use C(od -a -t x1 -N 16 <file>)
+  on Linux.
 - Beware fetching files from windows machines when creating templates because certain tools, such as Powershell ISE,
   and regedit's export facility add a Byte Order Mark as the first character of the file, which can cause tracebacks.
 - You can use the M(win_copy) module with the C(content:) option if you prefer the template inline, as part of the
@@ -35,8 +123,6 @@ seealso:
 - module: template
 author:
 - Jon Hawkesworth (@jhawkesworth)
-extends_documentation_fragment:
-- template_common
 '''
 
 EXAMPLES = r'''

--- a/tests/integration/targets/win_copy/tasks/remote_tests.yml
+++ b/tests/integration/targets/win_copy/tasks/remote_tests.yml
@@ -23,14 +23,6 @@
 
 - name: fail source is a file but dest is a folder
   win_copy:
-    src: '{{test_win_copy_path}}\source\foo.txt'
-    dest: '{{test_win_copy_path}}\target\folder'
-    remote_src: yes
-  register: fail_remote_file_to_folder
-  failed_when: "'dest is already a folder' not in fail_remote_file_to_folder.msg"
-
-- name: fail source is a file but dest is a folder
-  win_copy:
     src: '{{test_win_copy_path}}\source\'
     dest: '{{test_win_copy_path}}\target\'
     remote_src: yes
@@ -124,6 +116,29 @@
   assert:
     that:
     - remote_copy_file_again is not changed
+
+- name: remote source is a file to a folder
+  win_copy:
+    src: '{{test_win_copy_path}}\source\foo.txt'
+    dest: '{{test_win_copy_path}}\target'
+    remote_src: yes
+  register: remote_file_to_folder
+
+- name: get result of remote source is a file to a folder
+  win_stat:
+    path: '{{test_win_copy_path}}\target\foo.txt'
+  register: remote_file_to_folder_actual
+
+- name: assert remote source is a file to a folder
+  assert:
+    that:
+    - remote_file_to_folder is changed
+    - remote_file_to_folder_actual.stat.exists
+
+- name: remove test file
+  win_file:
+    path: '{{test_win_copy_path}}\target\foo.txt'
+    state: absent
 
 - name: copy single file into folder remote (check mode)
   win_copy:

--- a/tests/integration/targets/win_copy/tasks/tests.yml
+++ b/tests/integration/targets/win_copy/tasks/tests.yml
@@ -420,12 +420,27 @@
     - copy_folder_contents_actual.files[3].filename == 'subdir3'
     - copy_folder_contents_actual.files[4].filename == 'subdir4'
 
-- name: fail to copy file to a folder
+- name: remove foo.txt before next test
+  win_file:
+    path: '{{test_win_copy_path}}\recursive-contents\foo.txt'
+    state: absent
+
+- name: copy file to a folder
   win_copy:
     src: foo.txt
     dest: '{{test_win_copy_path}}\recursive-contents'
-  register: fail_file_to_folder
-  failed_when: "'object at path is already a directory' not in fail_file_to_folder.msg"
+  register: file_to_folder
+
+- name: get result of copy file to folder
+  win_stat:
+    path: '{{test_win_copy_path}}\recursive-contents\foo.txt'
+  register: file_to_folder_actual
+
+- name: assert copy file to a folder
+  assert:
+    that:
+    - file_to_folder is changed
+    - file_to_folder_actual.stat.exists
 
 - name: fail to copy folder to a file
   win_copy:

--- a/tests/integration/targets/win_template/tasks/main.yml
+++ b/tests/integration/targets/win_template/tasks/main.yml
@@ -154,19 +154,19 @@
 
 - name: create template dest directory
   win_file:
-    path: '{{win_output_dir}}\directory'
+    path: '{{ remote_tmp_dir }}\directory'
     state: directory
 
 - name: template src file to directory with backslash (check mode)
   win_template:
     src: foo.j2
-    dest: '{{win_output_dir}}\directory\'
+    dest: '{{ remote_tmp_dir }}\directory\'
   check_mode: yes
   register: template_to_dir_backslash_check
 
 - name: get result of template src file to directory with backslash (check_mode)
   win_stat:
-    path: '{{win_output_dir}}\directory\foo.j2'
+    path: '{{ remote_tmp_dir }}\directory\foo.j2'
   register: template_to_dir_backslash_result_check
 
 - name: assert template src file to directory with backslash (check mode)
@@ -178,12 +178,12 @@
 - name: template src file to directory with backslash
   win_template:
     src: foo.j2
-    dest: '{{win_output_dir}}\directory\'
+    dest: '{{ remote_tmp_dir }}\directory\'
   register: template_to_dir_backslash
 
 - name: get result of template src file to directory with backslash
   win_stat:
-    path: '{{win_output_dir}}\directory\foo.j2'
+    path: '{{ remote_tmp_dir }}\directory\foo.j2'
   register: template_to_dir_backslash_result
 
 - name: assert template src file to directory with backslash
@@ -196,7 +196,7 @@
 - name: template src file to directory with backslash (idempotent)
   win_template:
     src: foo.j2
-    dest: '{{win_output_dir}}\directory\'
+    dest: '{{ remote_tmp_dir }}\directory\'
   register: template_to_dir_backslash_again
 
 - name: assert template src file to directory with backslash (idempotent)
@@ -207,13 +207,13 @@
 - name: template src file to directory (check mode)
   win_template:
     src: another_foo.j2
-    dest: '{{win_output_dir}}\directory'
+    dest: '{{ remote_tmp_dir }}\directory'
   check_mode: yes
   register: template_to_dir_check
 
 - name: get result of template src file to directory (check_mode)
   win_stat:
-    path: '{{win_output_dir}}\directory\another_foo.j2'
+    path: '{{ remote_tmp_dir }}\directory\another_foo.j2'
   register: template_to_dir_result_check
 
 - name: assert template src file to directory (check mode)
@@ -225,12 +225,12 @@
 - name: template src file to directory
   win_template:
     src: another_foo.j2
-    dest: '{{win_output_dir}}\directory'
+    dest: '{{ remote_tmp_dir }}\directory'
   register: template_to_dir
 
 - name: get result of template src file to directory
   win_stat:
-    path: '{{win_output_dir}}\directory\another_foo.j2'
+    path: '{{ remote_tmp_dir }}\directory\another_foo.j2'
   register: template_to_dir_result
 
 - name: assert template src file to directory with
@@ -243,7 +243,7 @@
 - name: template src file to directory (idempotent)
   win_template:
     src: another_foo.j2
-    dest: '{{win_output_dir}}\directory'
+    dest: '{{ remote_tmp_dir }}\directory'
   register: template_to_dir_again
 
 - name: assert template src file to directory (idempotent)


### PR DESCRIPTION
##### SUMMARY
Change the action plugins to call the FQCN of the module it needs to execute so that when they are called without the `collections:` keyword it will work.

Also updates the behaviour of `win_copy` to work just like `copy` when `dest` is a folder.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_copy
win_template
win_updates