### PR TITLE
win_package: Use signed ints when comparing the RC

### DIFF
--- a/plugins/modules/win_package.ps1
+++ b/plugins/modules/win_package.ps1
@@ -644,8 +644,12 @@ Function Invoke-Executable {
 
     $result = Run-Command @commandArgs
 
-    $module.Result.rc = $result.rc
-    if ($ReturnCodes -notcontains $result.rc) {
+    # Run-Command returns rc as a UInt32 but we need to compare it with a Int32, we get the byte equivalent Int32 value
+    # instead. https://github.com/ansible-collections/ansible.windows/issues/46
+    $rc = [BitConverter]::ToInt32([BitConverter]::GetBytes($result.rc), 0)
+
+    $module.Result.rc = $rc
+    if ($ReturnCodes -notcontains $rc) {
         $module.Result.stdout = $result.stdout
         $module.Result.stderr = $result.stderr
         if ($LogPath -and (Test-Path -LiteralPath $LogPath)) {
@@ -657,7 +661,7 @@ Function Invoke-Executable {
         $module.Result.failed = $false
     }
 
-    if ($result.rc -eq 3010) {
+    if ($rc -eq 3010) {
         $module.Result.reboot_required = $true
     }
 }

--- a/plugins/modules/win_package.py
+++ b/plugins/modules/win_package.py
@@ -64,8 +64,11 @@ options:
     description:
     - One or more return codes from the package installation that indicates
       success.
-    - Before Ansible 2.4 this was just 0 but since Ansible 2.4 this is both C(0) and
-      C(3010).
+    - The return codes are read as a signed integer, any values greater than
+      2147483647 need to be represented as the signed equivalent, i.e.
+      C(4294967295) is C(-1).
+    - To convert a unsigned number to the signed equivalent you can run
+      "[Int32]("0x{0:X}" -f ([UInt32]3221225477))".
     - A return code of C(3010) usually means that a reboot is required, the
       C(reboot_required) return value is set if the return code is C(3010).
     - This is only used for the C(msi), C(msp), and C(registry) providers.

--- a/tests/integration/targets/win_package/tasks/registry_tests.yml
+++ b/tests/integration/targets/win_package/tasks/registry_tests.yml
@@ -236,8 +236,8 @@
   win_package:
     path: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
     product_id: '{{ registry_id }}'
-    arguments: '-Command Remove-Item -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{{ registry_id }}; exit 1'
-    expected_return_code: 1
+    arguments: '-Command Remove-Item -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{{ registry_id }}; exit -1'
+    expected_return_code: -1
     state: absent
   register: registry_uninstall_explicit_path
 
@@ -250,7 +250,7 @@
   assert:
     that:
     - registry_uninstall_explicit_path is changed
-    - registry_uninstall_explicit_path.rc == 1
+    - registry_uninstall_explicit_path.rc == -1
     - not registry_uninstall_explicit_path.reboot_required
     - not registry_uninstall_explicit_path_actual.exists
 


### PR DESCRIPTION
##### SUMMARY
The return code from `Run-Command` is an unsigned int while the `expected_return_code` parameter is a list of signed ints. We need to convert the output of `Run-Command` to be a signed int so comparisons of any negative numbers are done correctly.

Fixes https://github.com/ansible-collections/ansible.windows/issues/46

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_package