### PR TITLE
When applying windows updates, continue after failing if there is a

### DIFF
--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -166,8 +166,10 @@ class ActionModule(ActionBase):
         # if the module failed to run at all then changed won't be populated
         # so we just return the result as is
         # https://github.com/ansible/ansible/issues/38232
+        # but continue if reboot is requested
         failed = result.get('failed', False)
-        if ("updates" not in result.keys() and self._task.async_val == 0) or failed:
+        if ("updates" not in result.keys() and self._task.async_val == 0) or \
+            (failed and not (reboot and result.get('reboot_required', False))):
             result['failed'] = True
             return result
 

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -169,7 +169,7 @@ class ActionModule(ActionBase):
         # but continue if reboot is requested
         failed = result.get('failed', False)
         if ("updates" not in result.keys() and self._task.async_val == 0) or \
-            (failed and not (reboot and result.get('reboot_required', False))):
+                (failed and not (reboot and result.get('reboot_required', False))):
             result['failed'] = True
             return result
 


### PR DESCRIPTION
_From @ramon-garcia on Feb 10, 2019 11:33_

##### SUMMARY
Fix for issue #49874 , solved as pull request as requested: continue with window updates, if failed but reboot requested and there is a reboot pending.

After a Windows update fails, if reboot was requested and there is a reboot pending, continue the flow for rebooting. This is necessary : sometimes after applying many updates, some of them fail. After rebooting, these updates succeed . 

In fact, this is behavior that was designed in win_updates.py. But fixing bug #38232 unintentionally broke that behavior.

##### COMPONENT NAME
win_updates.py



_Copied from original issue: ansible/ansible#52007_