### PR TITLE
Refactor win_service to use newer Ansible.Basic util

### DIFF
--- a/plugins/modules/win_service.ps1
+++ b/plugins/modules/win_service.ps1
@@ -3,461 +3,680 @@
 # Copyright: (c) 2014, Chris Hoffman <choffman@chathamfinancial.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
-#Requires -Module Ansible.ModuleUtils.SID
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -CSharpUtil ansible_collections.ansible.windows.plugins.module_utils.SCManager
 
-$ErrorActionPreference = "Stop"
-
-$params = Parse-Args $args -supports_check_mode $true
-$check_mode = Get-AnsibleParam -obj $params -name '_ansible_check_mode' -type 'bool' -default $false
-
-$dependencies = Get-AnsibleParam -obj $params -name 'dependencies' -type 'list' -default $null
-$dependency_action = Get-AnsibleParam -obj $params -name 'dependency_action' -type 'str' -default 'set' -validateset 'add','remove','set'
-$description = Get-AnsibleParam -obj $params -name 'description' -type 'str'
-$desktop_interact = Get-AnsibleParam -obj $params -name 'desktop_interact' -type 'bool' -default $false
-$display_name = Get-AnsibleParam -obj $params -name 'display_name' -type 'str'
-$force_dependent_services = Get-AnsibleParam -obj $params -name 'force_dependent_services' -type 'bool' -default $false
-$name = Get-AnsibleParam -obj $params -name 'name' -type 'str' -failifempty $true
-$password = Get-AnsibleParam -obj $params -name 'password' -type 'str'
-$path = Get-AnsibleParam -obj $params -name 'path'
-$start_mode = Get-AnsibleParam -obj $params -name 'start_mode' -type 'str' -validateset 'auto','manual','disabled','delayed'
-$state = Get-AnsibleParam -obj $params -name 'state' -type 'str' -validateset 'started','stopped','restarted','absent','paused'
-$username = Get-AnsibleParam -obj $params -name 'username' -type 'str'
-
-$result = @{
-    changed = $false
-}
-
-# parse the username to SID and back so we get the full username with domain in a way WMI understands
-if ($null -ne $username) {
-    if ($username -eq "LocalSystem") {
-        $username_sid = "S-1-5-18"
-    } else {
-        $username_sid = Convert-ToSID -account_name $username
+$spec = @{
+    options = @{
+        dependencies = @{ type = 'list'; elements = 'str' }
+        dependency_action = @{ type = 'str'; default = 'set'; choices = 'add', 'remove', 'set' }
+        description = @{ type = 'str' }
+        desktop_interact = @{ type = 'bool'; default = $false }
+        display_name = @{ type = 'str' }
+        force_dependent_services = @{ type = 'bool'; default = $false }
+        name = @{ type = 'str'; required = $true }
+        password = @{ type = 'str'; no_log = $true }
+        path = @{ type = 'str'; }
+        start_mode = @{ type = 'str'; choices = 'auto', 'manual', 'disabled', 'delayed' }
+        state = @{ type = 'str'; choices = 'started', 'stopped', 'restarted', 'absent', 'paused' }
+        update_password = @{ type = 'str'; choices = 'always', 'on_create' }
+        username = @{ type = 'str' }
     }
-
-    # the SYSTEM account is a special beast, Win32_Service Change requires StartName to be LocalSystem
-    # to specify LocalSystem/NT AUTHORITY\SYSTEM
-    if ($username_sid -eq "S-1-5-18") {
-        $username = "LocalSystem"
-        $password = $null
-    } else {
-        # Win32_Service, password must be "" and not $null when setting to LocalService or NetworkService
-        if ($username_sid -in @("S-1-5-19", "S-1-5-20")) {
-            $password = ""
-        }
-        $username = Convert-FromSID -sid $username_sid
+    required_by = @{
+        password = @('username')
     }
+    supports_check_mode = $true
 }
-if ($null -ne $password -and $null -eq $username) {
-    Fail-Json $result "The argument 'username' must be supplied with 'password'"
-}
-if ($desktop_interact -eq $true -and (-not ($username -eq "LocalSystem" -or $null -eq $username))) {
-    Fail-Json $result "Can only set 'desktop_interact' to true when 'username' equals 'LocalSystem'"
-}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$dependencies = $module.Params.dependencies
+$dependencyAction = $module.Params.dependency_action
+$description = $module.Params.description
+$desktopInteract = $module.Params.desktop_interact
+$displayName = $module.Params.display_name
+$forceDependentServices = $module.Params.force_dependent_services
+$name = $module.Params.name
+$password = $module.Params.password
+$path = $module.Params.path
+$serviceType = $null  # TODO: expose this as a module option.
+$startMode = $module.Params.start_mode
+$state = $module.Params.state
+$updatePassword = $module.Params.update_password
+$username = $module.Params.username
+
+$module.Result.exists = $false
+
 if ($null -ne $path) {
     $path = [System.Environment]::ExpandEnvironmentVariables($path)
 }
 
-Function Get-ServiceInfo($name) {
-    # Need to get new objects so we have the latest info
-    $svc = Get-Service | Where-Object { $_.Name -eq $name -or $_.DisplayName -eq $name }
-    $wmi_svc = Get-CimInstance -ClassName Win32_Service -Filter "name='$($svc.Name)'"
+Function ConvertTo-SecurityIdentifier {
+    [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingEmptyCatchBlock', '',
+        Justification='Ignore a SID conversion eror and try alternative, we do not care about the error')]
+    param (
+        [Parameter(Mandatory=$true)]
+        [String]$Name
+    )
 
-    # Delayed start_mode is in reality Automatic (Delayed), need to check reg key for type
-    $delayed = Get-DelayedStatus -name $svc.Name
-    $actual_start_mode = $wmi_svc.StartMode.ToString().ToLower()
-    if ($delayed -and $actual_start_mode -eq 'auto') {
-        $actual_start_mode = 'delayed'
-    }
-
-    $existing_dependencies = @()
-    $existing_depended_by = @()
-    if ($svc.ServicesDependedOn.Count -gt 0) {
-        foreach ($dependency in $svc.ServicesDependedOn.Name) {
-            $existing_dependencies += $dependency
-        }
-    }
-    if ($svc.DependentServices.Count -gt 0) {
-        foreach ($dependency in $svc.DependentServices.Name) {
-            $existing_depended_by += $dependency
-        }
-    }
-    $description = $wmi_svc.Description
-    if ($null -eq $description) {
-        $description = ""
-    }
-
-    $result.exists = $true
-    $result.name = $svc.Name
-    $result.display_name = $svc.DisplayName
-    $result.state = $svc.Status.ToString().ToLower()
-    $result.start_mode = $actual_start_mode
-    $result.path = $wmi_svc.PathName
-    $result.description = $description
-    $result.username = $wmi_svc.StartName
-    $result.desktop_interact = $wmi_svc.DesktopInteract
-    $result.dependencies = $existing_dependencies
-    $result.depended_by = $existing_depended_by
-    $result.can_pause_and_continue = $svc.CanPauseAndContinue
-}
-
-Function Get-WmiErrorMessage($return_value) {
-    # These values are derived from https://msdn.microsoft.com/en-us/library/aa384901(v=vs.85).aspx
-    switch ($return_value) {
-        1 { "Not Supported: The request is not supported" }
-        2 { "Access Denied: The user did not have the necessary access" }
-        3 { "Dependent Services Running: The service cannot be stopped because other services that are running are dependent on it" }
-        4 { "Invalid Service Control: The requested control code is not valid, or it is unacceptable to the service" }
-        5 { "Service Cannot Accept Control: The requested control code cannot be sent to the service because the state of the service (Win32_BaseService.State property) is equal to 0, 1, or 2" }
-        6 { "Service Not Active: The service has not been started" }
-        7 { "Service Request Timeout: The service did not respond to the start request in a timely fashion" }
-        8 { "Unknown Failure: Unknown failure when starting the service" }
-        9 { "Path Not Found: The directory path to the service executable file was not found" }
-        10 { "Service Already Running: The service is already running" }
-        11 { "Service Database Locked: The database to add a new service is locked" }
-        12 { "Service Dependency Deleted: A dependency this service relies on has been removed from the system" }
-        13 { "Service Dependency Failure: The service failed to find the service needed from a dependent service" }
-        14 { "Service Disabled: The service has been disabled from the system" }
-        15 { "Service Logon Failed: The service does not have the correct authentication to run on the system" }
-        16 { "Service Marked For Deletion: This service is being removed from the system" }
-        17 { "Service No Thread: The service has no execution thread" }
-        18 { "Status Circular Dependency: The service has circular dependencies when it starts" }
-        19 { "Status Duplicate Name: A service is running under the same name" }
-        20 { "Status Invalid Name: The service name has invalid characters" }
-        21 { "Status Invalid Parameter: Invalid parameters have been passed to the service" }
-        22 { "Status Invalid Service Account: The account under which this service runs is either invalid or lacks the permissions to run the service" }
-        23 { "Status Service Exists: The service exists in the database of services available from the system" }
-        24 { "Service Already Paused: The service is currently paused in the system" }
-        default { "Other Error" }
-    }
-}
-
-Function Get-DelayedStatus($name) {
-    $delayed_key = "HKLM:\System\CurrentControlSet\Services\$name"
+    # First check if the account is already a SID
     try {
-        $delayed = ConvertTo-Bool ((Get-ItemProperty -LiteralPath $delayed_key).DelayedAutostart)
-    } catch {
-        $delayed = $false
+        New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList $Name
+        return
+    } catch [ArgumentException] {}
+
+    # win_service allows LocalSystem as a way of specifying SYSTEM as that is what the GUI shows. This name cannot be
+    # translated so we have a manual check for it.
+    if ($Name -eq 'LocalSystem') {
+        [System.Security.Principal.SecurityIdentifier]'S-1-5-18'
+        return
     }
 
-    $delayed
+    # Handle cases when referencing a local user like .\account.
+    if ($Name.Contains('\')) {
+        $nameSplit = $Name.Split('\.', 2)
+        if ($nameSplit[0] -eq '.') {
+            $domain = $env:COMPUTERNAME
+        } else {
+            $domain = $nameSplit[0]
+        }
+        $username = $nameSplit[1]
+
+        $ntAccount = New-Object -TypeName System.Security.Principal.NTAccount -ArgumentList $domain, $username
+    } else {
+        $ntAccount = New-Object -TypeName System.Security.Principal.NTAccount -ArgumentList $Name
+    }
+
+    $ntAccount.Translate([System.Security.Principal.SecurityIdentifier])
 }
 
-Function Set-ServiceStartMode($svc, $start_mode) {
-    if ($result.start_mode -ne $start_mode) {
-        try {
-            $delayed_key = "HKLM:\System\CurrentControlSet\Services\$($svc.Name)"
-            # Original start up type was auto (delayed) and we want auto, need to removed delayed key
-            if ($start_mode -eq 'auto' -and $result.start_mode -eq 'delayed') {
-                Set-ItemProperty -LiteralPath $delayed_key -Name "DelayedAutostart" -Value 0 -WhatIf:$check_mode
-            # Original start up type was auto and we want auto (delayed), need to add delayed key
-            } elseif ($start_mode -eq 'delayed' -and $result.start_mode -eq 'auto') {
-                Set-ItemProperty -LiteralPath $delayed_key -Name "DelayedAutostart" -Value 1 -WhatIf:$check_mode
-            # Original start up type was not auto or auto (delayed), need to change to auto and add delayed key
-            } elseif ($start_mode -eq 'delayed') {
-                $svc | Set-Service -StartupType "auto" -WhatIf:$check_mode
-                Set-ItemProperty -LiteralPath $delayed_key -Name "DelayedAutostart" -Value 1 -WhatIf:$check_mode
-            # Original start up type was not what we were looking for, just change to that type
+Function ConvertTo-ServiceStartModeDiff {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [Ansible.Windows.SCManager.ServiceStartType]
+        $StartMode
+    )
+
+    # Convert the enum ServiceStartType to the value for a diff.
+    switch ($StartMode) {
+        BootStart { 'boot' }
+        SystemStart { 'system' }
+        AutoStart { 'auto' }
+        DemandStart { 'manual' }
+        Disabled { 'disabled' }
+        AutoStartDelayed { 'delayed' }
+    }
+}
+
+Function ConvertTo-ServiceStateDiff {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [Ansible.Windows.SCManager.ServiceStatus]
+        $State
+    )
+
+    # Converts the enum ServiceStatus to the value for a diff.
+    switch ($State) {
+        Stopped { 'stopped' }
+        StartPending { 'start_pending' }
+        StopPending { 'stop_pending' }
+        Running { 'started' }
+        ContinuePending { 'continue_pending' }
+        PausePending { 'pause_pending' }
+        Paused { 'paused' }
+    }
+}
+
+Function ConvertTo-ServiceTypeDiff {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [Ansible.Windows.SCManager.ServiceType]
+        $ServiceType
+    )
+
+    # Converts the enum ServiceType to the valud for a diff.
+    $ServiceType = [uint32]$ServiceType -band -bnot [uint32][Ansible.Windows.SCManager.ServiceType]::InteractiveProcess
+    $ServiceType = $ServiceType -band -bnot [uint32][Ansible.Windows.SCManager.ServiceType]::UserServiceInstance
+    switch (([Ansible.Windows.SCManager.ServiceType]$ServiceType).ToString()) {
+        KernelDriver { 'kernel_driver' }
+        FileSystemDriver { 'file_system_driver' }
+        Adapter { 'adapter' }
+        RecognizerDriver { 'recognizer_driver' }
+        Win32OwnProcess { 'win32_own_process' }
+        Win32ShareProcess { 'win32_share_process' }
+        UserOwnprocess { 'user_own_process' }
+        UserShareProcess { 'user_share_process' }
+        PkgService { 'pkg_service' }
+    }
+}
+
+Function Get-ServiceDiff {
+    [CmdletBinding()]
+    param (
+        [Ansible.Windows.SCManager.Service]
+        $Service
+    )
+
+    if (-not $Service) {
+        ""
+    } else {
+        @{
+            dependencies = $Service.DependentOn
+            description = $Service.Description
+            desktop_interact = $Service.ServiceType.HasFlag(
+                [Ansible.Windows.SCManager.ServiceType]::InteractiveProcess)
+            display_name = $Service.DisplayName
+            name = $Service.ServiceName
+            password = 'REDACTED'
+            path = $Service.Path
+            service_type = ConvertTo-ServiceTypeDiff -ServiceType $Service.ServiceType
+            start_mode = ConvertTo-ServiceStartModeDiff -StartMode $Service.StartType
+            state = ConvertTo-ServiceStateDiff -State $Service.State
+            username = $Service.Account.Value
+        }
+    }
+}
+
+Function Get-ServiceFromName {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [String]
+        $Name
+    )
+
+    # Get-Service -Name * doesn't work if the name has a wildcard char like '[]'. Use Where-Object to achieve the same
+    # result just in a slightly more expensive way.
+    Get-Service | Where-Object { $_.ServiceName -eq $Name -or $_.DisplayName -eq $Name }
+}
+
+Function Set-ServiceAccount {
+    [CmdletBinding()]
+    param (
+        [String]
+        $Username,
+
+        [String]
+        $Password,
+
+        [Switch]
+        $UpdatePassword,
+
+        [Ansible.Basic.AnsibleModule]
+        $Module,
+
+        [Ansible.Windows.SCManager.Service]
+        $Service
+    )
+
+    $Module.Diff.after.username = $Username
+    $Module.Diff.after.password = 'REDACTED'
+    if ($null -ne $Service) {
+        $desiredSid = $null
+        if ($Username) {
+            $desiredSid = ConvertTo-SecurityIdentifier -Name $Username
+            $Module.Diff.after.username = $desiredSid.Translate([System.Security.Principal.NTAccount]).Value
+        }
+        $actualSid = ConvertTo-SecurityIdentifier -Name $Service.Account.Value
+
+        if ($null -eq $desiredSid) {
+            $Module.Diff.after.username = $Service.Account.Value
+        } elseif (-not $desiredSid.Equals($actualSid)) {
+            # We need to remove the desktop interact flag if we are changing from SYSTEM to another account
+            $systemSid = ConvertTo-SecurityIdentifier -Name 'LocalSystem'
+            if (-not $desiredSid.Equals($systemSid)) {
+                Set-ServiceType -DesktopInteract $false -Username $username -Module $Module -Service $Service
+            }
+
+            if (-not $Module.CheckMode) {
+                $Service.Account = $desiredSid
+            }
+            $UpdatePassword = $true  # Always set the password if changing the account.
+
+            $Module.Result.changed = $true
+        }
+
+        # We cannot compare the password, so always change it based on the update_password module option.
+        if ($UpdatePassword -and $Password) {
+            $Module.Diff.after.password = 'CHANGED REDACTED'
+
+            if (-not $Module.CheckMode -and $Service) {
+                $Service.Password = $Password
+            }
+            $Module.Result.changed = $true
+        }
+    }
+}
+
+Function Set-ServiceDependencies {
+    [CmdletBinding()]
+    param (
+        [String[]]
+        $Dependencies,
+
+        [String]
+        $DependencyAction,
+
+        [Ansible.Basic.AnsibleModule]
+        $Module,
+
+        [Ansible.Windows.SCManager.Service]
+        $Service
+    )
+
+    $Module.Diff.after.dependencies = $Dependencies
+    if ($null -ne $Service) {
+        $Module.Diff.after.dependencies = $Service.DependentOn
+
+        if ($null -ne $Dependencies) {
+            $existingDependencies = [String[]]$Service.DependentOn
+            [String[]]$addedDependents = @()
+            [String[]]$removedDependents = @()
+
+            if ($DependencyAction -eq 'add') {
+                $addedDependents = [Linq.Enumerable]::Except($Dependencies, $existingDependencies)
+            } elseif ($DependencyAction -eq 'remove') {
+                $removedDependents = [Linq.Enumerable]::Intersect($Dependencies, $existingDependencies)
             } else {
-                $svc | Set-Service -StartupType $start_mode -WhatIf:$check_mode
+                $addedDependents = [Linq.Enumerable]::Except($Dependencies, $existingDependencies)
+                $removedDependents = [Linq.Enumerable]::Except($existingDependencies, $Dependencies)
             }
-        } catch {
-            Fail-Json $result $_.Exception.Message
-        }
 
-        $result.changed = $true
-    }
-}
-
-Function Set-ServiceAccount($wmi_svc, $username_sid, $username, $password) {
-    if ($result.username -eq "LocalSystem") {
-        $actual_sid = "S-1-5-18"
-    } else {
-        $actual_sid = Convert-ToSID -account_name $result.username
-    }
-
-    if ($actual_sid -ne $username_sid) {
-        $change_arguments = @{
-            StartName = $username
-            StartPassword = $password
-            DesktopInteract = $result.desktop_interact
-        }
-        # need to disable desktop interact when not using the SYSTEM account
-        if ($username_sid -ne "S-1-5-18") {
-            $change_arguments.DesktopInteract = $false
-        }
-
-        #WMI.Change doesn't support -WhatIf, cannot fully test with check_mode
-        if (-not $check_mode) {
-            $return = $wmi_svc | Invoke-CimMethod -MethodName Change -Arguments $change_arguments
-            if ($return.ReturnValue -ne 0) {
-                $error_msg = Get-WmiErrorMessage -return_value $result.ReturnValue
-                Fail-Json -obj $result -message "Failed to set service account to $($username): $($return.ReturnValue) - $error_msg"
-            }
-        }
-
-        $result.changed = $true
-    }
-}
-
-Function Set-ServiceDesktopInteract($wmi_svc, $desktop_interact) {
-    if ($result.desktop_interact -ne $desktop_interact) {
-        if (-not $check_mode) {
-            $return = $wmi_svc | Invoke-CimMethod -MethodName Change -Arguments @{DesktopInteract = $desktop_interact}
-            if ($return.ReturnValue -ne 0) {
-                $error_msg = Get-WmiErrorMessage -return_value $return.ReturnValue
-                Fail-Json -obj $result -message "Failed to set desktop interact $($desktop_interact): $($return.ReturnValue) - $error_msg"
-            }
-        }
-
-        $result.changed = $true
-    }
-}
-
-Function Set-ServiceDisplayName($svc, $display_name) {
-    if ($result.display_name -ne $display_name) {
-        try {
-            $svc | Set-Service -DisplayName $display_name -WhatIf:$check_mode
-        } catch {
-            Fail-Json $result $_.Exception.Message
-        }
-
-        $result.changed = $true
-    }
-}
-
-Function Set-ServiceDescription($svc, $description) {
-    if ($result.description -ne $description) {
-        try {
-            $svc | Set-Service -Description $description -WhatIf:$check_mode
-        } catch {
-            Fail-Json $result $_.Exception.Message
-        }
-
-        $result.changed = $true
-    }
-}
-
-Function Set-ServicePath($name, $path) {
-    if ($result.path -ne $path) {
-        try {
-            Set-ItemProperty -LiteralPath "HKLM:\System\CurrentControlSet\Services\$name" -Name ImagePath -Value $path -WhatIf:$check_mode
-        } catch {
-            Fail-Json $result $_.Exception.Message
-        }
-
-        $result.changed = $true
-    }
-}
-
-Function Set-ServiceDependencies($wmi_svc, $dependency_action, $dependencies) {
-    $existing_dependencies = $result.dependencies
-    [System.Collections.ArrayList]$new_dependencies = @()
-
-    if ($dependency_action -eq 'set') {
-        foreach ($dependency in $dependencies) {
-            $new_dependencies.Add($dependency)
-        }
-    } else {
-        $new_dependencies = $existing_dependencies
-        foreach ($dependency in $dependencies) {
-            if ($dependency_action -eq 'remove') {
-                if ($new_dependencies -contains $dependency) {
-                    $new_dependencies.Remove($dependency)
+            if ($addedDependents -or $removedDependents) {
+                $newDependents = $Service.DependentOn
+                foreach ($toRemove in $removedDependents) {
+                    $null = $newDependents.Remove($toRemove)
                 }
-            } elseif ($dependency_action -eq 'add') {
-                if ($new_dependencies -notcontains $dependency) {
-                    $new_dependencies.Add($dependency)
+                foreach ($toAdd in $addedDependents) {
+                    $newDependents.Add($toAdd)
+                }
+                $Module.Diff.after.dependencies = $newDependents
+
+                if (-not $Module.CheckMode) {
+                    $Service.DependentOn = $newDependents
+                }
+                $Module.Result.changed = $true
+            }
+        }
+    }
+}
+
+Function Set-ServiceDescription {
+    [CmdletBinding()]
+    param (
+        # [String] - Cannot set so we can pass $null in (empty string is delete while $null is preserve).
+        $Description,
+
+        [Ansible.Basic.AnsibleModule]
+        $Module,
+
+        [Ansible.Windows.SCManager.Service]
+        $Service
+    )
+
+    $Module.Diff.after.description = $Description
+    if ($null -ne $Service) {
+        if ($null -eq $Description) {
+            $Module.Diff.after.description = $Service.Description
+        } else {
+            if (-not $Description) {
+                $Description = $null
+            }
+
+            if ($Description -cne $Service.Description) {
+                if (-not $Module.CheckMode) {
+                    $Service.Description = $Description
+                }
+                $Module.Result.changed = $true
+            }
+        }
+    }
+}
+
+Function Set-ServiceDisplayName {
+    [CmdletBinding()]
+    param (
+        [String]
+        $DisplayName,
+
+        [Ansible.Basic.AnsibleModule]
+        $Module,
+
+        [Ansible.Windows.SCManager.Service]
+        $Service
+    )
+
+    $Module.Diff.after.display_name = $DisplayName
+    if ($null -ne $Service) {
+        if (-not $DisplayName) {
+            $Module.Diff.after.display_name = $Service.DisplayName
+        } elseif ($DisplayName -cne $Service.DisplayName) {
+            if (-not $Module.CheckMode) {
+                $Service.DisplayName = $DisplayName
+            }
+            $Module.Result.changed = $true
+        }
+    }
+}
+
+Function Set-ServicePath {
+    [CmdletBinding()]
+    param (
+        [String]
+        [AllowNull()]
+        $Path,
+
+        [Ansible.Basic.AnsibleModule]
+        $Module,
+
+        [Ansible.Windows.SCManager.Service]
+        $Service
+    )
+
+    $Module.Diff.after.path = $Path
+    if ($null -ne $Service) {
+        if (-not $Path) {
+            $Module.Diff.after.path = $Service.Path
+        } elseif ($Path -cne $Service.Path) {
+            if (-not $Module.CheckMode) {
+                $Service.Path = $Path
+            }
+            $Module.Result.changed = $true
+        }
+    }
+}
+
+Function Set-ServiceStartMode {
+    [CmdletBinding()]
+    param (
+        [String]
+        $StartMode,
+
+        [Ansible.Basic.AnsibleModule]
+        $Module,
+
+        [Ansible.Windows.SCManager.Service]
+        $Service
+    )
+
+    $Module.Diff.after.start_mode = $StartMode
+    if ($null -ne $Service) {
+        if (-not $StartMode) {
+            $Module.Diff.after.start_mode = ConvertTo-ServiceStartModeDiff -StartMode $Service.StartType
+        } else {
+            $stateMap = @{
+                auto = [Ansible.Windows.SCManager.ServiceStartType]::AutoStart
+                delayed = [Ansible.Windows.SCManager.ServiceStartType]::AutoStartDelayed
+                disabled = [Ansible.Windows.SCManager.ServiceStartType]::Disabled
+                manual = [Ansible.Windows.SCManager.ServiceStartType]::DemandStart
+            }
+
+            foreach ($kvp in $stateMap.GetEnumerator()) {
+                if ($StartMode -ne $kvp.Key) {
+                    continue
+                }
+
+                if ($Service.StartType -ne $kvp.Value) {
+                    if (-not $Module.CheckMode) {
+                        $Service.StartType = $kvp.Value
+                    }
+
+                    $Module.Result.changed = $true
                 }
             }
         }
     }
+}
 
-    $will_change = $false
-    foreach ($dependency in $new_dependencies) {
-        if ($existing_dependencies -notcontains $dependency) {
-            $will_change = $true
-        }
-    }
-    foreach ($dependency in $existing_dependencies) {
-        if ($new_dependencies -notcontains $dependency) {
-            $will_change = $true
-        }
-    }
+Function Set-ServiceState {
+    [CmdletBinding()]
+    param (
+        [String]
+        $State,
 
-    if ($will_change -eq $true) {
-        if (-not $check_mode) {
-            $return = $wmi_svc | Invoke-CimMethod -MethodName Change -Arguments @{ServiceDependencies = $new_dependencies}
-            if ($return.ReturnValue -ne 0) {
-                $error_msg = Get-WmiErrorMessage -return_value $return.ReturnValue
-                $dep_string = $new_dependencies -join ", "
-                Fail-Json -obj $result -message "Failed to set service dependencies $($dep_string): $($return.ReturnValue) - $error_msg"
+        [Switch]
+        $ForceDependentServices,
+
+        [Ansible.Basic.AnsibleModule]
+        $Module,
+
+        [Ansible.Windows.SCManager.Service]
+        $Service
+    )
+
+    $Module.Diff.after.state = $State
+    if ($null -ne $Service) {
+        $stateEnum = [Ansible.Windows.SCManager.ServiceStatus]
+
+        # Due to *-Service cmdlets in win ps struggling with wildcard chars like [ we need to pipe in an actual service
+        # object to the state changing cmdlets.
+        $winService = Get-ServiceFromName -Name $Service.ServiceName
+
+        if (-not $State) {
+            $Module.Diff.after.state = ConvertTo-ServiceStateDiff -State $Service.State
+
+        } elseif ($State -eq 'started' -and $Service.State -ne $stateEnum::Running) {
+            if ($Service.State -eq $stateEnum::Paused) {
+                try {
+                    $winService | Resume-Service -WhatIf:$Module.CheckMode
+                } catch {
+                    $msg = "failed to start service from paused state $($Service.ServiceName): $($_.Exception.Message)"
+                    $Module.FailJson($msg, $_)
+                }
+            } else {
+                $winService | Start-Service -WhatIf:$Module.CheckMode
             }
-        }
+            $Module.Result.changed = $true
 
-        $result.changed = $true
+        } elseif ($State -eq 'stopped' -and $Service.State -ne $stateEnum::Stopped) {
+            $winService | Stop-Service -Force:$ForceDependentServices.IsPresent -WhatIf:$Module.CheckMode
+            $Module.Result.changed = $true
+
+        } elseif ($State -eq 'restarted') {
+            $winService | Restart-Service -Force:$ForceDependentServices.IsPresent -WhatIf:$Module.CheckMode
+            $Module.Result.changed = $true
+
+        } elseif ($State -eq 'paused' -and $Service.State -ne $stateEnum::Paused) {
+            if (-not $Service.ControlsAccepted.HasFlag([Ansible.Windows.SCManager.ControlsAccepted]::PauseContinue)) {
+                $Module.FailJson("failed to pause service $($Service.ServiceName): The service does not support pausing")
+            }
+
+            try {
+                $winService | Suspend-Service -WhatIf:$Module.CheckMode
+            } catch {
+                $Module.FailJson("failed to pause service $($Service.ServiceName): $($_.Exception.Message)", $_)
+            }
+            $Module.Result.changed = $true
+        }
     }
 }
 
-Function Set-ServiceState($svc, $wmi_svc, $state) {
-    if ($state -eq "started" -and $result.state -ne "running") {
-        if ($result.state -eq "paused") {
-            try {
-                $svc | Resume-Service -WhatIf:$check_mode
-            } catch {
-                Fail-Json $result "failed to start service from paused state $($svc.Name): $($_.Exception.Message)"
+Function Set-ServiceType {
+    [CmdletBinding()]
+    param (
+        [String]
+        $ServiceType,
+
+        [Boolean]
+        $DesktopInteract,
+
+        [String]
+        $Username,
+
+        [Ansible.Basic.AnsibleModule]
+        $Module,
+
+        [Ansible.Windows.SCManager.Service]
+        $Service
+    )
+
+    $Module.Diff.after.desktop_interact = $DesktopInteract
+    $Module.Diff.after.service_type = $ServiceType
+    if ($null -ne $Service) {
+        [Ansible.Windows.SCManager.ServiceType]$desiredType = switch($ServiceType) {
+            kernel_driver { [Ansible.Windows.SCManager.ServiceType]::KernelDriver }
+            file_system_driver { [Ansible.Windows.SCManager.ServiceType]::FileSystemDriver }
+            adapter { [Ansible.Windows.SCManager.ServiceType]::Adapter }
+            recognizer_driver { [Ansible.Windows.SCManager.ServiceType]::RecognizerDriver }
+            win32_own_process { [Ansible.Windows.SCManager.ServiceType]::Win32OwnProcess }
+            win32_share_process { [Ansible.Windows.SCManager.ServiceType]::Win32ShareProcess }
+            user_own_process { [Ansible.Windows.SCManager.ServiceType]::UserOwnprocess }
+            user_share_process { [Ansible.Windows.SCManager.ServiceType]::UserShareProcess }
+            default { $Service.ServiceType }
+        }
+        $Module.Diff.after.service_type = ConvertTo-ServiceTypeDiff -ServiceType $desiredType
+
+        $interactive = [uint32][Ansible.Windows.SCManager.ServiceType]::InteractiveProcess
+        if ($DesktopInteract) {
+            if ($Username) {
+                $actualAccount = ConvertTo-SecurityIdentifier -Name $Username
+            } else {
+                $actualAccount = $Service.Account.Translate([System.Security.Principal.SecurityIdentifier])
             }
+            $systemSid = ConvertTo-SecurityIdentifier -Name 'LocalSystem'
+
+            if (-not $actualAccount.Equals($systemSid)) {
+                $Module.FailJson("Can only set 'desktop_interact' to true when 'username' equals 'SYSTEM'")
+            }
+
+            $desiredType = [uint32]$desiredType -bor $interactive
         } else {
-            try {
-                $svc | Start-Service -WhatIf:$check_mode
-            } catch {
-                Fail-Json $result $_.Exception.Message
+            $desiredType = [uint32]$desiredType -band -bnot $interactive
+        }
+
+        if ($desiredType -ne $Service.ServiceType) {
+            if (-not $Module.CheckMode) {
+                $Service.ServiceType = $desiredType
             }
-        }
-
-        $result.changed = $true
-    }
-
-    if ($state -eq "stopped" -and $result.state -ne "stopped") {
-        try {
-            $svc | Stop-Service -Force:$force_dependent_services -WhatIf:$check_mode
-        } catch {
-            Fail-Json $result $_.Exception.Message
-        }
-
-        $result.changed = $true
-    }
-
-    if ($state -eq "restarted") {
-        try {
-            $svc | Restart-Service -Force:$force_dependent_services -WhatIf:$check_mode
-        } catch {
-            Fail-Json $result $_.Exception.Message
-        }
-
-        $result.changed = $true
-    }
-
-    if ($state -eq "paused" -and $result.state -ne "paused") {
-        # check that we can actually pause the service
-        if ($result.can_pause_and_continue -eq $false) {
-            Fail-Json $result "failed to pause service $($svc.Name): The service does not support pausing"
-        }
-
-        try {
-            $svc | Suspend-Service -WhatIf:$check_mode
-        } catch {
-            Fail-Json $result "failed to pause service $($svc.Name): $($_.Exception.Message)"
-        }
-        $result.changed = $true
-    }
-
-    if ($state -eq "absent") {
-        try {
-            $svc | Stop-Service -Force:$force_dependent_services -WhatIf:$check_mode
-        } catch {
-            Fail-Json $result $_.Exception.Message
-        }
-        if (-not $check_mode) {
-            $return = $wmi_svc | Invoke-CimMethod -MethodName Delete
-            if ($return.ReturnValue -ne 0) {
-                $error_msg = Get-WmiErrorMessage -return_value $return.ReturnValue
-                Fail-Json -obj $result -message "Failed to delete service $($svc.Name): $($return.ReturnValue) - $error_msg"
-            }
-        }
-
-        $result.changed = $true
-    }
-}
-
-Function Set-ServiceConfiguration($svc) {
-    $wmi_svc = Get-CimInstance -ClassName Win32_Service -Filter "name='$($svc.Name)'"
-    Get-ServiceInfo -name $svc.Name
-    if ($desktop_interact -eq $true -and (-not ($result.username -eq 'LocalSystem' -or $username -eq 'LocalSystem'))) {
-        Fail-Json $result "Can only set desktop_interact to true when service is run with/or 'username' equals 'LocalSystem'"
-    }
-
-    if ($null -ne $start_mode) {
-        Set-ServiceStartMode -svc $svc -start_mode $start_mode
-    }
-
-    if ($null -ne $username) {
-        Set-ServiceAccount -wmi_svc $wmi_svc -username_sid $username_sid -username $username -password $password
-    }
-
-    if ($null -ne $display_name) {
-        Set-ServiceDisplayName -svc $svc -display_name $display_name
-    }
-
-    if ($null -ne $desktop_interact) {
-        Set-ServiceDesktopInteract -wmi_svc $wmi_svc -desktop_interact $desktop_interact
-    }
-
-    if ($null -ne $description) {
-        Set-ServiceDescription -svc $svc -description $description
-    }
-
-    if ($null -ne $path) {
-        Set-ServicePath -name $svc.Name -path $path
-    }
-
-    if ($null -ne $dependencies) {
-        Set-ServiceDependencies -wmi_svc $wmi_svc -dependency_action $dependency_action -dependencies $dependencies
-    }
-
-    if ($null -ne $state) {
-        Set-ServiceState -svc $svc -wmi_svc $wmi_svc -state $state
-    }
-}
-
-# need to use Where-Object as -Name doesn't work with [] in the service name
-# https://github.com/ansible/ansible/issues/37621
-$svc = Get-Service | Where-Object { $_.Name -eq $name -or $_.DisplayName -eq $name }
-if ($svc) {
-    Set-ServiceConfiguration -svc $svc
-} else {
-    $result.exists = $false
-    if ($state -ne 'absent') {
-        # Check if path is defined, if so create the service
-        if ($null -ne $path) {
-            try {
-                New-Service -Name $name -BinaryPathname $path -WhatIf:$check_mode
-            } catch {
-                Fail-Json $result $_.Exception.Message
-            }
-            $result.changed = $true
-
-            $svc = Get-Service | Where-Object { $_.Name -eq $name }
-            Set-ServiceConfiguration -svc $svc
-        } else {
-            # We will only reach here if the service is installed and the state is not absent
-            # Will check if any of the default actions are set and fail as we cannot action it
-            if ($null -ne $start_mode -or
-                $null -ne $state -or
-                $null -ne $username -or
-                $null -ne $password -or
-                $null -ne $display_name -or
-                $null -ne $description -or
-                $desktop_interact -ne $false -or
-                $null -ne $dependencies -or
-                $dependency_action -ne 'set') {
-                    Fail-Json $result "Service '$name' is not installed, need to set 'path' to create a new service"
-            }
+            $Module.Result.changed = $true
         }
     }
 }
 
-# After making a change, let's get the service info again unless we deleted it
+$service = Get-ServiceFromName -Name $name | ForEach-Object { [Ansible.Windows.SCManager.Service]$_.ServiceName }
+$module.Diff.before = Get-ServiceDiff -Service $service
+
 if ($state -eq 'absent') {
-    # Recreate result so it doesn't have the extra meta data now that is has been deleted
-    $changed = $result.changed
-    $result = @{
-        changed = $changed
-        exists = $false
+    if ($service) {
+        $winService = Get-ServiceFromName -Name $service.ServiceName
+        $winService | Stop-Service -Force:$forceDependentServices -WhatIf:$module.CheckMode
+        if (-not $module.CheckMode) {
+            $service.Delete()
+        }
+
+        $module.Result.changed = $true
     }
-} elseif ($null -ne $svc) {
-    Get-ServiceInfo -name $name
+
+    $module.Diff.after = ""
+} else {
+    # win_service can be used as a way to get info from an existing service by not setting any of these parameters.
+    # This should be deprecated in the future in favour of win_service_info to simplify this module.
+    $detectChanges = (
+        $null -ne $service -or
+        $null -ne $description -or
+        $null -ne $displayName -or
+        $null -ne $dependencies -or
+        $dependencyAction -ne 'set' -or
+        $desktopInteract -eq $true -or
+        $null -ne $path -or
+        $null -ne $startMode -or
+        $null -ne $state -or
+        $null -ne $username -or
+        $null -ne $password
+    )
+
+    if ($detectChanges) {
+        $updatePassword = switch ($updatePassword) {
+            always { $true }
+            on_create { $false }
+            default {
+                # TODO: add deprecation warning for a change to always as the default.
+                $false
+            }
+        }
+
+        if (-not $service) {
+            $updatePassword = $true
+
+            if ($null -ne $path) {
+                $null = New-Service -Name $name -BinaryPathName $path -WhatIf:$module.CheckMode
+                if (-not $module.CheckMode) {
+                    $service = New-Object -TypeName Ansible.Windows.SCManager.Service -ArgumentList $name
+                }
+                $module.Result.changed = $true
+            } else {
+                $module.FailJson("Service '$name' is not installed, need to set 'path' to create a new service")
+            }
+        }
+
+        # Each component is set in the Set-Service* cmdlets below
+        $module.Diff.after = @{
+            name = if ($service) { $service.ServiceName } else { $name }
+        }
+
+        $common = @{Service = $service; Module = $module}
+        Set-ServiceAccount -Username $username -Password $password -UpdatePassword:$updatePassword @common
+        Set-ServiceDependencies -Dependencies $dependencies -DependencyAction $dependencyAction @common
+        Set-ServiceDescription -Description $description @common
+        Set-ServiceDisplayName -DisplayName $displayName @common
+        Set-ServicePath -Path $path @common
+        Set-ServiceStartMode -StartMode $startMode @common
+        Set-ServiceState -State $state -ForceDependentServices:$forceDependentServices @common
+        Set-ServiceType -ServiceType $serviceType -DesktopInteract $desktopInteract -Username $username @common
+    } else {
+        # TODO: deprecate this scenario as state != 'absent' should require one of the params in $detectChanges.
+        $module.Diff.after = $module.Diff.before
+    }
 }
 
-Exit-Json -obj $result
+# The after diff already contains the pre-formatted return information. This should be deprecated with no new
+# fields returned as this is just a backwards compatibility nightmare.
+if ($module.Diff.after) {
+    $after = $module.Diff.after
+
+    $module.Result.exists = $true
+
+    $module.Result.dependencies = $after.dependencies
+    $module.Result.description = $after.description
+    $module.Result.desktop_interact = $after.desktop_interact
+    $module.Result.display_name = $after.display_name
+    $module.Result.name = $after.name
+    $module.Result.path = $after.path
+    $module.Result.start_mode = $after.start_mode
+
+    # Backwards compat, win_service used to just return the raw StartName value of the service and not a normalised
+    # name that the diff has. The only case this matters if the username is SYSTEM which we correct to LocalSystem.
+    $module.Result.username = $after.username
+    if ($after.username) {
+        $userSid = ConvertTo-SecurityIdentifier -Name $after.username
+        $systemSid = ConvertTo-SecurityIdentifier -Name 'LocalSystem'
+        if ($userSid.Equals($systemSid)) {
+            $module.Result.username = 'LocalSystem'
+        }
+    }
+
+    # Backwards compat, returned state was just a lowercase state of (Get-Service).State, whereas the diff matches
+    # the output of win_service_info, i.e. 'continue_pending' becomes 'continuepending'. Also started needs to become
+    # running to match the original value here.
+    $module.Result.state = $after.state.Replace('_', '')
+    if ($module.Result.state -in @('restarted', 'started')) {
+        $module.Result.state = 'running'
+    }
+
+    # This isn't something we return in the diff as we cannot set this value.
+    $module.Result.can_pause_and_continue = $null
+    $module.Result.depended_by = @()
+    if ($service) {
+        $service.Refresh()  # Always ensure we are working with the latest info available.
+        $module.Result.depended_by = $service.DependedBy
+        $module.Result.can_pause_and_continue = $service.ControlsAccepted.HasFlag(
+            [Ansible.Windows.SCManager.ControlsAccepted]::PauseContinue
+        )
+    }
+}
+
+$module.ExitJson()

--- a/tests/integration/targets/win_service/tasks/tests.yml
+++ b/tests/integration/targets/win_service/tasks/tests.yml
@@ -537,6 +537,31 @@
     - win_service_change_password_current_user_again.username == current_user
     - win_service_change_password_current_user_again.desktop_interact == False
 
+- name: test update_password on_create
+  win_service:
+    name: '{{ test_win_service_name }}'
+    username: '{{ ansible_user }}'
+    password: fake
+  register: update_password_on_create
+
+- name: assert test update_password on_create
+  assert:
+    that:
+    - not update_password_on_create is changed
+
+- name: force password update
+  win_service:
+    name: '{{ test_win_service_name }}'
+    username: '{{ ansible_user }}'
+    password: '{{ ansible_password }}'
+    update_password: always
+  register: update_password_always
+
+- name: assert force password update
+  assert:
+    that:
+    - update_password_always is changed
+
 - name: set the service username to a NT SERVICE account
   win_service:
     name: '{{ test_win_service_name }}'
@@ -602,6 +627,35 @@
     that:
     - win_service_description_again is not changed
     - win_service_description_again.description == 'New Description'
+
+- name: clear the description
+  win_service:
+    name: '{{ test_win_service_name }}'
+    description: ''
+  register: win_service_clear_description
+
+- name: get result of clear the description
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: win_service_clear_description_actual
+
+- name: assert clear the description
+  assert:
+    that:
+    - win_service_clear_description is changed
+    - win_service_clear_description.description == ''
+    - win_service_clear_description_actual.services[0].description == None
+
+- name: clear the description (idempotent)
+  win_service:
+    name: '{{ test_win_service_name }}'
+    description: ''
+  register: win_service_clear_description_again
+
+- name: assert clear the description (idempotent)
+  assert:
+    that:
+    - not win_service_clear_description_again is changed
 
 - name: set service path
   win_service:

--- a/tests/integration/targets/win_service/tasks/tests.yml
+++ b/tests/integration/targets/win_service/tasks/tests.yml
@@ -317,9 +317,9 @@
 - name: set password without username
   win_service:
     name: "{{test_win_service_name}}"
-    password: password
+    password: secret
   register: win_service_change_password_without_user
-  failed_when: win_service_change_password_without_user.msg != "The argument 'username' must be supplied with 'password'"
+  failed_when: 'win_service_change_password_without_user.msg != "missing parameter(s) required by ''password'': username"'
 
 - name: set service username to Network Service and desktop interact fail
   win_service:
@@ -327,7 +327,12 @@
     username: NT AUTHORITY\NetworkService
     desktop_interact: True
   register: win_desktop_interact_not_local_system
-  failed_when: win_desktop_interact_not_local_system.msg != "Can only set 'desktop_interact' to true when 'username' equals 'LocalSystem'"
+  failed_when: win_desktop_interact_not_local_system.msg != "Can only set 'desktop_interact' to true when 'username' equals 'SYSTEM'"
+
+- name: set service back to SYSTEM for next test
+  win_service:
+    name: '{{ test_win_service_name }}'
+    username: LocalSystem
 
 - name: set service username to Network Service
   win_service:
@@ -360,7 +365,7 @@
     name: "{{test_win_service_name}}"
     desktop_interact: True
   register: win_service_desktop_interact_current_user_fail
-  failed_when: win_service_desktop_interact_current_user_fail.msg != "Can only set desktop_interact to true when service is run with/or 'username' equals 'LocalSystem'"
+  failed_when: win_service_desktop_interact_current_user_fail.msg != "Can only set 'desktop_interact' to true when 'username' equals 'SYSTEM'"
 
 - name: set service username to Local Service
   win_service:
@@ -494,6 +499,16 @@
     - win_service_desktop_enable_again.username == 'LocalSystem'
     - win_service_desktop_enable_again.desktop_interact == True
 
+- name: get the common output format of the current user
+  win_shell: |
+    $user = [System.Security.Principal.NTAccount]'{{ ansible_user }}'
+    $user.Translate([System.Security.Principal.SecurityIdentifier]).Translate([System.Security.Principal.NTAccount]).Value
+  changed_when: no
+  register: current_user
+
+- set_fact:
+    current_user: '{{ current_user.stdout | trim }}'
+
 - name: set service username to current user
   win_service:
     name: "{{test_win_service_name}}"
@@ -505,7 +520,7 @@
   assert:
     that:
     - win_service_change_password_current_user is changed
-    - win_service_change_password_current_user.username|lower == '.\\{{ansible_user|lower}}'
+    - win_service_change_password_current_user.username == current_user
     - win_service_change_password_current_user.desktop_interact == False
 
 - name: set service username to current user again
@@ -519,8 +534,26 @@
   assert:
     that:
     - win_service_change_password_current_user_again is not changed
-    - win_service_change_password_current_user_again.username|lower == '.\\{{ansible_user|lower}}'
+    - win_service_change_password_current_user_again.username == current_user
     - win_service_change_password_current_user_again.desktop_interact == False
+
+- name: set the service username to a NT SERVICE account
+  win_service:
+    name: '{{ test_win_service_name }}'
+    username: NT SERVICE\{{ test_win_service_name }}
+  register: win_service_nt_account
+
+- name: get result of set the service username to a NT SERVICE account
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: win_service_nt_account_actual
+
+- name: assert set the service username to a NT SERVICE account
+  assert:
+    that:
+    - win_service_nt_account is changed
+    - win_service_nt_account.username == 'NT SERVICE\{{ test_win_service_name }}'
+    - win_service_nt_account_actual.services[0].username == 'NT SERVICE\{{ test_win_service_name }}'
 
 - name: set service display name
   win_service:
@@ -670,7 +703,7 @@
   assert:
     that:
     - win_service_dependency_add is changed
-    - win_service_dependency_add.dependencies == ['TestServiceParent2', '{{test_win_service_name}}']
+    - win_service_dependency_add.dependencies == [test_win_service_name, 'TestServiceParent2']
 
 - name: add another dependency to service again
   win_service:
@@ -683,7 +716,7 @@
   assert:
     that:
     - win_service_dependency_add_again is not changed
-    - win_service_dependency_add_again.dependencies == ['TestServiceParent2', '{{test_win_service_name}}']
+    - win_service_dependency_add_again.dependencies == [test_win_service_name, 'TestServiceParent2']
 
 - name: remove another dependency to service
   win_service:
@@ -696,7 +729,7 @@
   assert:
     that:
     - win_service_dependency_add is changed
-    - win_service_dependency_add.dependencies == ['{{test_win_service_name}}']
+    - win_service_dependency_add.dependencies == [test_win_service_name]
 
 - name: remove another dependency to service again
   win_service:
@@ -709,7 +742,7 @@
   assert:
     that:
     - win_service_dependency_add_again is not changed
-    - win_service_dependency_add_again.dependencies == ['{{test_win_service_name}}']
+    - win_service_dependency_add_again.dependencies == [test_win_service_name]
 
 - name: set dependency with a list
   win_service:
@@ -722,7 +755,7 @@
   assert:
     that:
     - win_service_dependency_set_list is changed
-    - win_service_dependency_set_list.dependencies == ['TestServiceParent2', '{{test_win_service_name}}']
+    - win_service_dependency_set_list.dependencies == [test_win_service_name, 'TestServiceParent2']
 
 - name: make sure all services are stopped, set to LocalSystem and set to auto start before next test
   win_service:
@@ -775,7 +808,7 @@
     name: "{{test_win_service_name}}"
     state: absent
   register: win_service_removed_failed
-  failed_when: win_service_removed_failed.msg != "Cannot stop service 'Test Service New (" + test_win_service_name + ")' because it has dependent services. It can only be stopped if the Force flag is set."
+  failed_when: '"Cannot stop service ''Test Service New (" + test_win_service_name + ")'' because it has dependent services. It can only be stopped if the Force flag is set." not in win_service_removed_failed.msg'
 
 - name: remove the service while ignoring dependencies
   win_service:
@@ -818,11 +851,17 @@
   register: win_service_paused_check
   check_mode: yes
 
+- name: get result of pause a service check
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: win_service_paused_check_actual
+
 - name: assert pause a service check
   assert:
     that:
     - win_service_paused_check is changed
-    - win_service_paused_check.state == 'running'
+    - win_service_paused_check.state == 'paused'
+    - win_service_paused_check_actual.services[0].state == 'started'
 
 - name: pause a service
   win_service:
@@ -830,11 +869,17 @@
     state: paused
   register: win_service_paused
 
+- name: get result of pause a service check
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: win_service_paused_actual
+
 - name: assert pause a service
   assert:
     that:
     - win_service_paused is changed
     - win_service_paused.state == 'paused'
+    - win_service_paused_actual.services[0].state == 'paused'
 
 - name: pause a service again
   win_service:
@@ -854,11 +899,17 @@
   register: start_paused_service_check
   check_mode: yes
 
+- name: get result of start a paused service check
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: start_paused_service_check_actual
+
 - name: assert start a paused service check
   assert:
     that:
     - start_paused_service_check is changed
-    - start_paused_service_check.state == 'paused'
+    - start_paused_service_check.state == 'running'
+    - start_paused_service_check_actual.services[0].state == 'paused'
 
 - name: start a paused service
   win_service:
@@ -866,11 +917,17 @@
     state: started
   register: start_paused_service
 
+- name: get result of start a paused service
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: start_paused_service_actual
+
 - name: assert start a paused service
   assert:
     that:
     - start_paused_service is changed
     - start_paused_service.state == 'running'
+    - start_paused_service_actual.services[0].state == 'started'
 
 - name: pause service for next test
   win_service:
@@ -885,11 +942,17 @@
   register: stop_paused_service_check
   check_mode: yes
 
+- name: get result of stop a paused service check
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: stop_paused_service_check_actual
+
 - name: assert stop a paused service check
   assert:
     that:
     - stop_paused_service_check is changed
-    - stop_paused_service_check.state == 'paused'
+    - stop_paused_service_check.state == 'stopped'
+    - stop_paused_service_check_actual.services[0].state == 'paused'
 
 - name: stop a paused service
   win_service:
@@ -898,11 +961,17 @@
     force_dependent_services: True
   register: stop_paused_service
 
+- name: get result of stop a paused service
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: stop_paused_service_actual
+
 - name: assert stop a paused service
   assert:
     that:
     - stop_paused_service is changed
     - stop_paused_service.state == 'stopped'
+    - stop_paused_service_actual.services[0].state == 'stopped'
 
 - name: fail to pause a stopped service check
   win_service:

--- a/tests/integration/targets/win_service_info/defaults/main.yml
+++ b/tests/integration/targets/win_service_info/defaults/main.yml
@@ -2,7 +2,7 @@
 test_path: '{{ remote_tmp_dir }}\win_service_info .ÅÑŚÌβŁÈ [$!@^&test(;)]'
 service_url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/win_service/SleepService.exe
 
-service_name1: ansible_service_info_test
+service_name1: ansible_service_info_test [*abc]
 service_name2: ansible_service_info_test2
 service_name3: ansible_service_info_other
 service_names:


### PR DESCRIPTION
##### SUMMARY
This is a refactor of the `win_service` module that adds the following

* Uses the `Ansible.Basic.AnsibleModule` wrapper
* Support for specifying virtual accounts and managed service accounts on the `username` option
* Separate `password` from `username`, they are no longer required to be set together so each can be updated individually
* Added `diff` output to better see what has changed
* Tidied up implementation to use the new SCManager C# util which opens up further configuration options like failure handling, service sid info, and lots of other config options
    * This also removes the 3 different ways we set things currently into the 1 unified interface that calls the Win32 APIs directly.

This PR also tweaks `win_service_info` in the following ways

* Supports `name` referencing a service with wildcard chars in the name
* Changed the `start_type` options of `boot_start` and `system_start` to just `boot` and `system` to better reflect how the other options are set in `win_service`

Fixes https://github.com/ansible-collections/ansible.windows/issues/28

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_service
win_service_info