### PR TITLE
Use FQCN for docs and remove Ansible version references

### DIFF
--- a/plugins/modules/win_acl.py
+++ b/plugins/modules/win_acl.py
@@ -70,13 +70,12 @@ options:
     choices: [ InheritOnly, None, NoPropagateInherit ]
     default: "None"
 notes:
-- If adding ACL's for AppPool identities (available since 2.3), the Windows
-  Feature "Web-Scripting-Tools" must be enabled.
+- If adding ACL's for AppPool identities, the Windows Feature "Web-Scripting-Tools" must be enabled.
 seealso:
-- module: win_acl_inheritance
-- module: win_file
-- module: win_owner
-- module: win_stat
+- module: ansible.windows.win_acl_inheritance
+- module: ansible.windows.win_file
+- module: ansible.windows.win_owner
+- module: ansible.windows.win_stat
 author:
 - Phil Schwartz (@schwartzmx)
 - Trond Hindenes (@trondhindenes)
@@ -85,14 +84,14 @@ author:
 
 EXAMPLES = r'''
 - name: Restrict write and execute access to User Fed-Phil
-  win_acl:
+  ansible.windows.win_acl:
     user: Fed-Phil
     path: C:\Important\Executable.exe
     type: deny
     rights: ExecuteFile,Write
 
 - name: Add IIS_IUSRS allow rights
-  win_acl:
+  ansible.windows.win_acl:
     path: C:\inetpub\wwwroot\MySite
     user: IIS_IUSRS
     rights: FullControl
@@ -102,7 +101,7 @@ EXAMPLES = r'''
     propagation: 'None'
 
 - name: Set registry key right
-  win_acl:
+  ansible.windows.win_acl:
     path: HKCU:\Bovine\Key
     user: BUILTIN\Users
     rights: EnumerateSubKeys
@@ -112,7 +111,7 @@ EXAMPLES = r'''
     propagation: 'None'
 
 - name: Remove FullControl AccessRule for IIS_IUSRS
-  win_acl:
+  ansible.windows.win_acl:
     path: C:\inetpub\wwwroot\MySite
     user: IIS_IUSRS
     rights: FullControl
@@ -122,7 +121,7 @@ EXAMPLES = r'''
     propagation: 'None'
 
 - name: Deny Intern
-  win_acl:
+  ansible.windows.win_acl:
     path: C:\Administrator\Documents
     user: Intern
     rights: Read,Write,Modify,FullControl,Delete

--- a/plugins/modules/win_acl_inheritance.py
+++ b/plugins/modules/win_acl_inheritance.py
@@ -38,27 +38,27 @@ options:
     type: bool
     default: no
 seealso:
-- module: win_acl
-- module: win_file
-- module: win_stat
+- module: ansible.windows.win_acl
+- module: ansible.windows.win_file
+- module: ansible.windows.win_stat
 author:
 - Hans-Joachim Kliemeck (@h0nIg)
 '''
 
 EXAMPLES = r'''
 - name: Disable inherited ACE's
-  win_acl_inheritance:
+  ansible.windows.win_acl_inheritance:
     path: C:\apache
     state: absent
 
 - name: Disable and copy inherited ACE's
-  win_acl_inheritance:
+  ansible.windows.win_acl_inheritance:
     path: C:\apache
     state: absent
     reorganize: yes
 
 - name: Enable and remove dedicated ACE's
-  win_acl_inheritance:
+  ansible.windows.win_acl_inheritance:
     path: C:\apache
     state: present
     reorganize: yes

--- a/plugins/modules/win_certificate_store.py
+++ b/plugins/modules/win_certificate_store.py
@@ -134,12 +134,12 @@ author:
 
 EXAMPLES = r'''
 - name: Import a certificate
-  win_certificate_store:
+  ansible.windows.win_certificate_store:
     path: C:\Temp\cert.pem
     state: present
 
 - name: Import pfx certificate that is password protected
-  win_certificate_store:
+  ansible.windows.win_certificate_store:
     path: C:\Temp\cert.pfx
     state: present
     password: VeryStrongPasswordHere!
@@ -147,7 +147,7 @@ EXAMPLES = r'''
   become_method: runas
 
 - name: Import pfx certificate without password and set private key as un-exportable
-  win_certificate_store:
+  ansible.windows.win_certificate_store:
     path: C:\Temp\cert.pfx
     state: present
     key_exportable: no
@@ -156,30 +156,30 @@ EXAMPLES = r'''
     ansible_winrm_transport: credssp
 
 - name: Remove a certificate based on file thumbprint
-  win_certificate_store:
+  ansible.windows.win_certificate_store:
     path: C:\Temp\cert.pem
     state: absent
 
 - name: Remove a certificate based on thumbprint
-  win_certificate_store:
+  ansible.windows.win_certificate_store:
     thumbprint: BD7AF104CF1872BDB518D95C9534EA941665FD27
     state: absent
 
 - name: Remove certificate based on thumbprint is CurrentUser/TrustedPublishers store
-  win_certificate_store:
+  ansible.windows.win_certificate_store:
     thumbprint: BD7AF104CF1872BDB518D95C9534EA941665FD27
     state: absent
     store_location: CurrentUser
     store_name: TrustedPublisher
 
 - name: Export certificate as der encoded file
-  win_certificate_store:
+  ansible.windows.win_certificate_store:
     path: C:\Temp\cert.cer
     state: exported
     file_type: der
 
 - name: Export certificate and key as pfx encoded file
-  win_certificate_store:
+  ansible.windows.win_certificate_store:
     path: C:\Temp\cert.pfx
     state: exported
     file_type: pkcs12
@@ -189,7 +189,7 @@ EXAMPLES = r'''
   become_user: SYSTEM
 
 - name: Import certificate be used by IIS
-  win_certificate_store:
+  ansible.windows.win_certificate_store:
     path: C:\Temp\cert.pfx
     file_type: pkcs12
     password: StrongPassword!

--- a/plugins/modules/win_command.py
+++ b/plugins/modules/win_command.py
@@ -16,7 +16,7 @@ description:
      - The C(win_command) module takes the command name followed by a list of space-delimited arguments.
      - The given command will be executed on all selected nodes. It will not be
        processed through the shell, so variables like C($env:HOME) and operations
-       like C("<"), C(">"), C("|"), and C(";") will not work (use the M(win_shell)
+       like C("<"), C(">"), C("|"), and C(";") will not work (use the M(ansible.windows.win_shell)
        module if you need these features).
      - For non-Windows targets, use the M(command) module instead.
 options:
@@ -52,34 +52,34 @@ options:
     type: str
 notes:
     - If you want to run a command through a shell (say you are using C(<),
-      C(>), C(|), etc), you actually want the M(win_shell) module instead. The
-      C(win_command) module is much more secure as it's not affected by the user's
+      C(>), C(|), etc), you actually want the M(ansible.windows.win_shell) module instead. The
+      M(ansible.windows.win_command) module is much more secure as it's not affected by the user's
       environment.
     - C(creates), C(removes), and C(chdir) can be specified after the command. For instance, if you only want to run a command if a certain file does not
       exist, use this.
 seealso:
 - module: command
-- module: psexec
+- module: community.windows.psexec
 - module: raw
-- module: win_psexec
-- module: win_shell
+- module: community.windows.win_psexec
+- module: ansible.windows.win_shell
 author:
     - Matt Davis (@nitzmahone)
 '''
 
 EXAMPLES = r'''
 - name: Save the result of 'whoami' in 'whoami_out'
-  win_command: whoami
+  ansible.windows.win_command: whoami
   register: whoami_out
 
 - name: Run command that only runs if folder exists and runs from a specific folder
-  win_command: wbadmin -backupTarget:C:\backup\
+  ansible.windows.win_command: wbadmin -backupTarget:C:\backup\
   args:
     chdir: C:\somedir\
     creates: C:\backup\
 
 - name: Run an executable and send data to the stdin for the executable
-  win_command: powershell.exe -
+  ansible.windows.win_command: powershell.exe -
   args:
     stdin: Write-Host test
 '''

--- a/plugins/modules/win_copy.py
+++ b/plugins/modules/win_copy.py
@@ -93,12 +93,12 @@ notes:
   with remote paths.
 - Because win_copy runs over WinRM, it is not a very efficient transfer
   mechanism. If sending large files consider hosting them on a web service and
-  using M(win_get_url) instead.
+  using M(ansible.windows.win_get_url) instead.
 seealso:
 - module: community.general.assemble
 - module: copy
-- module: win_get_url
-- module: win_robocopy
+- module: ansible.windows.win_get_url
+- module: community.windows.win_robocopy
 author:
 - Jon Hawkesworth (@jhawkesworth)
 - Jordan Borean (@jborean93)
@@ -106,50 +106,50 @@ author:
 
 EXAMPLES = r'''
 - name: Copy a single file
-  win_copy:
+  ansible.windows.win_copy:
     src: /srv/myfiles/foo.conf
     dest: C:\Temp\renamed-foo.conf
 
 - name: Copy a single file, but keep a backup
-  win_copy:
+  ansible.windows.win_copy:
     src: /srv/myfiles/foo.conf
     dest: C:\Temp\renamed-foo.conf
     backup: yes
 
 - name: Copy a single file keeping the filename
-  win_copy:
+  ansible.windows.win_copy:
     src: /src/myfiles/foo.conf
     dest: C:\Temp\
 
 - name: Copy folder to C:\Temp (results in C:\Temp\temp_files)
-  win_copy:
+  ansible.windows.win_copy:
     src: files/temp_files
     dest: C:\Temp
 
 - name: Copy folder contents recursively
-  win_copy:
+  ansible.windows.win_copy:
     src: files/temp_files/
     dest: C:\Temp
 
 - name: Copy a single file where the source is on the remote host
-  win_copy:
+  ansible.windows.win_copy:
     src: C:\Temp\foo.txt
     dest: C:\ansible\foo.txt
     remote_src: yes
 
 - name: Copy a folder recursively where the source is on the remote host
-  win_copy:
+  ansible.windows.win_copy:
     src: C:\Temp
     dest: C:\ansible
     remote_src: yes
 
 - name: Set the contents of a file
-  win_copy:
+  ansible.windows.win_copy:
     content: abc123
     dest: C:\Temp\foo.txt
 
 - name: Copy a single file as another user
-  win_copy:
+  ansible.windows.win_copy:
     src: NuGet.config
     dest: '%AppData%\NuGet\NuGet.config'
   vars:

--- a/plugins/modules/win_dns_client.py
+++ b/plugins/modules/win_dns_client.py
@@ -13,7 +13,7 @@ DOCUMENTATION = r'''
 module: win_dns_client
 short_description: Configures DNS lookup on Windows hosts
 description:
-  - The C(win_dns_client) module configures the DNS client on Windows network adapters.
+  - The M(ansible.windows.win_dns_client) module configures the DNS client on Windows network adapters.
 options:
   adapter_names:
     description:
@@ -27,14 +27,9 @@ options:
       - An empty list will configure the adapter to use the DHCP-assigned values on connections where DHCP is enabled,
         or disable DNS lookup on statically-configured connections.
       - IPv6 DNS servers can only be set on Windows Server 2012 or newer, older hosts can only set IPv4 addresses.
-      - Before 2.10 use ipv4_addresses instead.
     type: list
     required: yes
     aliases: [ "ipv4_addresses", "ip_addresses", "addresses" ]
-notes:
-  - Before 2.10, when setting an empty list of DNS server addresses on an adapter with DHCP enabled, a change was always registered.
-  - In 2.10, DNS servers will always be reset if the format of nameservers in the registry is not comma delimited.
-    See U(https://www.welivesecurity.com/2016/06/02/crouching-tiger-hidden-dns/)
 author:
 - Matt Davis (@nitzmahone)
 - Brian Scholer (@briantist)
@@ -42,12 +37,12 @@ author:
 
 EXAMPLES = r'''
 - name: Set a single address on the adapter named Ethernet
-  win_dns_client:
+  ansible.windows.win_dns_client:
     adapter_names: Ethernet
     dns_servers: 192.168.34.5
 
 - name: Set multiple lookup addresses on all visible adapters (usually physical adapters that are in the Up state), with debug logging to a file
-  win_dns_client:
+  ansible.windows.win_dns_client:
     adapter_names: '*'
     dns_servers:
     - 192.168.34.5
@@ -55,14 +50,14 @@ EXAMPLES = r'''
     log_path: C:\dns_log.txt
 
 - name: Set IPv6 DNS servers on the adapter named Ethernet
-  win_dns_client:
+  ansible.windows.win_dns_client:
     adapter_names: Ethernet
     dns_servers:
     - '2001:db8::2'
     - '2001:db8::3'
 
 - name: Configure all adapters whose names begin with Ethernet to use DHCP-assigned DNS values
-  win_dns_client:
+  ansible.windows.win_dns_client:
     adapter_names: 'Ethernet*'
     dns_servers: []
 '''

--- a/plugins/modules/win_domain.py
+++ b/plugins/modules/win_domain.py
@@ -14,7 +14,7 @@ short_description: Ensures the existence of a Windows domain
 description:
 - Ensure that the domain named by C(dns_domain_name) exists and is reachable.
 - If the domain is not reachable, the domain is created in a new forest on the target Windows Server 2012R2+ host.
-- This module may require subsequent use of the M(win_reboot) action if changes are made.
+- This module may require subsequent use of the M(ansible.windows.win_reboot) action if changes are made.
 options:
   dns_domain_name:
     description:
@@ -75,11 +75,11 @@ options:
     type: bool
     default: yes
 seealso:
-- module: win_domain_controller
-- module: win_domain_computer
-- module: win_domain_group
-- module: win_domain_membership
-- module: win_domain_user
+- module: ansible.windows.win_domain_controller
+- module: community.windows.win_domain_computer
+- module: community.windows.win_domain_group
+- module: ansible.windows.win_domain_membership
+- module: community.windows.win_domain_user
 author:
 - Matt Davis (@nitzmahone)
 '''
@@ -94,12 +94,12 @@ reboot_required:
 
 EXAMPLES = r'''
 - name: Create new domain in a new forest on the target host
-  win_domain:
+  ansible.windows.win_domain:
     dns_domain_name: ansible.vagrant
     safe_mode_password: password123!
 
 - name: Create new Windows domain in a new forest with specific parameters
-  win_domain:
+  ansible.windows.win_domain:
     create_dns_delegation: no
     database_path: C:\Windows\NTDS
     dns_domain_name: ansible.vagrant

--- a/plugins/modules/win_domain_controller.py
+++ b/plugins/modules/win_domain_controller.py
@@ -14,7 +14,7 @@ module: win_domain_controller
 short_description: Manage domain controller/member server state for a Windows host
 description:
     - Ensure that a Windows Server 2012+ host is configured as a domain controller or demoted to member server.
-    - This module may require subsequent use of the M(win_reboot) action if changes are made.
+    - This module may require subsequent use of the M(ansible.windows.win_reboot) action if changes are made.
 options:
   dns_domain_name:
     description:
@@ -83,11 +83,11 @@ options:
     - This does not relate to the C(-LogPath) paramter of the install controller cmdlet.
     type: str
 seealso:
-- module: win_domain
-- module: win_domain_computer
-- module: win_domain_group
-- module: win_domain_membership
-- module: win_domain_user
+- module: ansible.windows.win_domain
+- module: ansible.windows.win_domain_computer
+- module: community.windows.win_domain_group
+- module: ansible.windows.win_domain_membership
+- module: community.windows.win_domain_user
 author:
     - Matt Davis (@nitzmahone)
 '''
@@ -102,27 +102,27 @@ reboot_required:
 
 EXAMPLES = r'''
 - name: Ensure a server is a domain controller
-  win_domain_controller:
+  ansible.windows.win_domain_controller:
     dns_domain_name: ansible.vagrant
     domain_admin_user: testguy@ansible.vagrant
     domain_admin_password: password123!
     safe_mode_password: password123!
     state: domain_controller
 
-# ensure a server is not a domain controller
 # note that without an action wrapper, in the case where a DC is demoted,
 # the task will fail with a 401 Unauthorized, because the domain credential
 # becomes invalid to fetch the final output over WinRM. This requires win_async
 # with credential switching (or other clever credential-switching
 # mechanism to get the output and trigger the required reboot)
-- win_domain_controller:
+- name: Ensure a server is not a domain controller
+  ansible.windows.win_domain_controller:
     domain_admin_user: testguy@ansible.vagrant
     domain_admin_password: password123!
     local_admin_password: password123!
     state: member_server
 
 - name: Promote server as a read only domain controller
-  win_domain_controller:
+  ansible.windows.win_domain_controller:
     dns_domain_name: ansible.vagrant
     domain_admin_user: testguy@ansible.vagrant
     domain_admin_password: password123!
@@ -132,7 +132,7 @@ EXAMPLES = r'''
     site_name: London
 
 - name: Promote server with custom paths
-  win_domain_controller:
+  ansible.windows.win_domain_controller:
     dns_domain_name: ansible.vagrant
     domain_admin_user: testguy@ansible.vagrant
     domain_admin_password: password123!
@@ -144,6 +144,6 @@ EXAMPLES = r'''
   register: dc_promotion
 
 - name: Reboot after promotion
-  win_reboot:
+  ansible.windows.win_reboot:
   when: dc_promotion.reboot_required
 '''

--- a/plugins/modules/win_domain_membership.py
+++ b/plugins/modules/win_domain_membership.py
@@ -13,7 +13,7 @@ module: win_domain_membership
 short_description: Manage domain/workgroup membership for a Windows host
 description:
 - Manages domain membership or workgroup membership for a Windows host. Also supports hostname changes.
-- This module may require subsequent use of the M(win_reboot) action if changes are made.
+- This module may require subsequent use of the M(ansible.windows.win_reboot) action if changes are made.
 options:
   dns_domain_name:
     description:
@@ -47,14 +47,14 @@ options:
       - When C(state) is C(workgroup), the name of the workgroup that the Windows host should be in.
     type: str
 seealso:
-- module: win_domain
-- module: win_domain_controller
-- module: win_domain_computer
-- module: win_domain_group
-- module: win_domain_user
-- module: win_group
-- module: win_group_membership
-- module: win_user
+- module: ansible.windows.win_domain
+- module: ansible.windows.win_domain_controller
+- module: community.windows.win_domain_computer
+- module: community.windows.win_domain_group
+- module: community.windows.win_domain_user
+- module: ansible.windows.win_group
+- module: ansible.windows.win_group_membership
+- module: ansible.windows.win_user
 author:
     - Matt Davis (@nitzmahone)
 '''
@@ -76,7 +76,7 @@ EXAMPLES = r'''
 - hosts: winclient
   gather_facts: no
   tasks:
-  - win_domain_membership:
+  - ansible.windows.win_domain_membership:
       dns_domain_name: ansible.vagrant
       hostname: mydomainclient
       domain_admin_user: testguy@ansible.vagrant
@@ -85,7 +85,7 @@ EXAMPLES = r'''
       state: domain
     register: domain_state
 
-  - win_reboot:
+  - ansible.windows.win_reboot:
     when: domain_state.reboot_required
 
 
@@ -96,7 +96,7 @@ EXAMPLES = r'''
 - hosts: winclient
   gather_facts: no
   tasks:
-  - win_domain_membership:
+  - ansible.windows.win_domain_membership:
       workgroup_name: mywg
       domain_admin_user: '{{ win_domain_admin_user }}'
       domain_admin_password: '{{ win_domain_admin_password }}'

--- a/plugins/modules/win_dsc.py
+++ b/plugins/modules/win_dsc.py
@@ -18,7 +18,6 @@ description:
 - Requires PowerShell version 5.0 or newer.
 - Most of the options for this module are dynamic and will vary depending on
   the DSC Resource specified in I(resource_name).
-- See :doc:`/user_guide/windows_dsc` for more information on how to use this module.
 options:
   resource_name:
     description:
@@ -38,7 +37,7 @@ options:
     default: latest
   free_form:
     description:
-    - The M(win_dsc) module takes in multiple free form options based on the
+    - The M(ansible.windows.win_dsc) module takes in multiple free form options based on the
       DSC resource being invoked by I(resource_name).
     - There is no option actually named C(free_form) so see the examples.
     - This module will try and convert the option to the correct type required
@@ -56,16 +55,13 @@ options:
     - If the type of the DSC resource option is a C(DateTime), you should use
       a string in the form of an ISO 8901 string to ensure the exact date is
       used.
-    - Since Ansible 2.8, Ansible will now validate the input fields against the
-      DSC resource definition automatically. Older versions will silently
-      ignore invalid fields.
     type: str
     required: true
 notes:
 - By default there are a few builtin resources that come with PowerShell 5.0,
   see U(https://docs.microsoft.com/en-us/powershell/scripting/dsc/resources/resources) for
   more information on these resources.
-- Custom DSC resources can be installed with M(win_psmodule) using the I(name)
+- Custom DSC resources can be installed with M(community.windows.win_psmodule) using the I(name)
   option.
 - The DSC engine run's each task as the SYSTEM account, any resources that need
   to be accessed with a different account need to have C(PsDscRunAsCredential)
@@ -83,7 +79,7 @@ author:
 
 EXAMPLES = r'''
 - name: Verify the WSMan HTTP listener is active and configured correctly
-  win_shell: |
+  ansible.windows.win_shell: |
     $port = (Get-Item -LiteralPath WSMan:\localhost\Client\DefaultPorts\HTTP).Value
     $onlinePorts = @(Get-ChildItem -LiteralPath WSMan:\localhost\Listener |
         Where-Object { 'Transport=HTTP' -in $_.Keys } |
@@ -96,19 +92,19 @@ EXAMPLES = r'''
     }
 
 - name: Extract zip file
-  win_dsc:
+  ansible.windows.win_dsc:
     resource_name: Archive
     Ensure: Present
     Path: C:\Temp\zipfile.zip
     Destination: C:\Temp\Temp2
 
 - name: Install a Windows feature with the WindowsFeature resource
-  win_dsc:
+  ansible.windows.win_dsc:
     resource_name: WindowsFeature
     Name: telnet-client
 
 - name: Edit HKCU reg key under specific user
-  win_dsc:
+  ansible.windows.win_dsc:
     resource_name: Registry
     Ensure: Present
     Key: HKEY_CURRENT_USER\ExampleKey
@@ -119,7 +115,7 @@ EXAMPLES = r'''
   no_log: true
 
 - name: Create file with multiple attributes
-  win_dsc:
+  ansible.windows.win_dsc:
     resource_name: File
     DestinationPath: C:\ansible\dsc
     Attributes: # can also be a comma separated string, e.g. 'Hidden, System'
@@ -129,18 +125,18 @@ EXAMPLES = r'''
     Type: Directory
 
 - name: Call DSC resource with DateTime option
-  win_dsc:
+  ansible.windows.win_dsc:
     resource_name: DateTimeResource
     DateTimeOption: '2019-02-22T13:57:31.2311892+00:00'
 
 # more complex example using custom DSC resource and dict values
 - name: Setup the xWebAdministration module
-  win_psmodule:
+  ansible.windows.win_psmodule:
     name: xWebAdministration
     state: present
 
 - name: Create IIS Website with Binding and Authentication options
-  win_dsc:
+  ansible.windows.win_dsc:
     resource_name: xWebsite
     Ensure: Present
     Name: DSC Website

--- a/plugins/modules/win_environment.py
+++ b/plugins/modules/win_environment.py
@@ -46,7 +46,7 @@ options:
 notes:
 - This module is best-suited for setting the entire value of an
   environment variable. For safe element-based management of
-  path-like environment vars, use the M(win_path) module.
+  path-like environment vars, use the M(ansible.windows.win_path) module.
 - This module does not broadcast change events.
   This means that the minority of windows applications which can have
   their environment changed without restarting will not be notified and
@@ -54,21 +54,21 @@ notes:
   User level environment variables will require the user to log out
   and in again before they become available.
 seealso:
-- module: win_path
+- module: ansible.windows.win_path
 author:
 - Jon Hawkesworth (@jhawkesworth)
 '''
 
 EXAMPLES = r'''
 - name: Set an environment variable for all users
-  win_environment:
+  ansible.windows.win_environment:
     state: present
     name: TestVariable
     value: Test value
     level: machine
 
 - name: Remove an environment variable for the current user
-  win_environment:
+  ansible.windows.win_environment:
     state: absent
     name: TestVariable
     level: user

--- a/plugins/modules/win_feature.py
+++ b/plugins/modules/win_feature.py
@@ -51,8 +51,8 @@ options:
       - Can either be C({driveletter}:\sources\sxs) or C(\\{IP}\share\sources\sxs).
     type: str
 seealso:
-- module: win_chocolatey
-- module: win_package
+- module: chocolatey.chocolatey.win_chocolatey
+- module: ansible.windows.win_package
 author:
     - Paul Durivage (@angstwad)
     - Trond Hindenes (@trondhindenes)
@@ -60,25 +60,25 @@ author:
 
 EXAMPLES = r'''
 - name: Install IIS (Web-Server only)
-  win_feature:
+  ansible.windows.win_feature:
     name: Web-Server
     state: present
 
 - name: Install IIS (Web-Server and Web-Common-Http)
-  win_feature:
+  ansible.windows.win_feature:
     name:
     - Web-Server
     - Web-Common-Http
     state: present
 
 - name: Install NET-Framework-Core from file
-  win_feature:
+  ansible.windows.win_feature:
     name: NET-Framework-Core
     source: C:\Temp\iso\sources\sxs
     state: present
 
 - name: Install IIS Web-Server with sub features and management tools
-  win_feature:
+  ansible.windows.win_feature:
     name: Web-Server
     state: present
     include_sub_features: yes
@@ -86,7 +86,7 @@ EXAMPLES = r'''
   register: win_feature
 
 - name: Reboot if installing Web-Server feature requires it
-  win_reboot:
+  ansible.windows.win_reboot:
   when: win_feature.reboot_required
 '''
 

--- a/plugins/modules/win_file.py
+++ b/plugins/modules/win_file.py
@@ -38,32 +38,32 @@ options:
     choices: [ absent, directory, file, touch ]
 seealso:
 - module: file
-- module: win_acl
-- module: win_acl_inheritance
-- module: win_owner
-- module: win_stat
+- module: ansible.windows.win_acl
+- module: ansible.windows.win_acl_inheritance
+- module: ansible.windows.win_owner
+- module: ansible.windows.win_stat
 author:
 - Jon Hawkesworth (@jhawkesworth)
 '''
 
 EXAMPLES = r'''
 - name: Touch a file (creates if not present, updates modification time if present)
-  win_file:
+  ansible.windows.win_file:
     path: C:\Temp\foo.conf
     state: touch
 
 - name: Remove a file, if present
-  win_file:
+  ansible.windows.win_file:
     path: C:\Temp\foo.conf
     state: absent
 
 - name: Create directory structure
-  win_file:
+  ansible.windows.win_file:
     path: C:\Temp\folder\subfolder
     state: directory
 
 - name: Remove directory structure
-  win_file:
+  ansible.windows.win_file:
     path: C:\Temp
     state: absent
 '''

--- a/plugins/modules/win_find.py
+++ b/plugins/modules/win_find.py
@@ -102,102 +102,102 @@ author:
 
 EXAMPLES = r'''
 - name: Find files in path
-  win_find:
+  ansible.windows.win_find:
     paths: D:\Temp
 
 - name: Find hidden files in path
-  win_find:
+  ansible.windows.win_find:
     paths: D:\Temp
     hidden: yes
 
 - name: Find files in multiple paths
-  win_find:
+  ansible.windows.win_find:
     paths:
     - C:\Temp
     - D:\Temp
 
 - name: Find files in directory while searching recursively
-  win_find:
+  ansible.windows.win_find:
     paths: D:\Temp
     recurse: yes
 
 - name: Find files in directory while following symlinks
-  win_find:
+  ansible.windows.win_find:
     paths: D:\Temp
     recurse: yes
     follow: yes
 
 - name: Find files with .log and .out extension using powershell wildcards
-  win_find:
+  ansible.windows.win_find:
     paths: D:\Temp
     patterns: [ '*.log', '*.out' ]
 
 - name: Find files in path based on regex pattern
-  win_find:
+  ansible.windows.win_find:
     paths: D:\Temp
     patterns: out_\d{8}-\d{6}.log
 
 - name: Find files older than 1 day
-  win_find:
+  ansible.windows.win_find:
     paths: D:\Temp
     age: 86400
 
 - name: Find files older than 1 day based on create time
-  win_find:
+  ansible.windows.win_find:
     paths: D:\Temp
     age: 86400
     age_stamp: ctime
 
 - name: Find files older than 1 day with unit syntax
-  win_find:
+  ansible.windows.win_find:
     paths: D:\Temp
     age: 1d
 
 - name: Find files newer than 1 hour
-  win_find:
+  ansible.windows.win_find:
     paths: D:\Temp
     age: -3600
 
 - name: Find files newer than 1 hour with unit syntax
-  win_find:
+  ansible.windows.win_find:
     paths: D:\Temp
     age: -1h
 
 - name: Find files larger than 1MB
-  win_find:
+  ansible.windows.win_find:
     paths: D:\Temp
     size: 1048576
 
 - name: Find files larger than 1GB with unit syntax
-  win_find:
+  ansible.windows.win_find:
     paths: D:\Temp
     size: 1g
 
 - name: Find files smaller than 1MB
-  win_find:
+  ansible.windows.win_find:
     paths: D:\Temp
     size: -1048576
 
 - name: Find files smaller than 1GB with unit syntax
-  win_find:
+  ansible.windows.win_find:
     paths: D:\Temp
     size: -1g
 
 - name: Find folders/symlinks in multiple paths
-  win_find:
+  ansible.windows.win_find:
     paths:
     - C:\Temp
     - D:\Temp
     file_type: directory
 
 - name: Find files and return SHA256 checksum of files found
-  win_find:
+  ansible.windows.win_find:
     paths: C:\Temp
     get_checksum: yes
     checksum_algorithm: sha256
 
 - name: Find files and do not return the checksum
-  win_find:
+  ansible.windows.win_find:
     paths: C:\Temp
     get_checksum: no
 '''
@@ -235,7 +235,7 @@ files:
             type: float
             sample: 1477984205.15
         exists:
-            description: Whether the file exists, will always be true for M(win_find).
+            description: Whether the file exists, will always be true for M(ansible.windows.win_find).
             returned: success, path exists
             type: bool
             sample: true

--- a/plugins/modules/win_group.py
+++ b/plugins/modules/win_group.py
@@ -36,21 +36,21 @@ options:
     default: present
 seealso:
 - module: group
-- module: win_domain_group
-- module: win_group_membership
+- module: community.windows.win_domain_group
+- module: ansible.windows.win_group_membership
 author:
 - Chris Hoffman (@chrishoffman)
 '''
 
 EXAMPLES = r'''
 - name: Create a new group
-  win_group:
+  ansible.windows.win_group:
     name: deploy
     description: Deploy Group
     state: present
 
 - name: Remove a group
-  win_group:
+  ansible.windows.win_group:
     name: deploy
     state: absent
 '''

--- a/plugins/modules/win_group_membership.py
+++ b/plugins/modules/win_group_membership.py
@@ -34,23 +34,22 @@ options:
   state:
     description:
       - Desired state of the members in the group.
-      - C(pure) was added in Ansible 2.8.
       - When C(state) is C(pure), only the members specified will exist,
         and all other existing members not specified are removed.
     type: str
     choices: [ absent, present, pure ]
     default: present
 seealso:
-- module: win_domain_group
-- module: win_domain_membership
-- module: win_group
+- module: community.windows.win_domain_group
+- module: ansible.windows.win_domain_membership
+- module: ansible.windows.win_group
 author:
     - Andrew Saraceni (@andrewsaraceni)
 '''
 
 EXAMPLES = r'''
 - name: Add a local and domain user to a local group
-  win_group_membership:
+  ansible.windows.win_group_membership:
     name: Remote Desktop Users
     members:
       - NewLocalAdmin
@@ -58,7 +57,7 @@ EXAMPLES = r'''
     state: present
 
 - name: Remove a domain group and service user from a local group
-  win_group_membership:
+  ansible.windows.win_group_membership:
     name: Backup Operators
     members:
       - DOMAIN\TestGroup
@@ -66,7 +65,7 @@ EXAMPLES = r'''
     state: absent
 
 - name: Ensure only a domain user exists in a local group
-  win_group_membership:
+  ansible.windows.win_group_membership:
     name: Remote Desktop Users
     members:
       - DOMAIN\TestUser

--- a/plugins/modules/win_hostname.py
+++ b/plugins/modules/win_hostname.py
@@ -24,19 +24,19 @@ options:
     type: str
     required: true
 seealso:
-- module: win_dns_client
+- module: ansible.windows.win_dns_client
 author:
 - Ripon Banik (@riponbanik)
 '''
 
 EXAMPLES = r'''
 - name: Change the hostname to sample-hostname
-  win_hostname:
+  ansible.windows.win_hostname:
     name: sample-hostname
   register: res
 
 - name: Reboot
-  win_reboot:
+  ansible.windows.win_reboot:
   when: res.reboot_required
 '''
 

--- a/plugins/modules/win_optional_feature.py
+++ b/plugins/modules/win_optional_feature.py
@@ -43,37 +43,37 @@ options:
       - Can either be C({driveletter}:\sources\sxs) or C(\\{IP}\share\sources\sxs).
     type: str
 seealso:
-- module: win_chocolatey
-- module: win_feature
-- module: win_package
+- module: chocolatey.chocolatey.win_chocolatey
+- module: ansible.windows.win_feature
+- module: ansible.windows.win_package
 author:
     - Carson Anderson (@rcanderson23)
 '''
 
 EXAMPLES = r'''
 - name: Install .Net 3.5
-  win_optional_feature:
+  ansible.windows.win_optional_feature:
     name: NetFx3
     state: present
 
 - name: Install .Net 3.5 from source
-  win_optional_feature:
+  ansible.windows.win_optional_feature:
     name: NetFx3
     source: \\share01\win10\sources\sxs
     state: present
 
 - name: Install Microsoft Subsystem for Linux
-  win_optional_feature:
+  ansible.windows.win_optional_feature:
     name: Microsoft-Windows-Subsystem-Linux
     state: present
   register: wsl_status
 
 - name: Reboot if installing Linux Subsytem as feature requires it
-  win_reboot:
+  ansible.windows.win_reboot:
   when: wsl_status.reboot_required
 
 - name: Install multiple features in one task
-  win_optional_feature:
+  ansible.windows.win_optional_feature:
     name:
     - NetFx3
     - Microsoft-Windows-Subsystem-Linux

--- a/plugins/modules/win_owner.py
+++ b/plugins/modules/win_owner.py
@@ -31,22 +31,22 @@ options:
     type: bool
     default: no
 seealso:
-- module: win_acl
-- module: win_file
-- module: win_stat
+- module: ansible.windows.win_acl
+- module: ansible.windows.win_file
+- module: ansible.windows.win_stat
 author:
 - Hans-Joachim Kliemeck (@h0nIg)
 '''
 
 EXAMPLES = r'''
 - name: Change owner of path
-  win_owner:
+  ansible.windows.win_owner:
     path: C:\apache
     user: apache
     recurse: yes
 
 - name: Set the owner of root directory
-  win_owner:
+  ansible.windows.win_owner:
     path: C:\apache
     user: SYSTEM
     recurse: no

--- a/plugins/modules/win_path.py
+++ b/plugins/modules/win_path.py
@@ -49,7 +49,7 @@ options:
 notes:
    - This module is for modifying individual elements of path-like
      environment variables. For general-purpose management of other
-     environment vars, use the M(win_environment) module.
+     environment vars, use the M(ansible.windows.win_environment) module.
    - This module does not broadcast change events.
      This means that the minority of windows applications which can have
      their environment changed without restarting will not be notified and
@@ -57,20 +57,20 @@ notes:
    - User level environment variables will require an interactive user to
      log out and in again before they become available.
 seealso:
-- module: win_environment
+- module: ansible.windows.win_environment
 author:
 - Matt Davis (@nitzmahone)
 '''
 
 EXAMPLES = r'''
 - name: Ensure that system32 and Powershell are present on the global system path, and in the specified order
-  win_path:
+  ansible.windows.win_path:
     elements:
     - '%SystemRoot%\system32'
     - '%SystemRoot%\system32\WindowsPowerShell\v1.0'
 
 - name: Ensure that C:\Program Files\MyJavaThing is not on the current user's CLASSPATH
-  win_path:
+  ansible.windows.win_path:
     name: CLASSPATH
     elements: C:\Program Files\MyJavaThing
     scope: user

--- a/plugins/modules/win_ping.py
+++ b/plugins/modules/win_ping.py
@@ -35,13 +35,13 @@ author:
 
 EXAMPLES = r'''
 # Test connectivity to a windows host
-# ansible winserver -m win_ping
+# ansible winserver -m ansible.windows.win_ping
 
 - name: Example from an Ansible Playbook
-  win_ping:
+  ansible.windows.win_ping:
 
 - name: Induce an exception to see what happens
-  win_ping:
+  ansible.windows.win_ping:
     data: crash
 '''
 

--- a/plugins/modules/win_reboot.py
+++ b/plugins/modules/win_reboot.py
@@ -28,14 +28,6 @@ options:
     type: int
     default: 0
     aliases: [ post_reboot_delay_sec ]
-  shutdown_timeout:
-    description:
-    - Maximum seconds to wait for shutdown to occur.
-    - Increase this timeout for very slow hardware, large update applications, etc.
-    - This option has been removed since Ansible 2.5 as the win_reboot behavior has changed.
-    type: int
-    default: 600
-    aliases: [ shutdown_timeout_sec ]
   reboot_timeout:
     description:
     - Maximum seconds to wait for machine to re-appear on the network and respond to a test command.
@@ -66,8 +58,8 @@ options:
     type: str
     default: '(Get-WmiObject -ClassName Win32_OperatingSystem).LastBootUpTime'
 notes:
-- If a shutdown was already scheduled on the system, C(win_reboot) will abort the scheduled shutdown and enforce its own shutdown.
-- Beware that when C(win_reboot) returns, the Windows system may not have settled yet and some base services could be in limbo.
+- If a shutdown was already scheduled on the system, M(ansible.windows.win_reboot) will abort the scheduled shutdown and enforce its own shutdown.
+- Beware that when M(ansible.windows.win_reboot) returns, the Windows system may not have settled yet and some base services could be in limbo.
   This can result in unexpected behavior. Check the examples for ways to mitigate this.
 - The connection user must have the C(SeRemoteShutdownPrivilege) privilege enabled, see
   U(https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/force-shutdown-from-a-remote-system)
@@ -80,37 +72,37 @@ author:
 
 EXAMPLES = r'''
 - name: Reboot the machine with all defaults
-  win_reboot:
+  ansible.windows.win_reboot:
 
 - name: Reboot a slow machine that might have lots of updates to apply
-  win_reboot:
+  ansible.windows.win_reboot:
     reboot_timeout: 3600
 
 # Install a Windows feature and reboot if necessary
 - name: Install IIS Web-Server
-  win_feature:
+  ansible.windows.win_feature:
     name: Web-Server
   register: iis_install
 
 - name: Reboot when Web-Server feature requires it
-  win_reboot:
+  ansible.windows.win_reboot:
   when: iis_install.reboot_required
 
 # One way to ensure the system is reliable, is to set WinRM to a delayed startup
 - name: Ensure WinRM starts when the system has settled and is ready to work reliably
-  win_service:
+  ansible.windows.win_service:
     name: WinRM
     start_mode: delayed
 
 
 # Additionally, you can add a delay before running the next task
 - name: Reboot a machine that takes time to settle after being booted
-  win_reboot:
+  ansible.windows.win_reboot:
     post_reboot_delay: 120
 
 # Or you can make win_reboot validate exactly what you need to work before running the next task
 - name: Validate that the netlogon service has started, before running the next task
-  win_reboot:
+  ansible.windows.win_reboot:
     test_command: 'exit (Get-Service -Name Netlogon).Status -ne "Running"'
 '''
 

--- a/plugins/modules/win_reg_stat.py
+++ b/plugins/modules/win_reg_stat.py
@@ -16,7 +16,7 @@ DOCUMENTATION = r'''
 module: win_reg_stat
 short_description: Get information about Windows registry keys
 description:
-- Like M(win_file), M(win_reg_stat) will return whether the key/property exists.
+- Like M(ansible.windows.win_file), M(ansible.windows.win_reg_stat) will return whether the key/property exists.
 - It also returns the sub keys and properties of the key specified.
 - If specifying a property name through I(property), it will return the information specific for that property.
 options:
@@ -35,26 +35,26 @@ notes:
 - The C(properties) return value will contain an empty string key C("") that refers to the key's C(Default) value. If
   the value has not been set then this key is not returned.
 seealso:
-- module: win_regedit
-- module: win_regmerge
+- module: ansible.windows.win_regedit
+- module: ansible.windows.win_regmerge
 author:
 - Jordan Borean (@jborean93)
 '''
 
 EXAMPLES = r'''
 - name: Obtain information about a registry key using short form
-  win_reg_stat:
+  ansible.windows.win_reg_stat:
     path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion
   register: current_version
 
 - name: Obtain information about a registry key property
-  win_reg_stat:
+  ansible.windows.win_reg_stat:
     path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion
     name: CommonFilesDir
   register: common_files_dir
 
 - name: Obtain the registry key's (Default) property
-  win_reg_stat:
+  ansible.windows.win_reg_stat:
     path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion
     name: ''
   register: current_version_default

--- a/plugins/modules/win_regedit.py
+++ b/plugins/modules/win_regedit.py
@@ -88,10 +88,9 @@ notes:
 - Check-mode C(-C/--check) and diff output C(-D/--diff) are supported, so that you can test every change against the active configuration before
   applying changes.
 - Beware that some registry hives (C(HKEY_USERS) in particular) do not allow to create new registry paths in the root folder.
-- Since ansible 2.4, when checking if a string registry value has changed, a case-sensitive test is used. Previously the test was case-insensitive.
 seealso:
-- module: win_reg_stat
-- module: win_regmerge
+- module: ansible.windows.win_reg_stat
+- module: ansible.windows.win_regmerge
 author:
 - Adam Keech (@smadam813)
 - Josh Ludwig (@joshludwig)
@@ -100,91 +99,91 @@ author:
 
 EXAMPLES = r'''
 - name: Create registry path MyCompany
-  win_regedit:
+  ansible.windows.win_regedit:
     path: HKCU:\Software\MyCompany
 
 - name: Add or update registry path MyCompany, with entry 'hello', and containing 'world'
-  win_regedit:
+  ansible.windows.win_regedit:
     path: HKCU:\Software\MyCompany
     name: hello
     data: world
 
 - name: Add or update registry path MyCompany, with dword entry 'hello', and containing 1337 as the decimal value
-  win_regedit:
+  ansible.windows.win_regedit:
     path: HKCU:\Software\MyCompany
     name: hello
     data: 1337
     type: dword
 
 - name: Add or update registry path MyCompany, with dword entry 'hello', and containing 0xff2500ae as the hex value
-  win_regedit:
+  ansible.windows.win_regedit:
     path: HKCU:\Software\MyCompany
     name: hello
     data: 0xff2500ae
     type: dword
 
 - name: Add or update registry path MyCompany, with binary entry 'hello', and containing binary data in hex-string format
-  win_regedit:
+  ansible.windows.win_regedit:
     path: HKCU:\Software\MyCompany
     name: hello
     data: hex:be,ef,be,ef,be,ef,be,ef,be,ef
     type: binary
 
 - name: Add or update registry path MyCompany, with binary entry 'hello', and containing binary data in yaml format
-  win_regedit:
+  ansible.windows.win_regedit:
     path: HKCU:\Software\MyCompany
     name: hello
     data: [0xbe,0xef,0xbe,0xef,0xbe,0xef,0xbe,0xef,0xbe,0xef]
     type: binary
 
 - name: Add or update registry path MyCompany, with expand string entry 'hello'
-  win_regedit:
+  ansible.windows.win_regedit:
     path: HKCU:\Software\MyCompany
     name: hello
     data: '%appdata%\local'
     type: expandstring
 
 - name: Add or update registry path MyCompany, with multi string entry 'hello'
-  win_regedit:
+  ansible.windows.win_regedit:
     path: HKCU:\Software\MyCompany
     name: hello
     data: ['hello', 'world']
     type: multistring
 
 - name: Disable keyboard layout hotkey for all users (changes existing)
-  win_regedit:
+  ansible.windows.win_regedit:
     path: HKU:\.DEFAULT\Keyboard Layout\Toggle
     name: Layout Hotkey
     data: 3
     type: dword
 
 - name: Disable language hotkey for current users (adds new)
-  win_regedit:
+  ansible.windows.win_regedit:
     path: HKCU:\Keyboard Layout\Toggle
     name: Language Hotkey
     data: 3
     type: dword
 
 - name: Remove registry path MyCompany (including all entries it contains)
-  win_regedit:
+  ansible.windows.win_regedit:
     path: HKCU:\Software\MyCompany
     state: absent
     delete_key: yes
 
 - name: Clear the existing (Default) entry at path MyCompany
-  win_regedit:
+  ansible.windows.win_regedit:
     path: HKCU:\Software\MyCompany
     state: absent
     delete_key: no
 
 - name: Remove entry 'hello' from registry path MyCompany
-  win_regedit:
+  ansible.windows.win_regedit:
     path: HKCU:\Software\MyCompany
     name: hello
     state: absent
 
 - name: Change default mouse trailing settings for new users
-  win_regedit:
+  ansible.windows.win_regedit:
     path: HKLM:\ANSIBLE\Control Panel\Mouse
     name: MouseTrails
     data: 10

--- a/plugins/modules/win_service.py
+++ b/plugins/modules/win_service.py
@@ -250,42 +250,42 @@ options:
     - Can also be set to C(LocalSystem) or C(SYSTEM) to use the SYSTEM account.
     - A newly created service will default to C(LocalSystem).
     - If using a custom user account, it must have the C(SeServiceLogonRight)
-      granted to be able to start up. You can use the M(win_user_right) module
+      granted to be able to start up. You can use the M(ansible.windows.win_user_right) module
       to grant this user right for you.
     - Set to C(NT SERVICE\service name) to run as the NT SERVICE account for that service.
     - This can also be a gMSA in the form C(DOMAIN\gMSA$).
     type: str
 notes:
 - This module historically returning information about the service in its return values. These should be avoided in
-  favour of the M(win_service_info) module.
+  favour of the M(ansible.windows.win_service_info) module.
 seealso:
 - module: service
-- module: win_nssm
-- module: win_service_info
-- module: win_user_right
+- module: community.windows.win_nssm
+- module: ansible.windows.win_service_info
+- module: ansible.windows.win_user_right
 author:
 - Chris Hoffman (@chrishoffman)
 '''
 
 EXAMPLES = r'''
 - name: Restart a service
-  win_service:
+  ansible.windows.win_service:
     name: spooler
     state: restarted
 
 - name: Set service startup mode to auto and ensure it is started
-  win_service:
+  ansible.windows.win_service:
     name: spooler
     start_mode: auto
     state: started
 
 - name: Pause a service
-  win_service:
+  ansible.windows.win_service:
     name: Netlogon
     state: paused
 
 - name: Ensure that WinRM is started when the system has settled
-  win_service:
+  ansible.windows.win_service:
     name: WinRM
     start_mode: delayed
 
@@ -294,92 +294,92 @@ EXAMPLES = r'''
 # - state: stopped
 # - start_mode: auto
 - name: Create a new service
-  win_service:
+  ansible.windows.win_service:
     name: service name
     path: C:\temp\test.exe
 
 - name: Create a new service with extra details
-  win_service:
+  ansible.windows.win_service:
     name: service name
     path: C:\temp\test.exe
     display_name: Service Name
     description: A test service description
 
 - name: Remove a service
-  win_service:
+  ansible.windows.win_service:
     name: service name
     state: absent
 
 # This is required to be set for non-service accounts that need to run as a service
 - name: Grant domain account the SeServiceLogonRight user right
-  win_user_right:
+  ansible.windows.win_user_right:
     name: SeServiceLogonRight
     users:
     - DOMAIN\User
     action: add
 
 - name: Set the log on user to a domain account
-  win_service:
+  ansible.windows.win_service:
     name: service name
     state: restarted
     username: DOMAIN\User
     password: Password
 
 - name: Set the log on user to a local account
-  win_service:
+  ansible.windows.win_service:
     name: service name
     state: restarted
     username: .\Administrator
     password: Password
 
 - name: Set the log on user to Local System
-  win_service:
+  ansible.windows.win_service:
     name: service name
     state: restarted
     username: SYSTEM
 
 - name: Set the log on user to Local System and allow it to interact with the desktop
-  win_service:
+  ansible.windows.win_service:
     name: service name
     state: restarted
     username: SYSTEM
     desktop_interact: yes
 
 - name: Set the log on user to Network Service
-  win_service:
+  ansible.windows.win_service:
     name: service name
     state: restarted
     username: NT AUTHORITY\NetworkService
 
 - name: Set the log on user to Local Service
-  win_service:
+  ansible.windows.win_service:
     name: service name
     state: restarted
     username: NT AUTHORITY\LocalService
 
 - name: Set the log on user as the services' virtual account
-  win_service:
+  ansible.windows.win_service:
     name: service name
     username: NT SERVICE\service name
 
 - name: Set the log on user as a gMSA
-  win_service:
+  ansible.windows.win_service:
     name: service name
     username: DOMAIN\gMSA$  # The end $ is important and should be set for all gMSA
 
 - name: Set dependencies to ones only in the list
-  win_service:
+  ansible.windows.win_service:
     name: service name
     dependencies: [ service1, service2 ]
 
 - name: Add dependencies to existing dependencies
-  win_service:
+  ansible.windows.win_service:
     name: service name
     dependencies: [ service1, service2 ]
     dependency_action: add
 
 - name: Remove dependencies from existing dependencies
-  win_service:
+  ansible.windows.win_service:
     name: service name
     dependencies:
     - service1
@@ -387,7 +387,7 @@ EXAMPLES = r'''
     dependency_action: remove
 
 - name: Set required privileges for a service
-  win_service:
+  ansible.windows.win_service:
     name: service name
     username: NT SERVICE\LocalService
     required_privileges:
@@ -395,13 +395,13 @@ EXAMPLES = r'''
     - SeRestorePrivilege
 
 - name: Remove all required privileges for a service
-  win_service:
+  ansible.windows.win_service:
     name: service name
     username: NT SERVICE\LocalService
     required_privileges: []
 
 - name: Set failure actions for a service with no reset period
-  win_service:
+  ansible.windows.win_service:
     name: service name
     failure_actions:
     - type: restart
@@ -415,7 +415,7 @@ EXAMPLES = r'''
     failure_reset_period_sec: '0xFFFFFFFF'
 
 - name: Set only 1 failure action without a repeat of the last action
-  win_service:
+  ansible.windows.win_service:
     name: service name
     failure_actions:
     - type: restart
@@ -423,7 +423,7 @@ EXAMPLES = r'''
     - type: none
 
 - name: Remove failure action information
-  win_service:
+  ansible.windows.win_service:
     name: service name
     failure_actions: []
     failure_command: ''  # removes the existing command

--- a/plugins/modules/win_service_info.py
+++ b/plugins/modules/win_service_info.py
@@ -23,27 +23,27 @@ options:
     - If omitted then all services will returned.
     type: str
 seealso:
-- module: win_service
+- module: ansible.windows.win_service
 author:
 - Jordan Borean (@jborean93)
 '''
 
 EXAMPLES = r'''
 - name: Get info for all installed services
-  win_service_info:
+  ansible.windows.win_service_info:
   register: service_info
 
 - name: Get info for a single service
-  win_service_info:
+  ansible.windows.win_service_info:
     name: WinRM
   register: service_info
 
 - name: Get info for a service using its display name
-  win_service_info:
+  ansible.windows.win_service_info:
     name: Windows Remote Management (WS-Management)
 
 - name: Find all services that start with 'win'
-  win_service_info:
+  ansible.windows.win_service_info:
     name: win*
 '''
 

--- a/plugins/modules/win_share.py
+++ b/plugins/modules/win_share.py
@@ -84,11 +84,8 @@ author:
 '''
 
 EXAMPLES = r'''
-# Playbook example
-# Add share and set permissions
----
 - name: Add secret share
-  win_share:
+  ansible.windows.win_share:
     name: internal
     description: top secret share
     path: C:\shares\internal
@@ -98,7 +95,7 @@ EXAMPLES = r'''
     deny: HR-External
 
 - name: Add public company share
-  win_share:
+  ansible.windows.win_share:
     name: company
     description: top secret share
     path: C:\shares\company
@@ -107,7 +104,7 @@ EXAMPLES = r'''
     read: Global
 
 - name: Remove previously added share
-  win_share:
+  ansible.windows.win_share:
     name: internal
     state: absent
 '''

--- a/plugins/modules/win_shell.py
+++ b/plugins/modules/win_shell.py
@@ -13,14 +13,14 @@ DOCUMENTATION = r'''
 module: win_shell
 short_description: Execute shell commands on target hosts
 description:
-     - The C(win_shell) module takes the command name followed by a list of space-delimited arguments.
-       It is similar to the M(win_command) module, but runs
+     - The M(ansible.windows.win_shell) module takes the command name followed by a list of space-delimited arguments.
+       It is similar to the M(ansible.windows.win_command) module, but runs
        the command via a shell (defaults to PowerShell) on the target host.
      - For non-Windows targets, use the M(shell) module instead.
 options:
   free_form:
     description:
-      - The C(win_shell) module takes a free form command to run.
+      - The M(ansible.windows.win_shell) module takes a free form command to run.
       - There is no parameter actually named 'free form'. See the examples!
     type: str
     required: yes
@@ -61,47 +61,46 @@ options:
     type: str
 notes:
    -  If you want to run an executable securely and predictably, it may be
-      better to use the M(win_command) module instead. Best practices when writing
-      playbooks will follow the trend of using M(win_command) unless C(win_shell) is
+      better to use the M(ansible.windows.win_command) module instead. Best practices when writing
+      playbooks will follow the trend of using M(ansible.windows.win_command) unless C(win_shell) is
       explicitly required. When running ad-hoc commands, use your best judgement.
    -  WinRM will not return from a command execution until all child processes created have exited.
-      Thus, it is not possible to use C(win_shell) to spawn long-running child or background processes.
+      Thus, it is not possible to use M(ansible.windows.win_shell) to spawn long-running child or background processes.
       Consider creating a Windows service for managing background processes.
 seealso:
-- module: psexec
+- module: community.windows.psexec
 - module: raw
 - module: script
 - module: shell
-- module: win_command
-- module: win_psexec
+- module: ansible.windows.win_command
+- module: community.windows.win_psexec
 author:
     - Matt Davis (@nitzmahone)
 '''
 
 EXAMPLES = r'''
-# Execute a command in the remote shell; stdout goes to the specified
-# file on the remote.
-- win_shell: C:\somescript.ps1 >> C:\somelog.txt
+- name: Execute a comand in the remote shell, stdout goes to the specified file on the remote
+  ansible.windows.win_shell: C:\somescript.ps1 >> C:\somelog.txt
 
-# Change the working directory to somedir/ before executing the command.
-- win_shell: C:\somescript.ps1 >> C:\somelog.txt chdir=C:\somedir
+- name: Change the working directory to somedir/ before executing the command
+  ansible.windows.win_shell: C:\somescript.ps1 >> C:\somelog.txt
+  args:
+    chdir: C:\somedir
 
-# You can also use the 'args' form to provide the options. This command
-# will change the working directory to somedir/ and will only run when
-# somedir/somelog.txt doesn't exist.
-- win_shell: C:\somescript.ps1 >> C:\somelog.txt
+- name: Run a command with an idempotent check on what it creates, will only run when somedir/somelog.txt does not exist
+  ansible.windows.win_shell: C:\somescript.ps1 >> C:\somelog.txt
   args:
     chdir: C:\somedir
     creates: C:\somelog.txt
 
-# Run a command under a non-Powershell interpreter (cmd in this case)
-- win_shell: echo %HOMEDIR%
+- name: Run a command under a non-Powershell interpreter (cmd in this case)
+  ansible.windows.win_shell: echo %HOMEDIR%
   args:
     executable: cmd
   register: homedir_out
 
 - name: Run multi-lined shell commands
-  win_shell: |
+  ansible.windows.win_shell: |
     $value = Test-Path -Path C:\temp
     if ($value) {
         Remove-Item -Path C:\temp -Force
@@ -109,7 +108,7 @@ EXAMPLES = r'''
     New-Item -Path C:\temp -ItemType Directory
 
 - name: Retrieve the input based on stdin
-  win_shell: '$string = [Console]::In.ReadToEnd(); Write-Output $string.Trim()'
+  ansible.windows.win_shell: '$string = [Console]::In.ReadToEnd(); Write-Output $string.Trim()'
   args:
     stdin: Input message
 '''

--- a/plugins/modules/win_stat.py
+++ b/plugins/modules/win_stat.py
@@ -47,26 +47,26 @@ options:
         default: no
 seealso:
 - module: stat
-- module: win_acl
-- module: win_file
-- module: win_owner
+- module: ansible.windows.win_acl
+- module: ansible.windows.win_file
+- module: ansible.windows.win_owner
 author:
 - Chris Church (@cchurch)
 '''
 
 EXAMPLES = r'''
 - name: Obtain information about a file
-  win_stat:
+  ansible.windows.win_stat:
     path: C:\foo.ini
   register: file_info
 
 - name: Obtain information about a folder
-  win_stat:
+  ansible.windows.win_stat:
     path: C:\bar
   register: folder_info
 
 - name: Get MD5 checksum of a file
-  win_stat:
+  ansible.windows.win_stat:
     path: C:\foo.ini
     get_checksum: yes
     checksum_algorithm: md5
@@ -76,7 +76,7 @@ EXAMPLES = r'''
     var: md5_checksum.stat.checksum
 
 - name: Get SHA1 checksum of file
-  win_stat:
+  ansible.windows.win_stat:
     path: C:\foo.ini
     get_checksum: yes
   register: sha1_checksum
@@ -85,7 +85,7 @@ EXAMPLES = r'''
     var: sha1_checksum.stat.checksum
 
 - name: Get SHA256 checksum of file
-  win_stat:
+  ansible.windows.win_stat:
     path: C:\foo.ini
     get_checksum: yes
     checksum_algorithm: sha256

--- a/plugins/modules/win_tempfile.py
+++ b/plugins/modules/win_tempfile.py
@@ -47,12 +47,12 @@ author:
 
 EXAMPLES = r"""
 - name: Create temporary build directory
-  win_tempfile:
+  ansible.windows.win_tempfile:
     state: directory
     suffix: build
 
 - name: Create temporary file
-  win_tempfile:
+  ansible.windows.win_tempfile:
     state: file
     suffix: temp
 """

--- a/plugins/modules/win_template.py
+++ b/plugins/modules/win_template.py
@@ -102,7 +102,6 @@ options:
     default: '{{'
 notes:
 - Including a string that uses a date in the template will result in the template being marked 'changed' each time.
-- Since Ansible 0.9, templates are loaded with C(trim_blocks=True).
 - >
   Also, you can override jinja2 settings by adding a special header to template file.
   i.e. C(#jinja2:variable_start_string:'[%', variable_end_string:'%]', trim_blocks: False)
@@ -114,11 +113,11 @@ notes:
   on Linux.
 - Beware fetching files from windows machines when creating templates because certain tools, such as Powershell ISE,
   and regedit's export facility add a Byte Order Mark as the first character of the file, which can cause tracebacks.
-- You can use the M(win_copy) module with the C(content:) option if you prefer the template inline, as part of the
+- You can use the M(ansible.windows.win_copy) module with the C(content:) option if you prefer the template inline, as part of the
   playbook.
 - For Linux you can use M(template) which uses '\\n' as C(newline_sequence) by default.
 seealso:
-- module: win_copy
+- module: ansible.windows.win_copy
 - module: copy
 - module: template
 author:
@@ -127,12 +126,12 @@ author:
 
 EXAMPLES = r'''
 - name: Create a file from a Jinja2 template
-  win_template:
+  ansible.windows.win_template:
     src: /mytemplates/file.conf.j2
     dest: C:\Temp\file.conf
 
 - name: Create a Unix-style file from a Jinja2 template
-  win_template:
+  ansible.windows.win_template:
     src: unix/config.conf.j2
     dest: C:\share\unix\config.conf
     newline_sequence: '\n'

--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -43,7 +43,7 @@ options:
         description:
         - Ansible will automatically reboot the remote host if it is required
           and continue to install updates after the reboot.
-        - This can be used instead of using a M(win_reboot) task after this one
+        - This can be used instead of using a M(ansible.windows.win_reboot) task after this one
           and ensures all updates for that category is installed in one go.
         - Async does not work when C(reboot=yes).
         type: bool
@@ -106,55 +106,55 @@ options:
         type: bool
         default: no
 notes:
-- C(win_updates) must be run by a user with membership in the local Administrators group.
-- C(win_updates) will use the default update service configured for the machine (Windows Update, Microsoft Update, WSUS, etc).
-- C(win_updates) will I(become) SYSTEM using I(runas) unless C(use_scheduled_task) is C(yes)
-- By default C(win_updates) does not manage reboots, but will signal when a
-  reboot is required with the I(reboot_required) return value, as of Ansible v2.5
-  C(reboot) can be used to reboot the host if required in the one task.
-- C(win_updates) can take a significant amount of time to complete (hours, in some cases).
+- M(ansible.windows.win_updates) must be run by a user with membership in the local Administrators group.
+- M(ansible.windows.win_updates) will use the default update service configured for the machine (Windows Update, Microsoft Update, WSUS, etc).
+- M(ansible.windows.win_updates) will I(become) SYSTEM using I(runas) unless C(use_scheduled_task) is C(yes)
+- By default M(ansible.windows.win_updates) does not manage reboots, but will signal when a
+  reboot is required with the I(reboot_required) return value.
+  M(reboot) can be used to reboot the host if required in the one task.
+- M(ansible.windows.win_updates) can take a significant amount of time to complete (hours, in some cases).
   Performance depends on many factors, including OS version, number of updates, system load, and update server load.
-- Beware that just after C(win_updates) reboots the system, the Windows system may not have settled yet
+- Beware that just after M(ansible.windows.win_updates) reboots the system, the Windows system may not have settled yet
   and some base services could be in limbo. This can result in unexpected behavior.
   Check the examples for ways to mitigate this.
 - More information about PowerShell and how it handles RegEx strings can be
   found at U(https://technet.microsoft.com/en-us/library/2007.11.powershell.aspx).
 seealso:
-- module: win_chocolatey
-- module: win_feature
-- module: win_hotfix
-- module: win_package
+- module: chocolatey.chocolatey.win_chocolatey
+- module: ansible.windows.win_feature
+- module: community.windows.win_hotfix
+- module: ansible.windows.win_package
 author:
 - Matt Davis (@nitzmahone)
 '''
 
 EXAMPLES = r'''
 - name: Install all security, critical, and rollup updates without a scheduled task
-  win_updates:
+  ansible.windows.win_updates:
     category_names:
       - SecurityUpdates
       - CriticalUpdates
       - UpdateRollups
 
 - name: Install only security updates as a scheduled task for Server 2008
-  win_updates:
+  ansible.windows.win_updates:
     category_names: SecurityUpdates
     use_scheduled_task: yes
 
 - name: Search-only, return list of found updates (if any), log to C:\ansible_wu.txt
-  win_updates:
+  ansible.windows.win_updates:
     category_names: SecurityUpdates
     state: searched
     log_path: C:\ansible_wu.txt
 
 - name: Install all security updates with automatic reboots
-  win_updates:
+  ansible.windows.win_updates:
     category_names:
     - SecurityUpdates
     reboot: yes
 
 - name: Install only particular updates based on the KB numbers
-  win_updates:
+  ansible.windows.win_updates:
     category_name:
     - SecurityUpdates
     whitelist:
@@ -162,7 +162,7 @@ EXAMPLES = r'''
     - KB4073117
 
 - name: Exclude updates based on the update title
-  win_updates:
+  ansible.windows.win_updates:
     category_name:
     - SecurityUpdates
     - CriticalUpdates
@@ -172,19 +172,19 @@ EXAMPLES = r'''
 
 # One way to ensure the system is reliable just after a reboot, is to set WinRM to a delayed startup
 - name: Ensure WinRM starts when the system has settled and is ready to work reliably
-  win_service:
+  ansible.windows.win_service:
     name: WinRM
     start_mode: delayed
 
 # Optionally, you can increase the reboot_timeout to survive long updates during reboot
 - name: Ensure we wait long enough for the updates to be applied during reboot
-  win_updates:
+  ansible.windows.win_updates:
     reboot: yes
     reboot_timeout: 3600
 
 # Search and download Windows updates
 - name: Search and download Windows updates without installing them
-  win_updates:
+  ansible.windows.win_updates:
     state: downloaded
 '''
 

--- a/plugins/modules/win_user.py
+++ b/plugins/modules/win_user.py
@@ -94,11 +94,11 @@ options:
     default: present
 seealso:
 - module: user
-- module: win_domain_membership
-- module: win_domain_user
-- module: win_group
-- module: win_group_membership
-- module: win_user_profile
+- module: ansible.windows.win_domain_membership
+- module: community.windows.win_domain_user
+- module: ansible.windows.win_group
+- module: ansible.windows.win_group_membership
+- module: community.windows.win_user_profile
 author:
     - Paul Durivage (@angstwad)
     - Chris Church (@cchurch)
@@ -106,7 +106,7 @@ author:
 
 EXAMPLES = r'''
 - name: Ensure user bob is present
-  win_user:
+  ansible.windows.win_user:
     name: bob
     password: B0bP4ssw0rd
     state: present
@@ -114,7 +114,7 @@ EXAMPLES = r'''
       - Users
 
 - name: Ensure user bob is absent
-  win_user:
+  ansible.windows.win_user:
     name: bob
     state: absent
 '''

--- a/plugins/modules/win_user_right.py
+++ b/plugins/modules/win_user_right.py
@@ -50,9 +50,9 @@ notes:
 - If the server is domain joined this module can change a right but if a GPO
   governs this right then the changes won't last.
 seealso:
-- module: win_group
-- module: win_group_membership
-- module: win_user
+- module: ansible.windows.win_group
+- module: ansible.windows.win_group_membership
+- module: ansible.windows.win_user
 author:
 - Jordan Borean (@jborean93)
 '''
@@ -60,7 +60,7 @@ author:
 EXAMPLES = r'''
 ---
 - name: Replace the entries of Deny log on locally
-  win_user_right:
+  ansible.windows.win_user_right:
     name: SeDenyInteractiveLogonRight
     users:
     - Guest
@@ -68,7 +68,7 @@ EXAMPLES = r'''
     action: set
 
 - name: Add account to Log on as a service
-  win_user_right:
+  ansible.windows.win_user_right:
     name: SeServiceLogonRight
     users:
     - .\Administrator
@@ -76,7 +76,7 @@ EXAMPLES = r'''
     action: add
 
 - name: Remove accounts who can create Symbolic links
-  win_user_right:
+  ansible.windows.win_user_right:
     name: SeCreateSymbolicLinkPrivilege
     users:
     - SYSTEM
@@ -86,7 +86,7 @@ EXAMPLES = r'''
     action: remove
 
 - name: Remove all accounts who cannot log on remote interactively
-  win_user_right:
+  ansible.windows.win_user_right:
     name: SeDenyRemoteInteractiveLogonRight
     users: []
 '''

--- a/plugins/modules/win_wait_for.py
+++ b/plugins/modules/win_wait_for.py
@@ -92,47 +92,47 @@ options:
     default: 300
 seealso:
 - module: wait_for
-- module: win_wait_for_process
+- module: community.windows.win_wait_for_process
 author:
 - Jordan Borean (@jborean93)
 '''
 
 EXAMPLES = r'''
 - name: Wait 300 seconds for port 8000 to become open on the host, don't start checking for 10 seconds
-  win_wait_for:
+  ansible.windows.win_wait_for:
     port: 8000
     delay: 10
 
 - name: Wait 150 seconds for port 8000 of any IP to close active connections
-  win_wait_for:
+  ansible.windows.win_wait_for:
     host: 0.0.0.0
     port: 8000
     state: drained
     timeout: 150
 
 - name: Wait for port 8000 of any IP to close active connection, ignoring certain hosts
-  win_wait_for:
+  ansible.windows.win_wait_for:
     host: 0.0.0.0
     port: 8000
     state: drained
     exclude_hosts: ['10.2.1.2', '10.2.1.3']
 
 - name: Wait for file C:\temp\log.txt to exist before continuing
-  win_wait_for:
+  ansible.windows.win_wait_for:
     path: C:\temp\log.txt
 
 - name: Wait until process complete is in the file before continuing
-  win_wait_for:
+  ansible.windows.win_wait_for:
     path: C:\temp\log.txt
     regex: process complete
 
 - name: Wait until file is removed
-  win_wait_for:
+  ansible.windows.win_wait_for:
     path: C:\temp\log.txt
     state: absent
 
 - name: Wait until port 1234 is offline but try every 10 seconds
-  win_wait_for:
+  ansible.windows.win_wait_for:
     port: 1234
     state: absent
     sleep: 10

--- a/plugins/modules/win_whoami.py
+++ b/plugins/modules/win_whoami.py
@@ -24,16 +24,16 @@ notes:
   empty list as Administrator rights are required to query LSA for the
   information.
 seealso:
-- module: win_credential
-- module: win_group_membership
-- module: win_user_right
+- module: community.windows.win_credential
+- module: ansible.windows.win_group_membership
+- module: ansible.windows.win_user_right
 author:
 - Jordan Borean (@jborean93)
 '''
 
 EXAMPLES = r'''
 - name: Get whoami information
-  win_whoami:
+  ansible.windows.win_whoami:
 '''
 
 RETURN = r'''


### PR DESCRIPTION
##### SUMMARY
All plugin examples should use the fully qualified collection name. This also removes any references to features added/removed in specific Ansible versions as the collection is considered base 0.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
many