### PR TITLE
Use original logic for FQDN hostname builder

### DIFF
--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -335,11 +335,12 @@ if($gather_subset.Contains('platform')) {
     $win32_cs = Get-LazyCimInstance Win32_ComputerSystem
     $win32_os = Get-LazyCimInstance Win32_OperatingSystem
     $domain_suffix = $win32_cs.Domain.Substring($win32_cs.Workgroup.length)
-    $fqdn = $win32_cs.DNSHostname
+    $ip_props = [System.Net.NetworkInformation.IPGlobalProperties]::GetIPGlobalProperties()
+    $fqdn = $ip_props.HostName
 
-    if( $domain_suffix -ne "")
+    if ($ip_props.DomainName)
     {
-        $fqdn = $win32_cs.DNSHostname + "." + $domain_suffix
+        $fqdn = "$($fqdn).$($ip_props.DomainName)"
     }
 
     try {
@@ -353,7 +354,7 @@ if($gather_subset.Contains('platform')) {
         ansible_architecture = $win32_os.OSArchitecture
         ansible_domain = $domain_suffix
         ansible_fqdn = $fqdn
-        ansible_hostname = $win32_cs.DNSHostname
+        ansible_hostname = $ip_props.HostName
         ansible_netbios_name = $win32_cs.Name
         ansible_kernel = $osversion.Version.ToString()
         ansible_nodename = $fqdn


### PR DESCRIPTION
##### SUMMARY
The changes in https://github.com/ansible/ansible/pull/56279 fixed the stray period at the end of a host when not joined to a domain but it is returning the domain name and not the actual primary DNS suffix of the host.

This PR keeps that original logic but changes the source of the FQDN dns part back to the original IPGlobalProperties method.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup