### PR TITLE
Added WebRequest util modelled after the Ansible WebRequest util

### DIFF
--- a/plugins/doc_fragments/web_request.py
+++ b/plugins/doc_fragments/web_request.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2020 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment:
+
+    # Common options for ansible_collections.ansible.windows.plugins.module_utils.WebRequest
+    DOCUMENTATION = r'''
+options:
+  url_method:
+    description:
+    - The HTTP Method of the request.
+    type: str
+  follow_redirects:
+    description:
+    - Whether or the module should follow redirects.
+    - C(all) will follow all redirect.
+    - C(none) will not follow any redirect.
+    - C(safe) will follow only "safe" redirects, where "safe" means that the
+      client is only doing a C(GET) or C(HEAD) on the URI to which it is being
+      redirected.
+    - When following a redirected URL, the C(Authorization) header and any
+      credentials set will be dropped and not redirected.
+    choices:
+    - all
+    - none
+    - safe
+    default: safe
+    type: str
+  headers:
+    description:
+    - Extra headers to set on the request.
+    - This should be a dictionary where the key is the header name and the
+      value is the value for that header.
+    type: dict
+  http_agent:
+    description:
+    - Header to identify as, generally appears in web server logs.
+    - This is set to the C(User-Agent) header on a HTTP request.
+    default: ansible-httpget
+    type: str
+  maximum_redirection:
+    description:
+    - Specify how many times the module will redirect a connection to an
+      alternative URI before the connection fails.
+    - If set to C(0) or I(follow_redirects) is set to C(none), or C(safe) when
+      not doing a C(GET) or C(HEAD) it prevents all redirection.
+    default: 50
+    type: int
+  url_timeout:
+    description:
+    - Specifies how long the request can be pending before it times out (in
+      seconds).
+    - Set to C(0) to specify an infinite timeout.
+    default: 30
+    type: int
+  validate_certs:
+    description:
+    - If C(no), SSL certificates will not be validated.
+    - This should only be used on personally controlled sites using self-signed
+      certificates.
+    default: yes
+    type: bool
+  client_cert:
+    description:
+    - The path to the client certificate (.pfx) that is used for X509
+      authentication. This path can either be the path to the C(pfx) on the
+      filesystem or the PowerShell certificate path
+      C(Cert:\CurrentUser\My\<thumbprint>).
+    - The WinRM connection must be authenticated with C(CredSSP) or C(become)
+      is used on the task if the certificate file is not password protected.
+    - Other authentication types can set I(client_cert_password) when the cert
+      is password protected.
+    type: str
+  client_cert_password:
+    description:
+    - The password for I(client_cert) if the cert is password protected.
+    type: str
+  force_basic_auth:
+    description:
+    - By default the authentication header is only sent when a webservice
+      responses to an initial request with a 401 status. Since some basic auth
+      services do not properly send a 401, logins will fail.
+    - This option forces the sending of the Basic authentication header upon
+      the original request.
+    default: no
+    type: bool
+  url_username:
+    description:
+    - The username to use for authentication.
+    type: str
+  url_password:
+    description:
+    - The password for I(url_username).
+    type: str
+  use_default_credential:
+    description:
+    - Uses the current user's credentials when authenticating with a server
+      protected with C(NTLM), C(Kerberos), or C(Negotiate) authentication.
+    - Sites that use C(Basic) auth will still require explicit credentials
+      through the I(url_username) and I(url_password) options.
+    - The module will only have access to the user's credentials if using
+      C(become) with a password, you are connecting with SSH using a password,
+      or connecting with WinRM using C(CredSSP) or C(Kerberos with delegation).
+    - If not using C(become) or a different auth method to the ones stated
+      above, there will be no default credentials available and no
+      authentication will occur.
+    default: no
+    type: bool
+  use_proxy:
+    description:
+    - If C(no), it will not use the proxy defined in IE for the current user.
+    default: yes
+    type: bool
+  proxy_url:
+    description:
+    - An explicit proxy to use for the request.
+    - By default, the request will use the IE defined proxy unless I(use_proxy)
+      is set to C(no).
+    type: str
+  proxy_username:
+    description:
+    - The username to use for proxy authentication.
+    type: str
+  proxy_password:
+    description:
+    - The password for I(proxy_username).
+    type: str
+  proxy_use_default_credential:
+    description:
+    - Uses the current user's credentials when authenticating with a proxy host
+      protected with C(NTLM), C(Kerberos), or C(Negotiate) authentication.
+    - Proxies that use C(Basic) auth will still require explicit credentials
+      through the I(proxy_username) and I(proxy_password) options.
+    - The module will only have access to the user's credentials if using
+      C(become) with a password, you are connecting with SSH using a password,
+      or connecting with WinRM using C(CredSSP) or C(Kerberos with delegation).
+    - If not using C(become) or a different auth method to the ones stated
+      above, there will be no default credentials available and no proxy
+      authentication will occur.
+    default: no
+    type: bool
+seealso:
+- module: community.windows.win_inet_proxy
+'''

--- a/plugins/module_utils/WebRequest.psm1
+++ b/plugins/module_utils/WebRequest.psm1
@@ -1,0 +1,518 @@
+# Copyright (c) 2020 Ansible Project
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+Function Get-AnsibleWindowsWebRequest {
+    <#
+    .SYNOPSIS
+    Creates a System.Net.WebRequest object based on common URL module options in Ansible.
+
+    .DESCRIPTION
+    Will create a WebRequest based on common input options within Ansible. This can be used manually or with
+    Invoke-AnsibleWindowsWebRequest.
+
+    .PARAMETER Uri
+    The URI to create the web request for.
+
+    .PARAMETER UrlMethod
+    The protocol method to use, if omitted, will use the default value for the URI protocol specified.
+
+    .PARAMETER FollowRedirects
+    Whether to follow redirect reponses. This is only valid when using a HTTP URI.
+        all - Will follow all redirects
+        none - Will follow no redirects
+        safe - Will only follow redirects when GET or HEAD is used as the UrlMethod
+
+    .PARAMETER Headers
+    A hashtable or dictionary of header values to set on the request. This is only valid for a HTTP URI.
+
+    .PARAMETER HttpAgent
+    A string to set for the 'User-Agent' header. This is only valid for a HTTP URI.
+
+    .PARAMETER MaximumRedirection
+    The maximum number of redirections that will be followed. This is only valid for a HTTP URI.
+
+    .PARAMETER UrlTimeout
+    The timeout in seconds that defines how long to wait until the request times out.
+
+    .PARAMETER ValidateCerts
+    Whether to validate SSL certificates, default to True.
+
+    .PARAMETER ClientCert
+    The path to PFX file to use for X509 authentication. This is only valid for a HTTP URI. This path can either
+    be a filesystem path (C:\folder\cert.pfx) or a PSPath to a credential (Cert:\CurrentUser\My\<thumbprint>).
+
+    .PARAMETER ClientCertPassword
+    The password for the PFX certificate if required. This is only valid for a HTTP URI.
+
+    .PARAMETER ForceBasicAuth
+    Whether to set the Basic auth header on the first request instead of when required. This is only valid for a
+    HTTP URI.
+
+    .PARAMETER UrlUsername
+    The username to use for authenticating with the target.
+
+    .PARAMETER UrlPassword
+    The password to use for authenticating with the target.
+
+    .PARAMETER UseDefaultCredential
+    Whether to use the current user's credentials if available. This will only work when using Become, using SSH with
+    password auth, or WinRM with CredSSP or Kerberos with credential delegation.
+
+    .PARAMETER UseProxy
+    Whether to use the default proxy defined in IE (WinINet) for the user or set no proxy at all. This should not
+    be set to True when ProxyUrl is also defined.
+
+    .PARAMETER ProxyUrl
+    An explicit proxy server to use for the request instead of relying on the default proxy in IE. This is only
+    valid for a HTTP URI.
+
+    .PARAMETER ProxyUsername
+    An optional username to use for proxy authentication.
+
+    .PARAMETER ProxyPassword
+    The password for ProxyUsername.
+
+    .PARAMETER ProxyUseDefaultCredential
+    Whether to use the current user's credentials for proxy authentication if available. This will only work when
+    using Become, using SSH with password auth, or WinRM with CredSSP or Kerberos with credential delegation.
+
+    .PARAMETER Module
+    The AnsibleBasic module that can be used as a backup parameter source or a way to return warnings back to the
+    Ansible controller.
+
+    .EXAMPLE
+    $spec = @{
+        options = @{}
+    }
+    $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec, @(Get-AnsibleWindowsWebRequestSpec))
+
+    $web_request = Get-AnsibleWindowsWebRequest -Module $module
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Net.WebRequest])]
+    Param (
+        [Alias("url")]
+        [System.Uri]
+        $Uri,
+
+        [Alias("url_method")]
+        [System.String]
+        $UrlMethod,
+
+        [Alias("follow_redirects")]
+        [ValidateSet("all", "none", "safe")]
+        [System.String]
+        $FollowRedirects = "safe",
+
+        [System.Collections.IDictionary]
+        $Headers,
+
+        [Alias("http_agent")]
+        [System.String]
+        $HttpAgent = "ansible-httpget",
+
+        [Alias("maximum_redirection")]
+        [System.Int32]
+        $MaximumRedirection = 50,
+
+        [Alias("url_timeout")]
+        [System.Int32]
+        $UrlTimeout = 30,
+
+        [Alias("validate_certs")]
+        [System.Boolean]
+        $ValidateCerts = $true,
+
+        # Credential params
+        [Alias("client_cert")]
+        [System.String]
+        $ClientCert,
+
+        [Alias("client_cert_password")]
+        [System.String]
+        $ClientCertPassword,
+
+        [Alias("force_basic_auth")]
+        [Switch]
+        $ForceBasicAuth,
+
+        [Alias("url_username")]
+        [System.String]
+        $UrlUsername,
+
+        [Alias("url_password")]
+        [System.String]
+        $UrlPassword,
+
+        [Alias("use_default_credential")]
+        [Switch]
+        $UseDefaultCredential,
+
+        # Proxy params
+        [Alias("use_proxy")]
+        [System.Boolean]
+        $UseProxy = $true,
+
+        [Alias("proxy_url")]
+        [System.String]
+        $ProxyUrl,
+
+        [Alias("proxy_username")]
+        [System.String]
+        $ProxyUsername,
+
+        [Alias("proxy_password")]
+        [System.String]
+        $ProxyPassword,
+
+        [Alias("proxy_use_default_credential")]
+        [Switch]
+        $ProxyUseDefaultCredential,
+
+        [ValidateScript({ $_.GetType().FullName -eq 'Ansible.Basic.AnsibleModule' })]
+        [System.Object]
+        $Module
+    )
+
+    # Set module options for parameters unless they were explicitly passed in.
+    if ($Module) {
+        foreach ($param in $PSCmdlet.MyInvocation.MyCommand.Parameters.GetEnumerator()) {
+            if ($PSBoundParameters.ContainsKey($param.Key)) {
+                # Was set explicitly we want to use that value
+                continue
+            }
+
+            foreach ($alias in @($Param.Key) + $param.Value.Aliases) {
+                if ($Module.Params.ContainsKey($alias)) {
+                    $var_value = $Module.Params.$alias -as $param.Value.ParameterType
+                    Set-Variable -Name $param.Key -Value $var_value
+                    break
+                }
+            }
+        }
+    }
+
+    # Disable certificate validation if requested
+    # FUTURE: set this on ServerCertificateValidationCallback of the HttpWebRequest once .NET 4.5 is the minimum
+    if (-not $ValidateCerts) {
+        [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
+    }
+
+    # Enable TLS1.1/TLS1.2 if they're available but disabled (eg. .NET 4.5)
+    $security_protocols = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::SystemDefault
+    if ([System.Net.SecurityProtocolType].GetMember("Tls11").Count -gt 0) {
+        $security_protocols = $security_protocols -bor [System.Net.SecurityProtocolType]::Tls11
+    }
+    if ([System.Net.SecurityProtocolType].GetMember("Tls12").Count -gt 0) {
+        $security_protocols = $security_protocols -bor [System.Net.SecurityProtocolType]::Tls12
+    }
+    [System.Net.ServicePointManager]::SecurityProtocol = $security_protocols
+
+    $web_request = [System.Net.WebRequest]::Create($Uri)
+    if ($UrlMethod) {
+        $web_request.Method = $UrlMethod
+    }
+    $web_request.Timeout = $UrlTimeout * 1000
+
+    if ($UseDefaultCredential -and $web_request -is [System.Net.HttpWebRequest]) {
+        $web_request.UseDefaultCredentials = $true
+    } elseif ($UrlUsername) {
+        if ($ForceBasicAuth) {
+            $auth_value = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $UrlUsername, $UrlPassword)))
+            $web_request.Headers.Add("Authorization", "Basic $auth_value")
+        } else {
+            $credential = New-Object -TypeName System.Net.NetworkCredential -ArgumentList $UrlUsername, $UrlPassword
+            $web_request.Credentials = $credential
+        }
+    }
+
+    if ($ClientCert) {
+        # Expecting either a filepath or PSPath (Cert:\CurrentUser\My\<thumbprint>)
+        $cert = Get-Item -LiteralPath $ClientCert -ErrorAction SilentlyContinue
+        if ($null -eq $cert) {
+            Write-Error -Message "Client certificate '$ClientCert' does not exist" -Category ObjectNotFound
+            return
+        }
+
+        $crypto_ns = 'System.Security.Cryptography.X509Certificates'
+        if ($cert.PSProvider.Name -ne 'Certificate') {
+            try {
+                $cert = New-Object -TypeName "$crypto_ns.X509Certificate2" -ArgumentList @(
+                    $ClientCert, $ClientCertPassword
+                )
+            } catch [System.Security.Cryptography.CryptographicException] {
+                Write-Error -Message "Failed to read client certificate at '$ClientCert'" -Exception $_.Exception -Category SecurityError
+                return
+            }
+        }
+        $web_request.ClientCertificates = New-Object -TypeName "$crypto_ns.X509Certificate2Collection" -ArgumentList @(
+            $cert
+        )
+    }
+
+    if (-not $UseProxy) {
+        $proxy = $null
+    } elseif ($ProxyUrl) {
+        $proxy = New-Object -TypeName System.Net.WebProxy -ArgumentList $ProxyUrl, $true
+    } else  {
+        $proxy = $web_request.Proxy
+    }
+
+    # $web_request.Proxy may return $null for a FTP web request. We only set the credentials if we have an actual
+    # proxy to work with, otherwise just ignore the credentials property.
+    if ($null -ne $proxy) {
+        if ($ProxyUseDefaultCredential) {
+            # Weird hack, $web_request.Proxy returns an IWebProxy object which only gurantees the Credentials
+            # property. We cannot set UseDefaultCredentials so we just set the Credentials to the
+            # DefaultCredentials in the CredentialCache which does the same thing.
+            $proxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials
+        } elseif ($ProxyUsername) {
+            $proxy.Credentials = New-Object -TypeName System.Net.NetworkCredential -ArgumentList @(
+                $ProxyUsername, $ProxyPassword
+            )
+        } else {
+            $proxy.Credentials = $null
+        }
+    }
+
+    $web_request.Proxy = $proxy
+
+    # Some parameters only apply when dealing with a HttpWebRequest
+    if ($web_request -is [System.Net.HttpWebRequest]) {
+        if ($Headers) {
+            foreach ($header in $Headers.GetEnumerator()) {
+                switch ($header.Key) {
+                    Accept { $web_request.Accept = $header.Value }
+                    Connection { $web_request.Connection = $header.Value }
+                    Content-Length { $web_request.ContentLength = $header.Value }
+                    Content-Type { $web_request.ContentType = $header.Value }
+                    Expect { $web_request.Expect = $header.Value }
+                    Date { $web_request.Date = $header.Value }
+                    Host { $web_request.Host = $header.Value }
+                    If-Modified-Since { $web_request.IfModifiedSince = $header.Value }
+                    Range { $web_request.AddRange($header.Value) }
+                    Referer { $web_request.Referer = $header.Value }
+                    Transfer-Encoding {
+                        $web_request.SendChunked = $true
+                        $web_request.TransferEncoding = $header.Value
+                    }
+                    User-Agent { continue }
+                    default { $web_request.Headers.Add($header.Key, $header.Value) }
+                }
+            }
+        }
+
+        # For backwards compatibility we need to support setting the User-Agent if the header was set in the task.
+        # We just need to make sure that if an explicit http_agent module was set then that takes priority.
+        if ($Headers -and $Headers.ContainsKey("User-Agent")) {
+            $options = (Get-AnsibleWindowsWebRequestSpec).options
+            if ($HttpAgent -eq $options.http_agent.default) {
+                $HttpAgent = $Headers['User-Agent']
+            } elseif ($null -ne $Module) {
+                $Module.Warn("The 'User-Agent' header and the 'http_agent' was set, using the 'http_agent' for web request")
+            }
+        }
+        $web_request.UserAgent = $HttpAgent
+
+        switch ($FollowRedirects) {
+            none { $web_request.AllowAutoRedirect = $false }
+            safe {
+                if ($web_request.Method -in @("GET", "HEAD")) {
+                    $web_request.AllowAutoRedirect = $true
+                } else {
+                    $web_request.AllowAutoRedirect = $false
+                }
+            }
+            all { $web_request.AllowAutoRedirect = $true }
+        }
+
+        if ($MaximumRedirection -eq 0) {
+            $web_request.AllowAutoRedirect = $false
+        } else {
+            $web_request.MaximumAutomaticRedirections = $MaximumRedirection
+        }
+    }
+
+    return $web_request
+}
+
+Function Invoke-AnsibleWindowsWebRequest {
+    <#
+    .SYNOPSIS
+    Invokes a ScriptBlock with the WebRequest.
+
+    .DESCRIPTION
+    Invokes the ScriptBlock and handle extra information like accessing the response stream, closing those streams
+    safely as well as setting common module return values.
+
+    .PARAMETER Module
+    The Ansible.Basic module to set the return values for. This will set the following return values;
+        elapsed - The total time, in seconds, that it took to send the web request and process the response
+        msg - The human readable description of the response status code
+        status_code - An int that is the response status code
+
+    .PARAMETER Request
+    The System.Net.WebRequest to call. This can either be manually crafted or created with
+    Get-AnsibleWindowsWebRequest.
+
+    .PARAMETER Script
+    The ScriptBlock to invoke during the web request. This ScriptBlock should take in the params
+        Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+    This scriptblock should manage the response based on what it need to do.
+
+    .PARAMETER Body
+    An optional Stream to send to the target during the request.
+
+    .PARAMETER IgnoreBadResponse
+    By default a WebException will be raised for a non 2xx status code and the Script will not be invoked. This
+    parameter can be set to process all responses regardless of the status code.
+
+    .EXAMPLE Basic module that downloads a file
+    $spec = @{
+        options = @{
+            path = @{ type = "path"; required = $true }
+        }
+    }
+    $module = Ansible.Basic.AnsibleModule]::Create($args, $spec, @(Get-AnsibleWindowsWebRequestSpec))
+
+    $web_request = Get-AnsibleWindowsWebRequest -Module $module
+
+    Invoke-AnsibleWindowsWebRequest -Module $module -Request $web_request -Script {
+        Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+        $fs = [System.IO.File]::Create($module.Params.path)
+        try {
+            $Stream.CopyTo($fs)
+            $fs.Flush()
+        } finally {
+            $fs.Dispose()
+        }
+    }
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [System.Object]
+        [ValidateScript({ $_.GetType().FullName -eq 'Ansible.Basic.AnsibleModule' })]
+        $Module,
+
+        [Parameter(Mandatory=$true)]
+        [System.Net.WebRequest]
+        $Request,
+
+        [Parameter(Mandatory=$true)]
+        [ScriptBlock]
+        $Script,
+
+        [AllowNull()]
+        [System.IO.Stream]
+        $Body,
+
+        [Switch]
+        $IgnoreBadResponse
+    )
+
+    $start = Get-Date
+    if ($null -ne $Body) {
+        $request_st = $Request.GetRequestStream()
+        try {
+            $Body.CopyTo($request_st)
+            $request_st.Flush()
+        } finally {
+            $request_st.Close()
+        }
+    }
+
+    try {
+        try {
+            $web_response = $Request.GetResponse()
+        } catch [System.Net.WebException] {
+            # A WebResponse with a status code not in the 200 range will raise a WebException. We check if the
+            # exception raised contains the actual response and continue on if IgnoreBadResponse is set. We also
+            # make sure we set the status_code return value on the Module object if possible
+
+            if ($_.Exception.PSObject.Properties.Name -match "Response") {
+                $web_response = $_.Exception.Response
+
+                if (-not $IgnoreBadResponse -or $null -eq $web_response) {
+                    $Module.Result.msg = $_.Exception.StatusDescription
+                    $Module.Result.status_code = $_.Exception.Response.StatusCode
+                    throw $_
+                }
+            } else {
+                throw $_
+            }
+        }
+
+        if ($Request.RequestUri.IsFile) {
+            # A FileWebResponse won't have these properties set
+            $Module.Result.msg = "OK"
+            $Module.Result.status_code = 200
+        } else {
+            $Module.Result.msg = $web_response.StatusDescription
+            $Module.Result.status_code = $web_response.StatusCode
+        }
+
+        $response_stream = $web_response.GetResponseStream()
+        try {
+            # Invoke the ScriptBlock and pass in WebResponse and ResponseStream
+            &$Script -Response $web_response -Stream $response_stream
+        } finally {
+            $response_stream.Dispose()
+        }
+    } finally {
+        if ($web_response) {
+            $web_response.Close()
+        }
+        $Module.Result.elapsed = ((Get-date) - $start).TotalSeconds
+    }
+}
+
+Function Get-AnsibleWindowsWebRequestSpec {
+    <#
+    .SYNOPSIS
+    Used by modules to get the argument spec fragment for AnsibleModule.
+
+    .EXAMPLES
+    $spec = @{
+        options = @{}
+    }
+    $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec, @(Get-AnsibleWindowsWebRequestSpec))
+
+    .NOTES
+    The options here are reflected in the doc fragment 'ansible.windows.web_request' at
+    'plugins/doc_fragments/web_request.py'.
+    #>
+    @{
+        options = @{
+            url_method = @{ type = 'str' }
+            follow_redirects = @{ type = 'str'; choices = @('all', 'none', 'safe'); default = 'safe' }
+            headers = @{ type = 'dict' }
+            http_agent = @{ type = 'str'; default = 'ansible-httpget' }
+            maximum_redirection = @{ type = 'int'; default = 50 }
+            url_timeout = @{ type = 'int'; default = 30 }
+            validate_certs = @{ type = 'bool'; default = $true }
+
+            # Credential options
+            client_cert = @{ type = 'str' }
+            client_cert_password = @{ type = 'str'; no_log = $true }
+            force_basic_auth = @{ type = 'bool'; default = $false }
+            url_username = @{ type = 'str' }
+            url_password = @{ type = 'str'; no_log = $true }
+            use_default_credential = @{ type = 'bool'; default = $false }
+
+            # Proxy options
+            use_proxy = @{ type = 'bool'; default = $true }
+            proxy_url = @{ type = 'str' }
+            proxy_username = @{ type = 'str' }
+            proxy_password = @{ type = 'str'; no_log = $true }
+            proxy_use_default_credential = @{ type = 'bool'; default = $false }
+        }
+    }
+}
+
+$export_members = @{
+    Function = "Get-AnsibleWindowsWebRequest", "Get-AnsibleWindowsWebRequestSpec", "Invoke-AnsibleWindowsWebRequest"
+}
+Export-ModuleMember @export_members

--- a/plugins/modules/win_get_url.py
+++ b/plugins/modules/win_get_url.py
@@ -68,37 +68,40 @@ options:
         transfer.
       - This option cannot be set with I(checksum).
     type: str
+  url_method:
+    aliases:
+    - method
+  url_timeout:
+    aliases:
+    - timeout
+
+  # Following defined in the web_request fragment but the module contains deprecated aliases for backwards compatibility.
   url_username:
     description:
     - The username to use for authentication.
-    - The aliases I(user) and I(username) are deprecated and will be removed in
-      Ansible 2.14.
+    - The alias I(user) and I(username) is deprecated and will be removed on
+      the major release after C(2022-07-01).
     aliases:
     - user
     - username
   url_password:
     description:
     - The password for I(url_username).
-    - The alias I(password) is deprecated and will be removed in Ansible 2.14.
+    - The alias I(password) is deprecated and will be removed on the major
+      release after C(2022-07-01).
     aliases:
     - password
-  method:
-    description:
-    - This option is not for use with C(win_get_url) and should be ignored.
 notes:
 - If your URL includes an escaped slash character (%2F) this module will convert it to a real slash.
   This is a result of the behaviour of the System.Uri class as described in
   L(the documentation,https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/network/schemesettings-element-uri-settings#remarks).
-- Since Ansible 2.8, the module will skip reporting a change if the remote
-  checksum is the same as the local local even when C(force=yes). This is to
-  better align with M(get_url).
 extends_documentation_fragment:
-- url_windows
+- ansible.windows.web_request
 
 seealso:
 - module: get_url
 - module: uri
-- module: win_uri
+- module: ansible.windows.win_uri
 author:
 - Paul Durivage (@angstwad)
 - Takeshi Kuramochi (@tksarah)
@@ -106,18 +109,18 @@ author:
 
 EXAMPLES = r'''
 - name: Download earthrise.jpg to specified path
-  win_get_url:
+  ansible.windows.win_get_url:
     url: http://www.example.com/earthrise.jpg
     dest: C:\Users\RandomUser\earthrise.jpg
 
 - name: Download earthrise.jpg to specified path only if modified
-  win_get_url:
+  ansible.windows.win_get_url:
     url: http://www.example.com/earthrise.jpg
     dest: C:\Users\RandomUser\earthrise.jpg
     force: no
 
 - name: Download earthrise.jpg to specified path through a proxy server.
-  win_get_url:
+  ansible.windows.win_get_url:
     url: http://www.example.com/earthrise.jpg
     dest: C:\Users\RandomUser\earthrise.jpg
     proxy_url: http://10.0.0.1:8080
@@ -125,14 +128,14 @@ EXAMPLES = r'''
     proxy_password: password
 
 - name: Download file from FTP with authentication
-  win_get_url:
+  ansible.windows.win_get_url:
     url: ftp://server/file.txt
     dest: '%TEMP%\ftp-file.txt'
     url_username: ftp-user
     url_password: ftp-password
 
 - name: Download src with sha256 checksum url
-  win_get_url:
+  ansible.windows.win_get_url:
     url: http://www.example.com/earthrise.jpg
     dest: C:\temp\earthrise.jpg
     checksum_url: http://www.example.com/sha256sum.txt
@@ -140,7 +143,7 @@ EXAMPLES = r'''
     force: True
 
 - name: Download src with sha256 checksum url
-  win_get_url:
+  ansible.windows.win_get_url:
     url: http://www.example.com/earthrise.jpg
     dest: C:\temp\earthrise.jpg
     checksum: a97e6837f60cec6da4491bab387296bbcd72bdba

--- a/plugins/modules/win_package.py
+++ b/plugins/modules/win_package.py
@@ -30,10 +30,9 @@ options:
     - If the package is an MSI do not supply the C(/qn), C(/log) or
       C(/norestart) arguments.
     - This is only used for the C(msi), C(msp), and C(registry) providers.
-    - As of Ansible 2.5, this parameter can be a list of arguments and the
-      module will escape the arguments as necessary, it is recommended to use a
-      string when dealing with MSI packages due to the unique escaping issues
-      with msiexec.
+    - Can be a list of arguments and the module will escape the arguments as
+      necessary, it is recommended to use a string when dealing with MSI
+      packages due to the unique escaping issues with msiexec.
     type: raw
   chdir:
     description:
@@ -88,7 +87,8 @@ options:
     description:
     - The password for C(user_name), must be set when C(user_name) is.
     - This option is deprecated in favour of using become, see examples for
-      more information.
+      more information. Will be removed on the major release after
+      C(2022-07-01).
     type: str
     aliases: [ user_password ]
   path:
@@ -122,7 +122,8 @@ options:
     - This SHOULD be set when the package is an C(exe), or the path is a url
       or a network share and credential delegation is not being used. The
       C(creates_*) options can be used instead but is not recommended.
-    - The C(productid) alias will be removed in Ansible 2.14.
+    - The alias I(productid) is deprecated and will be removed on the major
+      release after C(2022-07-01).
     type: str
     aliases: [ productid ]
   provider:
@@ -131,8 +132,7 @@ options:
     - The C(auto) provider will select the proper provider if I(path)
       otherwise it scans all the other providers based on the I(product_id).
     - The C(msi) provider scans for MSI packages installed on a machine wide
-      and current user context based on the C(ProductCode) of the MSI. Before
-      Ansible 2.10 only the machine wide context was searched.
+      and current user context based on the C(ProductCode) of the MSI.
     - The C(msix) provider is used to install C(.appx), C(.msix),
       C(.appxbundle), or C(.msixbundle) packages. These packages are only
       installed or removed on the current use. The host must be set to allow
@@ -150,8 +150,6 @@ options:
       C(HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall),
       C(HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall), and
       C(HKCU:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall).
-      Before Ansible 2.10 only the C(HKLM) hive was searched.
-    - Before Ansible 2.10 only the C(msi) and C(registry) providers were used.
     choices:
     - auto
     - msi
@@ -167,7 +165,8 @@ options:
       installed or not.
     - For all providers but C(auto), the I(path) can be used for idempotency
       checks if it is locally accesible filesystem path.
-    - The C(ensure) alias will be removed in Ansible 2.14.
+    - The alias I(ensure) is deprecated and will be removed on the major
+      release after C(2022-07-01).
     type: str
     choices: [ absent, present ]
     default: present
@@ -180,18 +179,12 @@ options:
       does not support credential delegation like Basic or NTLM or become is
       not used.
     - This option is deprecated in favour of using become, see examples for
-      more information.
+      more information. Will be removed on the major release after
+      C(2022-07-01).
     type: str
     aliases: [ user_name ]
-
-  # Overrides the options in url_windows
-  timeout:
-    description:
-    - Specifies how long the web download request can be pending before it
-      times out in seconds.
-    - Set to C(0) to specify an infinite timeout.
 extends_documentation_fragment:
-- url_windows
+- ansible.windows.web_request
 
 notes:
 - When C(state=absent) and the product is an exe, the path may be different
@@ -203,9 +196,9 @@ notes:
 - All the installation checks under C(product_id) and C(creates_*) add
   together, if one fails then the program is considered to be absent.
 seealso:
-- module: win_chocolatey
-- module: win_hotfix
-- module: win_updates
+- module: chocolatey.chocolatey.win_chocolatey
+- module: community.windows.win_hotfix
+- module: ansible.windows.win_updates
 author:
 - Trond Hindenes (@trondhindenes)
 - Jordan Borean (@jborean93)
@@ -213,13 +206,13 @@ author:
 
 EXAMPLES = r'''
 - name: Install the Visual C thingy
-  win_package:
+  ansible.windows.win_package:
     path: http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe
     product_id: '{CF2BEA3C-26EA-32F8-AA9B-331F7E34BA97}'
     arguments: /install /passive /norestart
 
 - name: Install Visual C thingy with list of arguments instead of a string
-  win_package:
+  ansible.windows.win_package:
     path: http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe
     product_id: '{CF2BEA3C-26EA-32F8-AA9B-331F7E34BA97}'
     arguments:
@@ -228,30 +221,30 @@ EXAMPLES = r'''
     - /norestart
 
 - name: Install Remote Desktop Connection Manager from msi with a permanent log
-  win_package:
+  ansible.windows.win_package:
     path: https://download.microsoft.com/download/A/F/0/AF0071F3-B198-4A35-AA90-C68D103BDCCF/rdcman.msi
     product_id: '{0240359E-6A4C-4884-9E94-B397A02D893C}'
     state: present
     log_path: D:\logs\vcredist_x64-exe-{{lookup('pipe', 'date +%Y%m%dT%H%M%S')}}.log
 
 - name: Uninstall Remote Desktop Connection Manager
-  win_package:
+  ansible.windows.win_package:
     product_id: '{0240359E-6A4C-4884-9E94-B397A02D893C}'
     state: absent
 
 - name: Install Remote Desktop Connection Manager locally omitting the product_id
-  win_package:
+  ansible.windows.win_package:
     path: C:\temp\rdcman.msi
     state: present
 
 - name: Uninstall Remote Desktop Connection Manager from local MSI omitting the product_id
-  win_package:
+  ansible.windows.win_package:
     path: C:\temp\rdcman.msi
     state: absent
 
 # 7-Zip exe doesn't use a guid for the Product ID
 - name: Install 7zip from a network share with specific credentials
-  win_package:
+  ansible.windows.win_package:
     path: \\domain\programs\7z.exe
     product_id: 7-Zip
     arguments: /S
@@ -264,27 +257,27 @@ EXAMPLES = r'''
     ansible_become_password: Password
 
 - name: Install 7zip and use a file version for the installation check
-  win_package:
+  ansible.windows.win_package:
     path: C:\temp\7z.exe
     creates_path: C:\Program Files\7-Zip\7z.exe
     creates_version: 16.04
     state: present
 
 - name: Uninstall 7zip from the exe
-  win_package:
+  ansible.windows.win_package:
     path: C:\Program Files\7-Zip\Uninstall.exe
     product_id: 7-Zip
     arguments: /S
     state: absent
 
 - name: Uninstall 7zip without specifying the path
-  win_package:
+  ansible.windows.win_package:
     product_id: 7-Zip
     arguments: /S
     state: absent
 
 - name: Install application and override expected return codes
-  win_package:
+  ansible.windows.win_package:
     path: https://download.microsoft.com/download/1/6/7/167F0D79-9317-48AE-AEDB-17120579F8E2/NDP451-KB2858728-x86-x64-AllOS-ENU.exe
     product_id: '{7DEBE4EB-6B40-3766-BB35-5CBBC385DA37}'
     arguments: '/q /norestart'
@@ -292,17 +285,17 @@ EXAMPLES = r'''
     expected_return_code: [0, 666, 3010]
 
 - name: Install a .msp patch
-  win_package:
+  ansible.windows.win_package:
     path: C:\Patches\Product.msp
     state: present
 
 - name: Remove a .msp patch
-  win_package:
+  ansible.windows.win_package:
     product_id: '{AC76BA86-A440-FFFF-A440-0C13154E5D00}'
     state: absent
 
 - name: Enable installation of 3rd party MSIX packages
-  win_regedit:
+  ansible.windows.win_regedit:
     path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock
     name: AllowAllTrustedApps
     data: 1
@@ -310,12 +303,12 @@ EXAMPLES = r'''
     state: present
 
 - name: Install an MSIX package for the current user
-  win_package:
+  ansible.windows.win_package:
     path: C:\Installers\Calculator.msix  # Can be .appx, .msixbundle, or .appxbundle
     state: present
 
 - name: Uninstall an MSIX package using the product_id
-  win_package:
+  ansible.windows.win_package:
     product_id: InputApp
     state: absent
 '''

--- a/plugins/modules/win_uri.py
+++ b/plugins/modules/win_uri.py
@@ -23,11 +23,6 @@ options:
     - Supports FTP, HTTP or HTTPS URLs in the form of (ftp|http|https)://host.domain:port/path.
     type: str
     required: yes
-  method:
-    description:
-    - The HTTP Method of the request or response.
-    type: str
-    default: GET
   content_type:
     description:
     - Sets the "Content-Type" header.
@@ -63,30 +58,37 @@ options:
     type: list
     elements: int
     default: [ 200 ]
+
+  url_method:
+    default: GET
+    aliases:
+    - method
+  url_timeout:
+    aliases:
+    - timeout
+
+  # Following defined in the web_request fragment but the module contains deprecated aliases for backwards compatibility.
   url_username:
     description:
     - The username to use for authentication.
-    - Was originally called I(user) but was changed to I(url_username) in
-      Ansible 2.9.
-    - The aliases I(user) and I(username) are deprecated and will be removed in
-      Ansible 2.14.
+    - The alias I(user) and I(username) is deprecated and will be removed on
+      the major release after C(2022-07-01).
     aliases:
     - user
     - username
   url_password:
     description:
     - The password for I(url_username).
-    - Was originally called I(password) but was changed to I(url_password) in
-      Ansible 2.9.
-    - The alias I(password) is deprecated and will be removed in Ansible 2.14.
+    - The alias I(password) is deprecated and will be removed on the major
+      release after C(2022-07-01).
     aliases:
     - password
 extends_documentation_fragment:
-- url_windows
+- ansible.windows.web_request
 
 seealso:
 - module: uri
-- module: win_get_url
+- module: ansible.windows.win_get_url
 author:
 - Corwin Brown (@blakfeld)
 - Dag Wieers (@dagwieers)
@@ -94,25 +96,25 @@ author:
 
 EXAMPLES = r'''
 - name: Perform a GET and Store Output
-  win_uri:
+  ansible.windows.win_uri:
     url: http://example.com/endpoint
   register: http_output
 
 # Set a HOST header to hit an internal webserver:
 - name: Hit a Specific Host on the Server
-  win_uri:
+  ansible.windows.win_uri:
     url: http://example.com/
     method: GET
     headers:
       host: www.somesite.com
 
 - name: Perform a HEAD on an Endpoint
-  win_uri:
+  ansible.windows.win_uri:
     url: http://www.example.com/
     method: HEAD
 
 - name: POST a Body to an Endpoint
-  win_uri:
+  ansible.windows.win_uri:
     url: http://www.somesite.com/
     method: POST
     body: "{ 'some': 'json' }"

--- a/tests/integration/targets/module_utils_WebRequest/aliases
+++ b/tests/integration/targets/module_utils_WebRequest/aliases
@@ -1,0 +1,3 @@
+windows
+shippable/windows/group1
+needs/httptester

--- a/tests/integration/targets/module_utils_WebRequest/library/web_request_test.ps1
+++ b/tests/integration/targets/module_utils_WebRequest/library/web_request_test.ps1
@@ -1,0 +1,467 @@
+#!powershell
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -PowerShell ansible_collections.ansible.windows.plugins.module_utils.WebRequest
+
+$spec = @{
+    options = @{
+        httpbin_host = @{ type = 'str'; required = $true }
+    }
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$httpbin_host = $module.Params.httpbin_host
+
+Function Assert-Equals {
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)][AllowNull()]$Actual,
+        [Parameter(Mandatory=$true, Position=0)][AllowNull()]$Expected
+    )
+
+    $matched = $false
+    if ($Actual -is [System.Collections.ArrayList] -or $Actual -is [Array] -or $Actual -is [System.Collections.IList]) {
+        $Actual.Count | Assert-Equals -Expected $Expected.Count
+        for ($i = 0; $i -lt $Actual.Count; $i++) {
+            $actualValue = $Actual[$i]
+            $expectedValue = $Expected[$i]
+            Assert-Equals -Actual $actualValue -Expected $expectedValue
+        }
+        $matched = $true
+    } else {
+        $matched = $Actual -ceq $Expected
+    }
+
+    if (-not $matched) {
+        if ($Actual -is [PSObject]) {
+            $Actual = $Actual.ToString()
+        }
+
+        $call_stack = (Get-PSCallStack)[1]
+        $module.Result.test = $test
+        $module.Result.actual = $Actual
+        $module.Result.expected = $Expected
+        $module.Result.line = $call_stack.ScriptLineNumber
+        $module.Result.method = $call_stack.Position.Text
+
+        $module.FailJson("AssertionError: actual != expected")
+    }
+}
+
+Function Convert-StreamToString {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [System.IO.Stream]
+        $Stream
+    )
+
+    $ms = New-Object -TypeName System.IO.MemoryStream
+    try {
+        $Stream.CopyTo($ms)
+        [System.Text.Encoding]::UTF8.GetString($ms.ToArray())
+    } finally {
+        $ms.Dispose()
+    }
+}
+
+$tests = [Ordered]@{
+    'GET request over http' = {
+        $r = Get-AnsibleWindowsWebRequest -Uri "http://$httpbin_host/get"
+
+        $r.Method | Assert-Equals -Expected 'GET'
+        $r.Timeout | Assert-Equals -Expected 30000
+        $r.UseDefaultCredentials | Assert-Equals -Expected $false
+        $r.Credentials | Assert-Equals -Expected $null
+        $r.ClientCertificates.Count | Assert-Equals -Expected 0
+        $r.Proxy.Credentials | Assert-Equals -Expected $null
+        $r.UserAgent | Assert-Equals -Expected 'ansible-httpget'
+
+        $actual = Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.StatusCode | Assert-Equals -Expected 200
+            Convert-StreamToString -Stream $Stream
+        } | ConvertFrom-Json
+
+        $actual.headers.'User-Agent' | Assert-Equals -Expected 'ansible-httpget'
+        $actual.headers.'Host' | Assert-Equals -Expected $httpbin_host
+
+        $module.Result.msg | Assert-Equals -Expected 'OK'
+        $module.Result.status_code | Assert-Equals -Expected 200
+        $module.Result.ContainsKey('elapsed') | Assert-Equals -Expected $true
+    }
+
+    'GET request over https' = {
+        # url is an alias for the -Uri parameter.
+        $r = Get-AnsibleWindowsWebRequest -url "https://$httpbin_host/get"
+
+        $r.Method | Assert-Equals -Expected 'GET'
+        $r.Timeout | Assert-Equals -Expected 30000
+        $r.UseDefaultCredentials | Assert-Equals -Expected $false
+        $r.Credentials | Assert-Equals -Expected $null
+        $r.ClientCertificates.Count | Assert-Equals -Expected 0
+        $r.Proxy.Credentials | Assert-Equals -Expected $null
+        $r.UserAgent | Assert-Equals -Expected 'ansible-httpget'
+
+        $actual = Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.StatusCode | Assert-Equals -Expected 200
+            Convert-StreamToString -Stream $Stream
+        } | ConvertFrom-Json
+
+        $actual.headers.'User-Agent' | Assert-Equals -Expected 'ansible-httpget'
+        $actual.headers.'Host' | Assert-Equals -Expected $httpbin_host
+    }
+
+    'POST request' = {
+        $getParams = @{
+            Headers = @{
+                'Content-Type' = 'application/json'
+            }
+            UrlMethod = 'POST'
+            Uri = "https://$httpbin_host/post"
+        }
+        $r = Get-AnsibleWindowsWebRequest @getParams
+
+        $r.Method | Assert-Equals -Expected 'POST'
+        $r.Timeout | Assert-Equals -Expected 30000
+        $r.UseDefaultCredentials | Assert-Equals -Expected $false
+        $r.Credentials | Assert-Equals -Expected $null
+        $r.ClientCertificates.Count | Assert-Equals -Expected 0
+        $r.Proxy.Credentials | Assert-Equals -Expected $null
+        $r.ContentType | Assert-Equals -Expected 'application/json'
+        $r.UserAgent | Assert-Equals -Expected 'ansible-httpget'
+
+        $body = New-Object -TypeName System.IO.MemoryStream -ArgumentList @(,
+            ([System.Text.Encoding]::UTF8.GetBytes('{"foo":"bar"}'))
+        )
+        $actual = Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -Body $body -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.StatusCode | Assert-Equals -Expected 200
+            Convert-StreamToString -Stream $Stream
+        } | ConvertFrom-Json
+
+        $actual.headers.'User-Agent' | Assert-Equals -Expected 'ansible-httpget'
+        $actual.headers.'Host' | Assert-Equals -Expected $httpbin_host
+        $actual.data | Assert-Equals -Expected '{"foo":"bar"}'
+    }
+
+    'Safe redirection of GET' = {
+        $r = Get-AnsibleWindowsWebRequest -Uri "http://$httpbin_host/redirect/2"
+
+        Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.ResponseUri | Assert-Equals -Expected "http://$httpbin_host/get"
+            $Response.StatusCode | Assert-Equals -Expected 200
+        }
+    }
+
+    'Safe redirection of HEAD' = {
+        $r = Get-AnsibleWindowsWebRequest -Uri "http://$httpbin_host/redirect/2" -UrlMethod HEAD
+
+        Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.ResponseUri | Assert-Equals -Expected "http://$httpbin_host/get"
+            $Response.StatusCode | Assert-Equals -Expected 200
+        }
+    }
+
+    'Safe redirection of PUT' = {
+        $params = @{
+            UrlMethod = 'PUT'
+            Uri = "http://$httpbin_host/redirect-to?url=https://$httpbin_host/put"
+        }
+        $r = Get-AnsibleWindowsWebRequest @params
+
+        Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.ResponseUri | Assert-Equals -Expected $r.RequestUri
+            $Response.StatusCode | Assert-Equals -Expected 302
+        }
+    }
+
+    'None redirection of GET' = {
+        $params = @{
+            FollowRedirects = 'None'
+            Uri = "http://$httpbin_host/redirect/2"
+        }
+        $r = Get-AnsibleWindowsWebRequest @params
+
+        Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.ResponseUri | Assert-Equals -Expected $r.RequestUri
+            $Response.StatusCode | Assert-Equals -Expected 302
+        }
+    }
+
+    'None redirection of HEAD' = {
+        $params = @{
+            follow_redirects = 'None'
+            url_method = 'HEAD'
+            Uri = "http://$httpbin_host/redirect/2"
+        }
+        $r = Get-AnsibleWindowsWebRequest @params
+
+        Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.ResponseUri | Assert-Equals -Expected $r.RequestUri
+            $Response.StatusCode | Assert-Equals -Expected 302
+        }
+    }
+
+    'None redirection of PUT' = {
+        $params = @{
+            FollowRedirects = 'None'
+            UrlMethod = 'PUT'
+            Uri = "http://$httpbin_host/redirect-to?url=https://$httpbin_host/put"
+        }
+        $r = Get-AnsibleWindowsWebRequest @params
+
+        Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.ResponseUri | Assert-Equals -Expected $r.RequestUri
+            $Response.StatusCode | Assert-Equals -Expected 302
+        }
+    }
+
+    'All redirection of GET' = {
+        $params = @{
+            FollowRedirects = 'All'
+            Uri = "http://$httpbin_host/redirect/2"
+        }
+        $r = Get-AnsibleWindowsWebRequest @params
+
+        Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.ResponseUri | Assert-Equals -Expected "http://$httpbin_host/get"
+            $Response.StatusCode | Assert-Equals -Expected 200
+        }
+    }
+
+    'All redirection of HEAD' = {
+        $params = @{
+            follow_redirects = 'All'
+            url_method = 'HEAD'
+            Uri = "http://$httpbin_host/redirect/2"
+        }
+        $r = Get-AnsibleWindowsWebRequest @params
+
+        Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.ResponseUri | Assert-Equals -Expected "http://$httpbin_host/get"
+            $Response.StatusCode | Assert-Equals -Expected 200
+        }
+    }
+
+    'All redirection of PUT' = {
+        $params = @{
+            FollowRedirects = 'All'
+            UrlMethod = 'PUT'
+            Uri = "http://$httpbin_host/redirect-to?url=https://$httpbin_host/put"
+        }
+        $r = Get-AnsibleWindowsWebRequest @params
+
+        Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.ResponseUri | Assert-Equals -Expected "https://$httpbin_host/put"
+            $Response.StatusCode | Assert-Equals -Expected 200
+        }
+    }
+
+    'Exceeds maximum redirection - ignored' = {
+        $params = @{
+            MaximumRedirection = 4
+            Uri = "https://$httpbin_host/redirect/5"
+        }
+        $r = Get-AnsibleWindowsWebRequest @params
+
+        Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -IgnoreBadResponse -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.ResponseUri | Assert-Equals -Expected "https://$httpbin_host/relative-redirect/1"
+            $Response.StatusCode | Assert-Equals -Expected 302
+        }
+    }
+
+    'Exceeds maximum redirection - exception' = {
+        $params = @{
+            MaximumRedirection = 1
+            Uri = "https://$httpbin_host/redirect/2"
+        }
+        $r = Get-AnsibleWindowsWebRequest @params
+
+        $failed = $false
+        try {
+            $null = Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -Script {}
+        } catch {
+            $_.Exception.GetType().Name | Assert-Equals -Expected 'WebException'
+            $_.Exception.Message | Assert-Equals -Expected 'Too many automatic redirections were attempted.'
+            $failed = $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    'Basic auth as Credential' = {
+        $params = @{
+            Url = "http://$httpbin_host/basic-auth/username/password"
+            UrlUsername = 'username'
+            UrlPassword = 'password'
+        }
+        $r = Get-AnsibleWindowsWebRequest @params
+
+        Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -IgnoreBadResponse -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.StatusCode | Assert-Equals -Expected 200
+        }
+    }
+
+    'Basic auth as Header' = {
+        $params = @{
+            Url = "http://$httpbin_host/basic-auth/username/password"
+            url_username = 'username'
+            url_password = 'password'
+            ForceBasicAuth = $true
+        }
+        $r = Get-AnsibleWindowsWebRequest @params
+
+        Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -IgnoreBadResponse -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.StatusCode | Assert-Equals -Expected 200
+        }
+    }
+
+    'Send request with headers' = {
+        $params = @{
+            Headers = @{
+                'Content-Length' = 0
+                testingheader = 'testing_header'
+                TestHeader = 'test-header'
+                'User-Agent' = 'test-agent'
+            }
+            Url = "https://$httpbin_host/get"
+        }
+        $r = Get-AnsibleWindowsWebRequest @params
+
+        $actual = Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.StatusCode | Assert-Equals -Expected 200
+            Convert-StreamToString -Stream $Stream
+        } | ConvertFrom-Json
+
+        $actual.headers.'Testheader' | Assert-Equals -Expected 'test-header'
+        $actual.headers.'testingheader' | Assert-Equals -Expected 'testing_header'
+        $actual.Headers.'User-Agent' | Assert-Equals -Expected 'test-agent'
+    }
+
+    'Request with timeout' = {
+        $params = @{
+            Uri = "https://$httpbin_host/delay/5"
+            UrlTimeout = 1
+        }
+        $r = Get-AnsibleWindowsWebRequest @params
+
+        $failed = $false
+        try {
+            $null = Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -Script {}
+        } catch {
+            $failed = $true
+            $_.Exception.GetType().Name | Assert-Equals -Expected WebException
+            $_.Exception.Message | Assert-Equals -Expected 'The operation has timed out'
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    'Request with file URI' = {
+        $filePath = Join-Path $module.Tmpdir -ChildPath 'test.txt'
+        Set-Content -LiteralPath $filePath -Value 'test'
+
+        $r = Get-AnsibleWindowsWebRequest -Uri $filePath
+
+        $actual = Invoke-AnsibleWindowsWebRequest -Module $module -Request $r -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.ContentLength | Assert-Equals -Expected 6
+            Convert-StreamToString -Stream $Stream
+        }
+        $actual | Assert-Equals -Expected "test`r`n"
+        $module.Result.msg | Assert-Equals -Expected "OK"
+        $module.Result.status_code | Assert-Equals -Expected 200
+    }
+
+    'Web request based on module options' = {
+        Set-Variable complex_args -Scope Global -Value @{
+            url = "https://$httpbin_host/redirect/2"
+            url_method = 'GET'
+            follow_redirects = 'safe'
+            headers = @{
+                'User-Agent' = 'other-agent'
+            }
+            http_agent = 'actual-agent'
+            maximum_redirection = 2
+            url_timeout = 10
+            validate_certs = $false
+        }
+        $spec = @{
+            options = @{
+                url = @{ type = 'str'; required = $true }
+                test = @{ type = 'str'; choices = 'abc', 'def'}
+            }
+            mutually_exclusive = @(,@('url', 'test'))
+        }
+
+        $testModule = [Ansible.Basic.AnsibleModule]::Create(@(), $spec, @(Get-AnsibleWindowsWebRequestSpec))
+        $r = Get-AnsibleWindowsWebRequest -Url $testModule.Params.url -Module $testModule
+
+        $actual = Invoke-AnsibleWindowsWebRequest -Module $testModule -Request $r -Script {
+            Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
+
+            $Response.ResponseUri | Assert-Equals -Expected "https://$httpbin_host/get"
+            Convert-StreamToString -Stream $Stream
+        } | ConvertFrom-Json
+        $actual.headers.'User-Agent' | Assert-Equals -Expected 'actual-agent'
+    }
+
+    'Web request with default proxy' = {
+        $params = @{
+            Uri = "https://$httpbin_host/get"
+        }
+        $r = Get-AnsibleWindowsWebRequest @params
+
+        $null -ne $r.Proxy | Assert-Equals -Expected $true
+    }
+
+    'Web request with no proxy' = {
+        $params = @{
+            Uri = "https://$httpbin_host/get"
+            UseProxy = $false
+        }
+        $r = Get-AnsibleWindowsWebRequest @params
+
+        $null -eq $r.Proxy | Assert-Equals -Expected $true
+    }
+}
+
+# setup and teardown should favour native tools to create and delete the service and not the util we are testing.
+foreach ($testImpl in $tests.GetEnumerator()) {
+    Set-Variable -Name complex_args -Scope Global -Value @{}
+    $test = $testImpl.Key
+    &$testImpl.Value
+}
+
+$module.Result.data = "success"
+$module.ExitJson()

--- a/tests/integration/targets/module_utils_WebRequest/meta/main.yml
+++ b/tests/integration/targets/module_utils_WebRequest/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- setup_http_tests

--- a/tests/integration/targets/module_utils_WebRequest/tasks/main.yml
+++ b/tests/integration/targets/module_utils_WebRequest/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: test WebRequest
+  web_request_test:
+    httpbin_host: '{{ httpbin_host }}'
+  register: web_request
+
+- name: assert test WebRequest succeeded
+  assert:
+    that:
+    - web_request.data == 'success'


### PR DESCRIPTION
##### SUMMARY
Creates a copy of `Ansible.ModuleUtils.WebRequest` in the collection and migrates the 3 modules that use it to this copy. This starts the slow migration of module utils from ansible.windows into this collection.

Requires https://github.com/ansible/ansible/pull/69719 to be merged before this can work.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_get_url
win_package
win_uri