### PR TITLE
win_dsc: better error when WSMan not available

### DIFF
--- a/plugins/modules/win_dsc.py
+++ b/plugins/modules/win_dsc.py
@@ -73,11 +73,28 @@ notes:
 - To see the valid options for a DSC resource, run the module with C(-vvv) to
   show the possible module invocation. Default values are not shown in this
   output but are applied within the DSC engine.
+- The DSC engine requires the HTTP WSMan listener to be online and its port
+  configured as the default listener for HTTP. This is set up by default but if
+  a custom HTTP port is used or only a HTTPS listener is present then the
+  module will fail. See the examples for a way to check this out in PowerShell.
 author:
 - Trond Hindenes (@trondhindenes)
 '''
 
 EXAMPLES = r'''
+- name: Verify the WSMan HTTP listener is active and configured correctly
+  win_shell: |
+    $port = (Get-Item -LiteralPath WSMan:\localhost\Client\DefaultPorts\HTTP).Value
+    $onlinePorts = @(Get-ChildItem -LiteralPath WSMan:\localhost\Listener |
+        Where-Object { 'Transport=HTTP' -in $_.Keys } |
+        Get-ChildItem |
+        Where-Object Name -eq Port |
+        Select-Object -ExpandProperty Value)
+
+    if ($port -notin $onlinePorts) {
+        "The default client port $port is not set up as a WSMan HTTP listener, win_dsc will not work."
+    }
+
 - name: Extract zip file
   win_dsc:
     resource_name: Archive

--- a/tests/integration/targets/win_dsc/tasks/tests.yml
+++ b/tests/integration/targets/win_dsc/tasks/tests.yml
@@ -102,6 +102,24 @@
   register: fail_invalid_option_old_sub_dict
   failed_when: 'fail_invalid_option_old_sub_dict.msg != "Unsupported parameters for (win_dsc) module: Choice found in CimInstanceArrayParam. Supported parameters include: Key, IntValue, StringArrayValue, StringValue"'
 
+# https://github.com/ansible-collections/ansible.windows/issues/32
+- name: temporary change the default HTTP client port
+  win_shell: |
+    (Get-Item -LiteralPath WSMan:\localhost\Client\DefaultPorts\HTTP).Value
+    Set-Item -LiteralPath WSMan:\localhost\Client\DefaultPorts\HTTP -Value 1234
+  register: wsman_default_port
+
+- block:
+  - name: fail with unavailable HTTP WSMan listener
+    win_dsc:
+      resource_name: resource
+    register: fail_no_wsman
+    failed_when: 'fail_no_wsman.msg != "The win_dsc module requires the WSMan HTTP listener to be configured and online. The port win_dsc is set to use is 1234 as configured by ''Get-Item -LiteralPath WSMan:\localhost\Client\DefaultPorts\HTTP''."'
+
+  always:
+  - name: change the default HTTP client port back
+    win_shell: Set-Item -LiteralPath WSMan:\localhost\Client\DefaultPorts\HTTP -Value {{ wsman_default_port.stdout | trim }}
+
 - name: create test file (check mode)
   win_dsc:
     resource_name: File


### PR DESCRIPTION
##### SUMMARY
The `Invoke-DscResource` creates a CimSession in the background but there is no way to configure the port or protocol to use so it will only work when a HTTP WSMan listener is active on the port configured by `Get-Item -LiteralPath WSMan:\localhost\Client\DefaultPorts\HTTP`.

Instead of giving a cryptic error from the cmdlet this PR will give users a better message. It also adds this requirement to the docs for the module.

Fixes https://github.com/ansible-collections/ansible.windows/issues/32

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_dsc