### PR TITLE
win_service: feature bonanza

### DIFF
--- a/tests/integration/targets/win_service/tasks/error_control.yml
+++ b/tests/integration/targets/win_service/tasks/error_control.yml
@@ -1,0 +1,45 @@
+- name: set error control (check)
+  win_service:
+    name: '{{ test_win_service_name }}'
+    error_control: ignore
+  register: set_error_control_check
+  check_mode: yes
+
+- name: get result of set error control (check)
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: set_error_control_actual_check
+
+- name: assert set error control (check)
+  assert:
+    that:
+    - set_error_control_check is changed
+    - set_error_control_actual_check.services[0].error_control == 'normal'
+
+- name: set error control
+  win_service:
+    name: '{{ test_win_service_name }}'
+    error_control: ignore
+  register: set_type
+
+- name: get result of set error control
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: set_error_control_actual
+
+- name: assert set error control
+  assert:
+    that:
+    - set_type is changed
+    - set_error_control_actual.services[0].error_control == 'ignore'
+
+- name: set error control (idempotent)
+  win_service:
+    name: '{{ test_win_service_name }}'
+    error_control: ignore
+  register: set_error_control_again
+
+- name: assert set error control (idempotent)
+  assert:
+    that:
+    - not set_error_control_again is changed

--- a/tests/integration/targets/win_service/tasks/failure_actions.yml
+++ b/tests/integration/targets/win_service/tasks/failure_actions.yml
@@ -1,0 +1,241 @@
+- name: set a failure action (check mode)
+  win_service:
+    name: '{{ test_win_service_name }}'
+    failure_actions:
+    - type: restart
+    - type: run_command
+      delay_ms: 1000
+    - type: restart
+      delay: 0xFFFFFFFF
+    - type: reboot
+    failure_actions_on_non_crash_failure: yes
+    failure_command: fail command
+    failure_reboot_msg: fail reboot msg
+    failure_reset_period_sec: '0xFFFFFFFF'
+  register: set_actions_check
+  check_mode: yes
+
+- name: get result of set a failure action (check mode)
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: set_actions_actual_check
+
+- name: assert set a failure action (check mode)
+  assert:
+    that:
+    - set_actions_check is changed
+    - set_actions_actual_check.services[0].failure_actions | length == 0
+    - set_actions_actual_check.services[0].failure_actions_on_non_crash_failure == False
+    - set_actions_actual_check.services[0].failure_command == None
+    - set_actions_actual_check.services[0].failure_reboot_msg == None
+    - set_actions_actual_check.services[0].failure_reset_period_sec == 0
+
+- name: set a failure action
+  win_service:
+    name: '{{ test_win_service_name }}'
+    failure_actions:
+    - type: restart
+    - type: run_command
+      delay_ms: 1000
+    - type: restart
+      delay: 0xFFFFFFFF
+    - type: reboot
+    failure_actions_on_non_crash_failure: yes
+    failure_command: fail command
+    failure_reboot_msg: fail reboot msg
+    failure_reset_period_sec: '0xFFFFFFFF'
+  register: set_actions
+
+- name: get result of set a failure action
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: set_actions_actual
+
+- name: assert set a failure action
+  assert:
+    that:
+    - set_actions is changed
+    - set_actions_actual.services[0].failure_actions | length == 4
+    - set_actions_actual.services[0].failure_actions[0].delay_ms == 0
+    - set_actions_actual.services[0].failure_actions[0].type == 'restart'
+    - set_actions_actual.services[0].failure_actions[1].delay_ms == 1000
+    - set_actions_actual.services[0].failure_actions[1].type == 'run_command'
+    - set_actions_actual.services[0].failure_actions[2].delay_ms == 4294967295
+    - set_actions_actual.services[0].failure_actions[2].type == 'restart'
+    - set_actions_actual.services[0].failure_actions[3].delay_ms == 0
+    - set_actions_actual.services[0].failure_actions[3].type == 'reboot'
+    - set_actions_actual.services[0].failure_actions_on_non_crash_failure == True
+    - set_actions_actual.services[0].failure_command == 'fail command'
+    - set_actions_actual.services[0].failure_reboot_msg == 'fail reboot msg'
+    - set_actions_actual.services[0].failure_reset_period_sec == 4294967295
+
+- name: set a failure action (idempotent)
+  win_service:
+    name: '{{ test_win_service_name }}'
+    failure_actions:
+    - type: restart
+    - type: run_command
+      delay_ms: 1000
+    - type: restart
+      delay: 0xFFFFFFFF
+    - type: reboot
+    failure_actions_on_non_crash_failure: yes
+    failure_command: fail command
+    failure_reboot_msg: fail reboot msg
+    failure_reset_period_sec: '0xFFFFFFFF'
+  register: set_actions_again
+
+- name: assert set a failure action (idempotent)
+  assert:
+    that:
+    - not set_actions_again is changed
+
+- name: set other failure info
+  win_service:
+    name: '{{ test_win_service_name }}'
+    failure_command: fail command new
+  register: leave_actions
+
+- name: get result of set other failure info
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: leave_actions_actual
+
+- name: assert set other failure info
+  assert:
+    that:
+    - leave_actions is changed
+    - leave_actions_actual.services[0].failure_actions | length == 4
+    - leave_actions_actual.services[0].failure_actions[0].delay_ms == 0
+    - leave_actions_actual.services[0].failure_actions[0].type == 'restart'
+    - leave_actions_actual.services[0].failure_actions[1].delay_ms == 1000
+    - leave_actions_actual.services[0].failure_actions[1].type == 'run_command'
+    - leave_actions_actual.services[0].failure_actions[2].delay_ms == 4294967295
+    - leave_actions_actual.services[0].failure_actions[2].type == 'restart'
+    - leave_actions_actual.services[0].failure_actions[3].delay_ms == 0
+    - leave_actions_actual.services[0].failure_actions[3].type == 'reboot'
+    - leave_actions_actual.services[0].failure_actions_on_non_crash_failure == True
+    - leave_actions_actual.services[0].failure_command == 'fail command new'
+    - leave_actions_actual.services[0].failure_reboot_msg == 'fail reboot msg'
+    - leave_actions_actual.services[0].failure_reset_period_sec == 4294967295
+
+- name: edit a failure action
+  win_service:
+    name: '{{ test_win_service_name }}'
+    failure_actions:
+    - type: restart
+    - type: run_command
+      delay: 1000
+    - type: restart
+      delay: 0xFFFFFFFF
+    - type: none
+    failure_command: fail command 2
+  register: edit_action
+
+- name: get result of edit a failure action
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: edit_action_actual
+
+- name: assert edit a failure action
+  assert:
+    that:
+    - edit_action is changed
+    - edit_action_actual.services[0].failure_actions | length == 4
+    - edit_action_actual.services[0].failure_actions[0].delay_ms == 0
+    - edit_action_actual.services[0].failure_actions[0].type == 'restart'
+    - edit_action_actual.services[0].failure_actions[1].delay_ms == 1000
+    - edit_action_actual.services[0].failure_actions[1].type == 'run_command'
+    - edit_action_actual.services[0].failure_actions[2].delay_ms == 4294967295
+    - edit_action_actual.services[0].failure_actions[2].type == 'restart'
+    - edit_action_actual.services[0].failure_actions[3].delay_ms == 0
+    - edit_action_actual.services[0].failure_actions[3].type == 'none'
+    - edit_action_actual.services[0].failure_actions_on_non_crash_failure == True
+    - edit_action_actual.services[0].failure_command == 'fail command 2'
+    - edit_action_actual.services[0].failure_reboot_msg == 'fail reboot msg'
+    - edit_action_actual.services[0].failure_reset_period_sec == 4294967295
+
+- name: remove a failure action
+  win_service:
+    name: '{{ test_win_service_name }}'
+    failure_actions:
+    - type: restart
+    - type: run_command
+      delay: 1000
+    failure_reboot_msg: fail reboot msg 2
+    failure_reset_period_sec: 1234
+  register: remove_action
+
+- name: get result of remove a failure action
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: remove_action_actual
+
+- name: assert edit a failure action
+  assert:
+    that:
+    - remove_action is changed
+    - remove_action_actual.services[0].failure_actions | length == 2
+    - remove_action_actual.services[0].failure_actions[0].delay_ms == 0
+    - remove_action_actual.services[0].failure_actions[0].type == 'restart'
+    - remove_action_actual.services[0].failure_actions[1].delay_ms == 1000
+    - remove_action_actual.services[0].failure_actions[1].type == 'run_command'
+    - remove_action_actual.services[0].failure_actions_on_non_crash_failure == True
+    - remove_action_actual.services[0].failure_command == 'fail command 2'
+    - remove_action_actual.services[0].failure_reboot_msg == 'fail reboot msg 2'
+    - remove_action_actual.services[0].failure_reset_period_sec == 1234
+
+- name: add a failure action
+  win_service:
+    name: '{{ test_win_service_name }}'
+    failure_actions:
+    - type: restart
+    - type: run_command
+      delay: 1000
+    - type: none
+    failure_actions_on_non_crash_failure: no
+    failure_reboot_msg: ''
+  register: add_action
+
+- name: get result of add a failure action
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: add_action_actual
+
+- name: assert add a failure action
+  assert:
+    that:
+    - add_action is changed
+    - add_action_actual.services[0].failure_actions | length == 3
+    - add_action_actual.services[0].failure_actions[0].delay_ms == 0
+    - add_action_actual.services[0].failure_actions[0].type == 'restart'
+    - add_action_actual.services[0].failure_actions[1].delay_ms == 1000
+    - add_action_actual.services[0].failure_actions[1].type == 'run_command'
+    - add_action_actual.services[0].failure_actions[2].delay_ms == 0
+    - add_action_actual.services[0].failure_actions[2].type == 'none'
+    - add_action_actual.services[0].failure_actions_on_non_crash_failure == False
+    - add_action_actual.services[0].failure_command == 'fail command 2'
+    - add_action_actual.services[0].failure_reboot_msg == None
+    - add_action_actual.services[0].failure_reset_period_sec == 1234
+
+- name: clear failure actions
+  win_service:
+    name: '{{ test_win_service_name }}'
+    failure_actions: []
+    failure_command: ''
+  register: clear_action
+
+- name: get result of clear failure actions
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: clear_action_actual
+
+- name: assert clear failure actions
+  assert:
+    that:
+    - clear_action is changed
+    - clear_action_actual.services[0].failure_actions | length == 0
+    - clear_action_actual.services[0].failure_actions_on_non_crash_failure == False
+    - clear_action_actual.services[0].failure_command == None
+    - clear_action_actual.services[0].failure_reboot_msg == None
+    - clear_action_actual.services[0].failure_reset_period_sec == 0

--- a/tests/integration/targets/win_service/tasks/load_order_group.yml
+++ b/tests/integration/targets/win_service/tasks/load_order_group.yml
@@ -1,0 +1,62 @@
+- name: set load order group (check)
+  win_service:
+    name: '{{ test_win_service_name }}'
+    load_order_group: order group
+  register: set_load_order_group_check
+  check_mode: yes
+
+- name: get result of set load order group (check)
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: set_load_order_group_actual_check
+
+- name: assert set load order group (check)
+  assert:
+    that:
+    - set_load_order_group_check is changed
+    - set_load_order_group_actual_check.services[0].load_order_group == ''
+
+- name: set load order group
+  win_service:
+    name: '{{ test_win_service_name }}'
+    load_order_group: order group
+  register: set_type
+
+- name: get result of set load order group
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: set_load_order_group_actual
+
+- name: assert set load order group
+  assert:
+    that:
+    - set_type is changed
+    - set_load_order_group_actual.services[0].load_order_group == 'order group'
+
+- name: set load order group (idempotent)
+  win_service:
+    name: '{{ test_win_service_name }}'
+    load_order_group: order group
+  register: set_load_order_group_again
+
+- name: assert set load order group (idempotent)
+  assert:
+    that:
+    - not set_load_order_group_again is changed
+
+- name: reset load order group
+  win_service:
+    name: '{{ test_win_service_name }}'
+    load_order_group: ''
+  register: reset_load_order_group
+
+- name: get result of reset load order group
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: reset_load_order_group_actual
+
+- name: assert reset load order group
+  assert:
+    that:
+    - reset_load_order_group is changed
+    - reset_load_order_group_actual.services[0].load_order_group == ''

--- a/tests/integration/targets/win_service/tasks/main.yml
+++ b/tests/integration/targets/win_service/tasks/main.yml
@@ -38,7 +38,39 @@
   - TestServiceDependency
 
 - block:
+  - name: create new dummy test service
+    win_service:
+      name: "{{test_win_service_name}}"
+      path: "{{test_win_service_path}}"
+      display_name: "{{test_win_service_display_name}}"
+      description: "{{test_win_service_description}}"
+    register: win_service_added
+
+  - name: check that creating a new service succeeds with a change
+    assert:
+      that:
+      - win_service_added is changed
+      - win_service_added.name == test_win_service_name
+      - win_service_added.can_pause_and_continue == False
+      - win_service_added.display_name == test_win_service_display_name
+      - win_service_added.description == test_win_service_description
+      - win_service_added.path == test_win_service_path
+      - win_service_added.state == 'stopped'
+      - win_service_added.start_mode == 'auto'
+      - win_service_added.username == 'LocalSystem'
+      - win_service_added.desktop_interact == False
+      - win_service_added.dependencies == []
+      - win_service_added.depended_by == []
+      - win_service_added.exists == True
+
   - include_tasks: tests.yml
+  - include_tasks: error_control.yml
+  - include_tasks: failure_actions.yml
+  - include_tasks: load_order_group.yml
+  - include_tasks: pre_shutdown_timeout_ms.yml
+  - include_tasks: required_privileges.yml
+  - include_tasks: service_type.yml
+  - include_tasks: sid_info.yml
 
   always:
   - name: remove test services

--- a/tests/integration/targets/win_service/tasks/pre_shutdown_timeout_ms.yml
+++ b/tests/integration/targets/win_service/tasks/pre_shutdown_timeout_ms.yml
@@ -14,7 +14,8 @@
   assert:
     that:
     - set_pre_shutdown_timeout_ms_check is changed
-    - set_pre_shutdown_timeout_ms_actual_check.services[0].pre_shutdown_timeout_ms == 10000
+    # Different OS versions have different defaults, just make sure it didn't set our value in check mode
+    - set_pre_shutdown_timeout_ms_actual_check.services[0].pre_shutdown_timeout_ms != 4294967295
 
 - name: set pre shutdown timeout ms
   win_service:

--- a/tests/integration/targets/win_service/tasks/pre_shutdown_timeout_ms.yml
+++ b/tests/integration/targets/win_service/tasks/pre_shutdown_timeout_ms.yml
@@ -1,0 +1,45 @@
+- name: set pre shutdown timeout ms (check)
+  win_service:
+    name: '{{ test_win_service_name }}'
+    pre_shutdown_timeout_ms: 0xFFFFFFFF
+  register: set_pre_shutdown_timeout_ms_check
+  check_mode: yes
+
+- name: get result of set pre shutdown timeout ms (check)
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: set_pre_shutdown_timeout_ms_actual_check
+
+- name: assert set pre shutdown timeout ms (check)
+  assert:
+    that:
+    - set_pre_shutdown_timeout_ms_check is changed
+    - set_pre_shutdown_timeout_ms_actual_check.services[0].pre_shutdown_timeout_ms == 10000
+
+- name: set pre shutdown timeout ms
+  win_service:
+    name: '{{ test_win_service_name }}'
+    pre_shutdown_timeout_ms: 0xFFFFFFFF
+  register: set_type
+
+- name: get result of set pre shutdown timeout ms
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: set_pre_shutdown_timeout_ms_actual
+
+- name: assert set pre shutdown timeout ms
+  assert:
+    that:
+    - set_type is changed
+    - set_pre_shutdown_timeout_ms_actual.services[0].pre_shutdown_timeout_ms == 4294967295
+
+- name: set pre shutdown timeout ms (idempotent)
+  win_service:
+    name: '{{ test_win_service_name }}'
+    pre_shutdown_timeout_ms: 0xFFFFFFFF
+  register: set_pre_shutdown_timeout_ms_again
+
+- name: assert set pre shutdown timeout ms (idempotent)
+  assert:
+    that:
+    - not set_pre_shutdown_timeout_ms_again is changed

--- a/tests/integration/targets/win_service/tasks/required_privileges.yml
+++ b/tests/integration/targets/win_service/tasks/required_privileges.yml
@@ -1,0 +1,126 @@
+- name: set required privileges (check mode)
+  win_service:
+    name: '{{ test_win_service_name }}'
+    required_privileges:
+    - SeBackupPrivilege
+    - SeRestorePrivilege
+  register: set_privilege_check
+  check_mode: yes
+
+- name: get result of set required privileges (check mode)
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: set_privilege_actual_check
+
+- name: assert set required privileges (check mode)
+  assert:
+    that:
+    - set_privilege_check is changed
+    - set_privilege_actual_check.services[0].required_privileges == []
+
+- name: set required privileges
+  win_service:
+    name: '{{ test_win_service_name }}'
+    required_privileges:
+    - SeBackupPrivilege
+    - SeRestorePrivilege
+  register: set_privilege
+
+- name: get result of set required privileges
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: set_privilege_actual
+
+- name: assert set required privileges
+  assert:
+    that:
+    - set_privilege is changed
+    - set_privilege_actual.services[0].required_privileges == ['SeBackupPrivilege', 'SeRestorePrivilege']
+
+- name: set required privileges (idempotent)
+  win_service:
+    name: '{{ test_win_service_name }}'
+    required_privileges:
+    - SeBackupPrivilege
+    - SeRestorePrivilege
+  register: set_privilege_again
+
+- name: assert set required privileges (idempotent)
+  assert:
+    that:
+    - not set_privilege_again is changed
+
+- name: change without touching privilege
+  win_service:
+    name: '{{ test_win_service_name }}'
+    description: test
+  register: change_no_privilege
+
+- name: get result of change without touching privilege
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: change_no_privilege_actual
+
+- name: assert change without touching privilege
+  assert:
+    that:
+    - change_no_privilege is changed
+    - change_no_privilege_actual.services[0].required_privileges == set_privilege_actual.services[0].required_privileges
+
+- name: add a privilege
+  win_service:
+    name: '{{ test_win_service_name }}'
+    required_privileges:
+    - SeBackupPrivilege
+    - SeRestorePrivilege
+    - SeTakeOwnershipPrivilege
+  register: add_privilege
+
+- name: get result of add a privilege
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: add_privilege_actual
+
+- name: assert add a privilege
+  assert:
+    that:
+    - add_privilege is changed
+    - add_privilege_actual.services[0].required_privileges == ['SeBackupPrivilege', 'SeRestorePrivilege', 'SeTakeOwnershipPrivilege']
+
+- name: remove a privilege
+  win_service:
+    name: '{{ test_win_service_name }}'
+    required_privileges:
+    - SeBackupPrivilege
+    - SeRestorePrivilege
+  register: remove_privilege
+
+- name: get result of remove a privilege
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: remove_privilege_actual
+
+- name: assert remove a privilege
+  assert:
+    that:
+    - remove_privilege is changed
+    - remove_privilege_actual.services[0].required_privileges == ['SeBackupPrivilege', 'SeRestorePrivilege']
+
+- name: change a privilege
+  win_service:
+    name: '{{ test_win_service_name }}'
+    required_privileges:
+    - SeBackupPrivilege
+    - SeTakeOwnershipPrivilege
+  register: change_privilege
+
+- name: get result of change a privilege
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: change_privilege_actual
+
+- name: assert change a privilege
+  assert:
+    that:
+    - change_privilege is changed
+    - change_privilege_actual.services[0].required_privileges == ['SeBackupPrivilege', 'SeTakeOwnershipPrivilege']

--- a/tests/integration/targets/win_service/tasks/service_type.yml
+++ b/tests/integration/targets/win_service/tasks/service_type.yml
@@ -1,0 +1,45 @@
+- name: set service type (check)
+  win_service:
+    name: '{{ test_win_service_name }}'
+    service_type: win32_share_process
+  register: set_type_check
+  check_mode: yes
+
+- name: get result of set service type (check)
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: set_type_actual_check
+
+- name: assert set service type (check)
+  assert:
+    that:
+    - set_type_check is changed
+    - set_type_actual_check.services[0].service_type == 'win32_own_process'
+
+- name: set service type
+  win_service:
+    name: '{{ test_win_service_name }}'
+    service_type: win32_share_process
+  register: set_type
+
+- name: get result of set service type
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: set_type_actual
+
+- name: assert set service type
+  assert:
+    that:
+    - set_type is changed
+    - set_type_actual.services[0].service_type == 'win32_share_process'
+
+- name: set service type (idempotent)
+  win_service:
+    name: '{{ test_win_service_name }}'
+    service_type: win32_share_process
+  register: set_type_again
+
+- name: assert set service type (idempotent)
+  assert:
+    that:
+    - not set_type_again is changed

--- a/tests/integration/targets/win_service/tasks/sid_info.yml
+++ b/tests/integration/targets/win_service/tasks/sid_info.yml
@@ -1,0 +1,45 @@
+- name: set sid info (check)
+  win_service:
+    name: '{{ test_win_service_name }}'
+    sid_info: restricted
+  register: set_sid_info_check
+  check_mode: yes
+
+- name: get result of set sid info (check)
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: set_sid_info_actual_check
+
+- name: assert set sid info (check)
+  assert:
+    that:
+    - set_sid_info_check is changed
+    - set_sid_info_actual_check.services[0].sid_info == 'none'
+
+- name: set sid info
+  win_service:
+    name: '{{ test_win_service_name }}'
+    sid_info: restricted
+  register: set_type
+
+- name: get result of set sid info
+  win_service_info:
+    name: '{{ test_win_service_name }}'
+  register: set_sid_info_actual
+
+- name: assert set sid info
+  assert:
+    that:
+    - set_type is changed
+    - set_sid_info_actual.services[0].sid_info == 'restricted'
+
+- name: set sid info (idempotent)
+  win_service:
+    name: '{{ test_win_service_name }}'
+    sid_info: restricted
+  register: set_sid_info_again
+
+- name: assert set sid info (idempotent)
+  assert:
+    that:
+    - not set_sid_info_again is changed

--- a/tests/integration/targets/win_service/tasks/tests.yml
+++ b/tests/integration/targets/win_service/tasks/tests.yml
@@ -1,29 +1,4 @@
 ---
-- name: create new dummy test service
-  win_service:
-    name: "{{test_win_service_name}}"
-    path: "{{test_win_service_path}}"
-    display_name: "{{test_win_service_display_name}}"
-    description: "{{test_win_service_description}}"
-  register: win_service_added
-
-- name: check that creating a new service succeeds with a change
-  assert:
-    that:
-    - win_service_added is changed
-    - win_service_added.name == test_win_service_name
-    - win_service_added.can_pause_and_continue == False
-    - win_service_added.display_name == test_win_service_display_name
-    - win_service_added.description == test_win_service_description
-    - win_service_added.path == test_win_service_path
-    - win_service_added.state == 'stopped'
-    - win_service_added.start_mode == 'auto'
-    - win_service_added.username == 'LocalSystem'
-    - win_service_added.desktop_interact == False
-    - win_service_added.dependencies == []
-    - win_service_added.depended_by == []
-    - win_service_added.exists == True
-
 - name: test win_service module with short name
   win_service:
     name: "{{test_win_service_name}}"

--- a/tests/integration/targets/win_service_info/tasks/main.yml
+++ b/tests/integration/targets/win_service_info/tasks/main.yml
@@ -104,31 +104,44 @@
     dependencies:
     - '{{ service_name2 }}'
 
-- name: edit basic settings for service 2
+- name: edit advanced settings for service 2
   win_service:
     dependencies:
     - '{{ service_name3 }}'
     description: Service description
+    desktop_interact: yes
     display_name: Ansible Service Display Name
+    error_control: ignore
+    failure_actions:
+    - type: run_command
+      delay_ms: 500
+    - type: run_command
+      delay_ms: 600
+    - type: restart
+      delay_ms: 700
+    - type: reboot
+      delay_ms: 800
+    failure_actions_on_non_crash_failure: yes
+    failure_command: Command line
+    failure_reboot_msg: Reboot msg
+    failure_reset_period_sec: 86400
+    load_order_group: My group
     name: '{{ service_name2 }}'
+    required_privileges:
+    - SeBackupPrivilege
+    - SeRestorePrivilege
+    service_type: win32_share_process
+    sid_info: unrestricted
+    start_mode: delayed
     state: stopped
 
-# TODO: move this back into the above once win_service supports them
-- name: edit complex settings for service 2
-  win_command: sc.exe {{ item.action }} {{ service_name2 }} {{ item.args }}
-  with_items:
-  - action: config
-    args: type= share type= interact error= ignore group= "My group" start= delayed-auto
-  - action: failure
-    args: reset= 86400 reboot= "Reboot msg" command= "Command line" actions= run/500/run/600/restart/700/reboot/800
-  - action: failureflag
-    args: 1
-  - action: sidtype
-    args: unrestricted
-  - action: privs
-    args: SeBackupPrivilege/SeRestorePrivilege
-  - action: triggerinfo
-    args: start/namedpipe/abc start/namedpipe/def start/custom/0e0682e2-9951-4e6d-a36a-a0047e616f28/11223344/aabbccdd start/strcustom/c2961e88-c1f4-4d97-b581-219c852e1c7d/11223344/aabbccdd start/portopen/1234;tcp;imagepath;servicename
+# TODO: use win_service_trigger module once it has been created (or win_service if that's where it ends up)
+- name: add triggers for service 2
+  win_command: >-
+    sc.exe
+    triggerinfo
+    {{ service_name2 }}
+    start/namedpipe/abc start/namedpipe/def start/custom/0e0682e2-9951-4e6d-a36a-a0047e616f28/11223344/aabbccdd start/strcustom/c2961e88-c1f4-4d97-b581-219c852e1c7d/11223344/aabbccdd start/portopen/1234;tcp;imagepath;servicename
 
 - name: get info of advanced service using display name
   win_service_info:


### PR DESCRIPTION
##### SUMMARY
Now that the module has been refactored with https://github.com/ansible-collections/ansible.windows/pull/34 we can start adding more features into it. This PR adds the following options to win_service

* error_control
* failure_actions
* failure_actions_on_non_crash_failure
* failure_command
* failure_reboot_msg
* failure_reset_period_sec
* load_order_group
* pre_shutdown_timeout_ms
* required_privileges
* service_type
* sid_info

With this change the only things missing from the win_service module are:

* Triggers
    * This is quite complex and potentially warrants being in its own module
* Security Descriptors
    * I'm hoping to create a generic framework for `win_<resource>_sd` modules that this will fall under
* Preferred nodes
    * Only valid for NUMA enabled hosts, cannot really test in CI
* Process protection level
    * Once you set this we cannot touch the service so it would be difficult to make idempotent as well as test in CI
* Mentioned by @briantist, ability to set env vars for a service process
    * I can't find any official docs from MS but it looks like this can be done in the registry https://stackoverflow.com/questions/305870/accessing-environment-variables-from-windows-services/2728574#2728574, not sure if we should expose this here or just recommend win_regedit  

Fixes: https://github.com/ansible-collections/ansible.windows/issues/11

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_service