### PR TITLE
Added rst docs for each module

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,58 @@ This repo hosts the `ansible.windows` Ansible Collection.
 The collection includes the core plugins supported by Ansible to help the management of Windows hosts.
 
 
+## Included content
+
+<!--start collection content-->
+## Filter plugins
+Name | Description
+--- | ---
+ansible.windows.quote|Quotes argument(s) for the various shells in Windows command processing.
+## Modules
+Name | Description
+--- | ---
+[ansible.windows.win_acl](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_acl.rst)|Set file/directory/registry permissions for a system user or group
+[ansible.windows.win_acl_inheritance](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_acl_inheritance.rst)|Change ACL inheritance
+[ansible.windows.win_certificate_store](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_certificate_store.rst)|Manages the certificate store
+[ansible.windows.win_command](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_command.rst)|Executes a command on a remote Windows node
+[ansible.windows.win_copy](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_copy.rst)|Copies files to remote locations on windows hosts
+[ansible.windows.win_dns_client](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_dns_client.rst)|Configures DNS lookup on Windows hosts
+[ansible.windows.win_domain](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_domain.rst)|Ensures the existence of a Windows domain
+[ansible.windows.win_domain_controller](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_domain_controller.rst)|Manage domain controller/member server state for a Windows host
+[ansible.windows.win_domain_membership](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_domain_membership.rst)|Manage domain/workgroup membership for a Windows host
+[ansible.windows.win_dsc](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_dsc.rst)|Invokes a PowerShell DSC configuration
+[ansible.windows.win_environment](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_environment.rst)|Modify environment variables on windows hosts
+[ansible.windows.win_feature](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_feature.rst)|Installs and uninstalls Windows Features on Windows Server
+[ansible.windows.win_file](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_file.rst)|Creates, touches or removes files or directories
+[ansible.windows.win_find](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_find.rst)|Return a list of files based on specific criteria
+[ansible.windows.win_get_url](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_get_url.rst)|Downloads file from HTTP, HTTPS, or FTP to node
+[ansible.windows.win_group](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_group.rst)|Add and remove local groups
+[ansible.windows.win_group_membership](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_group_membership.rst)|Manage Windows local group membership
+[ansible.windows.win_hostname](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_hostname.rst)|Manages local Windows computer name
+[ansible.windows.win_optional_feature](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_optional_feature.rst)|Manage optional Windows features
+[ansible.windows.win_owner](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_owner.rst)|Set owner
+[ansible.windows.win_package](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_package.rst)|Installs/uninstalls an installable package
+[ansible.windows.win_path](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_path.rst)|Manage Windows path environment variables
+[ansible.windows.win_ping](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_ping.rst)|A windows version of the classic ping module
+[ansible.windows.win_reboot](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_reboot.rst)|Reboot a windows machine
+[ansible.windows.win_reg_stat](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_reg_stat.rst)|Get information about Windows registry keys
+[ansible.windows.win_regedit](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_regedit.rst)|Add, change, or remove registry keys and values
+[ansible.windows.win_service](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_service.rst)|Manage and query Windows services
+[ansible.windows.win_service_info](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_service_info.rst)|Gather information about Windows services
+[ansible.windows.win_share](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_share.rst)|Manage Windows shares
+[ansible.windows.win_shell](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_shell.rst)|Execute shell commands on target hosts
+[ansible.windows.win_stat](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_stat.rst)|Get information about Windows files
+[ansible.windows.win_tempfile](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_tempfile.rst)|Creates temporary files and directories
+[ansible.windows.win_template](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_template.rst)|Template a file out to a remote server
+[ansible.windows.win_updates](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_updates.rst)|Download and install Windows updates
+[ansible.windows.win_uri](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_uri.rst)|Interacts with webservices
+[ansible.windows.win_user](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_user.rst)|Manages local Windows user accounts
+[ansible.windows.win_user_right](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_user_right.rst)|Manage Windows User Rights
+[ansible.windows.win_wait_for](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_wait_for.rst)|Waits for a condition before continuing
+[ansible.windows.win_whoami](https://github.com/ansible-collections/ansible.windows/blob/master/docs/ansible.windows.win_whoami.rst)|Get information about the current user and process
+<!--end collection content-->
+
+
 ## Installation and Usage
 
 ### Installing the Collection from Ansible Galaxy

--- a/docs/ansible.windows.win_acl.rst
+++ b/docs/ansible.windows.win_acl.rst
@@ -1,0 +1,259 @@
+:orphan:
+
+.. _ansible.windows.win_acl_module:
+
+
+***********************
+ansible.windows.win_acl
+***********************
+
+**Set file/directory/registry permissions for a system user or group**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Add or remove rights/permissions for a given user or group for the specified file, folder, registry key or AppPool identifies.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>inherit</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>ContainerInherit</li>
+                                                                                                                                                                                                <li>ObjectInherit</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Inherit flags on the ACL rules.</div>
+                                            <div>Can be specified as a comma separated list, e.g. <code>ContainerInherit</code>, <code>ObjectInherit</code>.</div>
+                                            <div>For more information on the choices see MSDN InheritanceFlags enumeration at <a href='https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.inheritanceflags.aspx'>https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.inheritanceflags.aspx</a>.</div>
+                                            <div>Defaults to <code>ContainerInherit, ObjectInherit</code> for Directories.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The path to the file or directory.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>propagation</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>InheritOnly</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>None</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>NoPropagateInherit</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Propagation flag on the ACL rules.</div>
+                                            <div>For more information on the choices see MSDN PropagationFlags enumeration at <a href='https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.propagationflags.aspx'>https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.propagationflags.aspx</a>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>rights</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The rights/permissions that are to be allowed/denied for the specified user or group for the item at <code>path</code>.</div>
+                                            <div>If <code>path</code> is a file or directory, rights can be any right under MSDN FileSystemRights <a href='https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.filesystemrights.aspx'>https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.filesystemrights.aspx</a>.</div>
+                                            <div>If <code>path</code> is a registry key, rights can be any right under MSDN RegistryRights <a href='https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.registryrights.aspx'>https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.registryrights.aspx</a>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Specify whether to add <code>present</code> or remove <code>absent</code> the specified access rule.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>allow</li>
+                                                                                                                                                                                                <li>deny</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Specify whether to allow or deny the rights specified.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>user</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>User or Group to add specified rights to act on src file/folder or registry key.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - If adding ACL's for AppPool identities, the Windows Feature "Web-Scripting-Tools" must be enabled.
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`ansible.windows.win_acl_inheritance_module`
+      The official documentation on the **ansible.windows.win_acl_inheritance** module.
+   :ref:`ansible.windows.win_file_module`
+      The official documentation on the **ansible.windows.win_file** module.
+   :ref:`ansible.windows.win_owner_module`
+      The official documentation on the **ansible.windows.win_owner** module.
+   :ref:`ansible.windows.win_stat_module`
+      The official documentation on the **ansible.windows.win_stat** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Restrict write and execute access to User Fed-Phil
+      ansible.windows.win_acl:
+        user: Fed-Phil
+        path: C:\Important\Executable.exe
+        type: deny
+        rights: ExecuteFile,Write
+
+    - name: Add IIS_IUSRS allow rights
+      ansible.windows.win_acl:
+        path: C:\inetpub\wwwroot\MySite
+        user: IIS_IUSRS
+        rights: FullControl
+        type: allow
+        state: present
+        inherit: ContainerInherit, ObjectInherit
+        propagation: 'None'
+
+    - name: Set registry key right
+      ansible.windows.win_acl:
+        path: HKCU:\Bovine\Key
+        user: BUILTIN\Users
+        rights: EnumerateSubKeys
+        type: allow
+        state: present
+        inherit: ContainerInherit, ObjectInherit
+        propagation: 'None'
+
+    - name: Remove FullControl AccessRule for IIS_IUSRS
+      ansible.windows.win_acl:
+        path: C:\inetpub\wwwroot\MySite
+        user: IIS_IUSRS
+        rights: FullControl
+        type: allow
+        state: absent
+        inherit: ContainerInherit, ObjectInherit
+        propagation: 'None'
+
+    - name: Deny Intern
+      ansible.windows.win_acl:
+        path: C:\Administrator\Documents
+        user: Intern
+        rights: Read,Write,Modify,FullControl,Delete
+        type: deny
+        state: present
+
+
+
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Phil Schwartz (@schwartzmx)
+- Trond Hindenes (@trondhindenes)
+- Hans-Joachim Kliemeck (@h0nIg)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_acl_inheritance.rst
+++ b/docs/ansible.windows.win_acl_inheritance.rst
@@ -1,0 +1,147 @@
+:orphan:
+
+.. _ansible.windows.win_acl_inheritance_module:
+
+
+***********************************
+ansible.windows.win_acl_inheritance
+***********************************
+
+**Change ACL inheritance**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Change ACL (Access Control List) inheritance and optionally copy inherited ACE's (Access Control Entry) to dedicated ACE's or vice versa.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Path to be used for changing inheritance</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>reorganize</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>For P(state) = <em>absent</em>, indicates if the inherited ACE&#x27;s should be copied from the parent directory. This is necessary (in combination with removal) for a simple ACL instead of using multiple ACE deny entries.</div>
+                                            <div>For P(state) = <em>present</em>, indicates if the inherited ACE&#x27;s should be deduplicated compared to the parent directory. This removes complexity of the ACL structure.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>absent</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>present</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Specify whether to enable <em>present</em> or disable <em>absent</em> ACL inheritance.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`ansible.windows.win_acl_module`
+      The official documentation on the **ansible.windows.win_acl** module.
+   :ref:`ansible.windows.win_file_module`
+      The official documentation on the **ansible.windows.win_file** module.
+   :ref:`ansible.windows.win_stat_module`
+      The official documentation on the **ansible.windows.win_stat** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Disable inherited ACE's
+      ansible.windows.win_acl_inheritance:
+        path: C:\apache
+        state: absent
+
+    - name: Disable and copy inherited ACE's
+      ansible.windows.win_acl_inheritance:
+        path: C:\apache
+        state: absent
+        reorganize: yes
+
+    - name: Enable and remove dedicated ACE's
+      ansible.windows.win_acl_inheritance:
+        path: C:\apache
+        state: present
+        reorganize: yes
+
+
+
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Hans-Joachim Kliemeck (@h0nIg)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_certificate_store.rst
+++ b/docs/ansible.windows.win_certificate_store.rst
@@ -1,0 +1,365 @@
+:orphan:
+
+.. _ansible.windows.win_certificate_store_module:
+
+
+*************************************
+ansible.windows.win_certificate_store
+*************************************
+
+**Manages the certificate store**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Used to import/export and remove certificates and keys from the local certificate store.
+- This module is not used to create certificates and will only manage existing certs as a file or in the store.
+- It can be used to import PEM, DER, P7B, PKCS12 (PFX) certificates and export PEM, DER and PKCS12 certificates.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>file_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>der</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>pem</li>
+                                                                                                                                                                                                <li>pkcs12</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>The file type to export the certificate as when <code>state=exported</code>.</div>
+                                            <div><code>der</code> is a binary ASN.1 encoded file.</div>
+                                            <div><code>pem</code> is a base64 encoded file of a der file in the OpenSSL form.</div>
+                                            <div><code>pkcs12</code> (also known as pfx) is a binary container that contains both the certificate and private key unlike the other options.</div>
+                                            <div>When <code>pkcs12</code> is set and the private key is not exportable or accessible by the current user, it will throw an exception.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>key_exportable</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether to allow the private key to be exported.</div>
+                                            <div>If <code>no</code>, then this module and other process will only be able to export the certificate and the private key cannot be exported.</div>
+                                            <div>Used when <code>state=present</code> only.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>key_storage</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>default</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>machine</li>
+                                                                                                                                                                                                <li>user</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Specifies where Windows will store the private key when it is imported.</div>
+                                            <div>When set to <code>default</code>, the default option as set by Windows is used, typically <code>user</code>.</div>
+                                            <div>When set to <code>machine</code>, the key is stored in a path accessible by various users.</div>
+                                            <div>When set to <code>user</code>, the key is stored in a path only accessible by the current user.</div>
+                                            <div>Used when <code>state=present</code> only and cannot be changed once imported.</div>
+                                            <div>See <a href='https://msdn.microsoft.com/en-us/library/system.security.cryptography.x509certificates.x509keystorageflags.aspx'>https://msdn.microsoft.com/en-us/library/system.security.cryptography.x509certificates.x509keystorageflags.aspx</a> for more details.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The password of the pkcs12 certificate key.</div>
+                                            <div>This is used when reading a pkcs12 certificate file or the password to set when <code>state=exported</code> and <code>file_type=pkcs12</code>.</div>
+                                            <div>If the pkcs12 file has no password set or no password should be set on the exported file, do not set this option.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The path to a certificate file.</div>
+                                            <div>This is required when <em>state</em> is <code>present</code> or <code>exported</code>.</div>
+                                            <div>When <em>state</em> is <code>absent</code> and <em>thumbprint</em> is not specified, the thumbprint is derived from the certificate at this path.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li>exported</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>If <code>present</code>, will ensure that the certificate at <em>path</em> is imported into the certificate store specified.</div>
+                                            <div>If <code>absent</code>, will ensure that the certificate specified by <em>thumbprint</em> or the thumbprint of the cert at <em>path</em> is removed from the store specified.</div>
+                                            <div>If <code>exported</code>, will ensure the file at <em>path</em> is a certificate specified by <em>thumbprint</em>.</div>
+                                            <div>When exporting a certificate, if <em>path</em> is a directory then the module will fail, otherwise the file will be replaced if needed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>store_location</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>CurrentUser</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>LocalMachine</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>The store location to use when importing a certificate or searching for a certificate.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>store_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>AddressBook</li>
+                                                                                                                                                                                                <li>AuthRoot</li>
+                                                                                                                                                                                                <li>CertificateAuthority</li>
+                                                                                                                                                                                                <li>Disallowed</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>My</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>Root</li>
+                                                                                                                                                                                                <li>TrustedPeople</li>
+                                                                                                                                                                                                <li>TrustedPublisher</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>The store name to use when importing a certificate or searching for a certificate.</div>
+                                            <div><code>AddressBook</code>: The X.509 certificate store for other users</div>
+                                            <div><code>AuthRoot</code>: The X.509 certificate store for third-party certificate authorities (CAs)</div>
+                                            <div><code>CertificateAuthority</code>: The X.509 certificate store for intermediate certificate authorities (CAs)</div>
+                                            <div><code>Disallowed</code>: The X.509 certificate store for revoked certificates</div>
+                                            <div><code>My</code>: The X.509 certificate store for personal certificates</div>
+                                            <div><code>Root</code>: The X.509 certificate store for trusted root certificate authorities (CAs)</div>
+                                            <div><code>TrustedPeople</code>: The X.509 certificate store for directly trusted people and resources</div>
+                                            <div><code>TrustedPublisher</code>: The X.509 certificate store for directly trusted publishers</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>thumbprint</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The thumbprint as a hex string to either export or remove.</div>
+                                            <div>See the examples for how to specify the thumbprint.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - Some actions on PKCS12 certificates and keys may fail with the error ``the specified network password is not correct``, either use CredSSP or Kerberos with credential delegation, or use ``become`` to bypass these restrictions.
+   - The certificates must be located on the Windows host to be set with *path*.
+   - When importing a certificate for usage in IIS, it is generally required to use the ``machine`` key_storage option, as both ``default`` and ``user`` will make the private key unreadable to IIS APPPOOL identities and prevent binding the certificate to the https endpoint.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Import a certificate
+      ansible.windows.win_certificate_store:
+        path: C:\Temp\cert.pem
+        state: present
+
+    - name: Import pfx certificate that is password protected
+      ansible.windows.win_certificate_store:
+        path: C:\Temp\cert.pfx
+        state: present
+        password: VeryStrongPasswordHere!
+      become: yes
+      become_method: runas
+
+    - name: Import pfx certificate without password and set private key as un-exportable
+      ansible.windows.win_certificate_store:
+        path: C:\Temp\cert.pfx
+        state: present
+        key_exportable: no
+      # usually you don't set this here but it is for illustrative purposes
+      vars:
+        ansible_winrm_transport: credssp
+
+    - name: Remove a certificate based on file thumbprint
+      ansible.windows.win_certificate_store:
+        path: C:\Temp\cert.pem
+        state: absent
+
+    - name: Remove a certificate based on thumbprint
+      ansible.windows.win_certificate_store:
+        thumbprint: BD7AF104CF1872BDB518D95C9534EA941665FD27
+        state: absent
+
+    - name: Remove certificate based on thumbprint is CurrentUser/TrustedPublishers store
+      ansible.windows.win_certificate_store:
+        thumbprint: BD7AF104CF1872BDB518D95C9534EA941665FD27
+        state: absent
+        store_location: CurrentUser
+        store_name: TrustedPublisher
+
+    - name: Export certificate as der encoded file
+      ansible.windows.win_certificate_store:
+        path: C:\Temp\cert.cer
+        state: exported
+        file_type: der
+
+    - name: Export certificate and key as pfx encoded file
+      ansible.windows.win_certificate_store:
+        path: C:\Temp\cert.pfx
+        state: exported
+        file_type: pkcs12
+        password: AnotherStrongPass!
+      become: yes
+      become_method: runas
+      become_user: SYSTEM
+
+    - name: Import certificate be used by IIS
+      ansible.windows.win_certificate_store:
+        path: C:\Temp\cert.pfx
+        file_type: pkcs12
+        password: StrongPassword!
+        store_location: LocalMachine
+        key_storage: machine
+        state: present
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>thumbprints</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>A list of certificate thumbprints that were touched by the module.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;BC05633694E675449136679A658281F17A191087&#x27;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Jordan Borean (@jborean93)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_command.rst
+++ b/docs/ansible.windows.win_command.rst
@@ -1,0 +1,364 @@
+:orphan:
+
+.. _ansible.windows.win_command_module:
+
+
+***************************
+ansible.windows.win_command
+***************************
+
+**Executes a command on a remote Windows node**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- The ``win_command`` module takes the command name followed by a list of space-delimited arguments.
+- The given command will be executed on all selected nodes. It will not be processed through the shell, so variables like ``$env:HOME`` and operations like ``"<"``, ``">"``, ``"|"``, and ``";"`` will not work (use the :ref:`ansible.windows.win_shell <ansible.windows.win_shell_module>` module if you need these features).
+- For non-Windows targets, use the :ref:`command <command_module>` module instead.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>chdir</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Set the specified path as the current working directory before executing a command.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>creates</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A path or path filter pattern; when the referenced path exists on the target host, the task will be skipped.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>free_form</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The <code>win_command</code> module takes a free form command to run.</div>
+                                            <div>There is no parameter actually named &#x27;free form&#x27;. See the examples!</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>output_encoding_override</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>This option overrides the encoding of stdout/stderr output.</div>
+                                            <div>You can use this option when you need to run a command which ignore the console&#x27;s codepage.</div>
+                                            <div>You should only need to use this option in very rare circumstances.</div>
+                                            <div>This value can be any valid encoding <code>Name</code> based on the output of <code>[System.Text.Encoding]::GetEncodings(</code>). See <a href='https://docs.microsoft.com/dotnet/api/system.text.encoding.getencodings'>https://docs.microsoft.com/dotnet/api/system.text.encoding.getencodings</a>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>removes</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A path or path filter pattern; when the referenced path <b>does not</b> exist on the target host, the task will be skipped.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>stdin</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Set the stdin of the command directly to the specified value.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - If you want to run a command through a shell (say you are using ``<``, ``>``, ``|``, etc), you actually want the :ref:`ansible.windows.win_shell <ansible.windows.win_shell_module>` module instead. The :ref:`ansible.windows.win_command <ansible.windows.win_command_module>` module is much more secure as it's not affected by the user's environment.
+   - ``creates``, ``removes``, and ``chdir`` can be specified after the command. For instance, if you only want to run a command if a certain file does not exist, use this.
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`command_module`
+      The official documentation on the **command** module.
+   :ref:`community.windows.psexec_module`
+      The official documentation on the **community.windows.psexec** module.
+   :ref:`raw_module`
+      The official documentation on the **raw** module.
+   :ref:`community.windows.win_psexec_module`
+      The official documentation on the **community.windows.win_psexec** module.
+   :ref:`ansible.windows.win_shell_module`
+      The official documentation on the **ansible.windows.win_shell** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Save the result of 'whoami' in 'whoami_out'
+      ansible.windows.win_command: whoami
+      register: whoami_out
+
+    - name: Run command that only runs if folder exists and runs from a specific folder
+      ansible.windows.win_command: wbadmin -backupTarget:C:\backup\
+      args:
+        chdir: C:\somedir\
+        creates: C:\backup\
+
+    - name: Run an executable and send data to the stdin for the executable
+      ansible.windows.win_command: powershell.exe -
+      args:
+        stdin: Write-Host test
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>cmd</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The command executed by the task</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">rabbitmqctl join_cluster rabbit@master</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>delta</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The command execution delta time</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">0:00:00.325771</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>end</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The command execution end time</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-02-25 09:18:26.755339</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>msg</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>changed</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>rc</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The command return code (0 means success)</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>start</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The command execution start time</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-02-25 09:18:26.429568</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>stderr</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The command standard error</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ls: cannot access foo: No such file or directory</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>stdout</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The command standard output</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Clustering node rabbit@slave1 with rabbit@master ...</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>stdout_lines</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The command standard output split in lines</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&quot;u&#x27;Clustering node rabbit@slave1 with rabbit@master ...&#x27;&quot;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Matt Davis (@nitzmahone)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_copy.rst
+++ b/docs/ansible.windows.win_copy.rst
@@ -1,0 +1,432 @@
+:orphan:
+
+.. _ansible.windows.win_copy_module:
+
+
+************************
+ansible.windows.win_copy
+************************
+
+**Copies files to remote locations on windows hosts**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- The ``win_copy`` module copies a file on the local box to remote windows locations.
+- For non-Windows targets, use the :ref:`copy <copy_module>` module instead.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>backup</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Determine whether a backup should be created.</div>
+                                            <div>When set to <code>yes</code>, create a backup file including the timestamp information so you can get the original file back if you somehow clobbered it incorrectly.</div>
+                                            <div>No backup is taken when <code>remote_src=False</code> and multiple files are being copied.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>content</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>When used instead of <code>src</code>, sets the contents of a file directly to the specified value.</div>
+                                            <div>This is for simple values, for anything complex or with formatting please switch to the <span class='module'>template</span> module.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>decrypt</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>This option controls the autodecryption of source files using vault.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dest</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Remote absolute path where the file should be copied to.</div>
+                                            <div>If <code>src</code> is a directory, this must be a directory too.</div>
+                                            <div>Use \ for path separators or \\ when in &quot;double quotes&quot;.</div>
+                                            <div>If <code>dest</code> ends with \ then source or the contents of source will be copied to the directory without renaming.</div>
+                                            <div>If <code>dest</code> is a nonexistent path, it will only be created if <code>dest</code> ends with &quot;/&quot; or &quot;\&quot;, or <code>src</code> is a directory.</div>
+                                            <div>If <code>src</code> and <code>dest</code> are files and if the parent directory of <code>dest</code> doesn&#x27;t exist, then the task will fail.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>force</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>If set to <code>yes</code>, the file will only be transferred if the content is different than destination.</div>
+                                            <div>If set to <code>no</code>, the file will only be transferred if the destination does not exist.</div>
+                                            <div>If set to <code>no</code>, no checksuming of the content is performed which can help improve performance on larger files.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>local_follow</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>This flag indicates that filesystem links in the source tree, if they exist, should be followed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>remote_src</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>If <code>no</code>, it will search for src at originating/master machine.</div>
+                                            <div>If <code>yes</code>, it will go to the remote/target machine for the src.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>src</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Local path to a file to copy to the remote server; can be absolute or relative.</div>
+                                            <div>If path is a directory, it is copied (including the source folder name) recursively to <code>dest</code>.</div>
+                                            <div>If path is a directory and ends with &quot;/&quot;, only the inside contents of that directory are copied to the destination. Otherwise, if it does not end with &quot;/&quot;, the directory itself with all contents is copied.</div>
+                                            <div>If path is a file and dest ends with &quot;\&quot;, the file is copied to the folder with the same filename.</div>
+                                            <div>Required unless using <code>content</code>.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - Currently win_copy does not support copying symbolic links from both local to remote and remote to remote.
+   - It is recommended that backslashes ``\`` are used instead of ``/`` when dealing with remote paths.
+   - Because win_copy runs over WinRM, it is not a very efficient transfer mechanism. If sending large files consider hosting them on a web service and using :ref:`ansible.windows.win_get_url <ansible.windows.win_get_url_module>` instead.
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`community.general.assemble_module`
+      The official documentation on the **community.general.assemble** module.
+   :ref:`copy_module`
+      The official documentation on the **copy** module.
+   :ref:`ansible.windows.win_get_url_module`
+      The official documentation on the **ansible.windows.win_get_url** module.
+   :ref:`community.windows.win_robocopy_module`
+      The official documentation on the **community.windows.win_robocopy** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Copy a single file
+      ansible.windows.win_copy:
+        src: /srv/myfiles/foo.conf
+        dest: C:\Temp\renamed-foo.conf
+
+    - name: Copy a single file, but keep a backup
+      ansible.windows.win_copy:
+        src: /srv/myfiles/foo.conf
+        dest: C:\Temp\renamed-foo.conf
+        backup: yes
+
+    - name: Copy a single file keeping the filename
+      ansible.windows.win_copy:
+        src: /src/myfiles/foo.conf
+        dest: C:\Temp\
+
+    - name: Copy folder to C:\Temp (results in C:\Temp\temp_files)
+      ansible.windows.win_copy:
+        src: files/temp_files
+        dest: C:\Temp
+
+    - name: Copy folder contents recursively
+      ansible.windows.win_copy:
+        src: files/temp_files/
+        dest: C:\Temp
+
+    - name: Copy a single file where the source is on the remote host
+      ansible.windows.win_copy:
+        src: C:\Temp\foo.txt
+        dest: C:\ansible\foo.txt
+        remote_src: yes
+
+    - name: Copy a folder recursively where the source is on the remote host
+      ansible.windows.win_copy:
+        src: C:\Temp
+        dest: C:\ansible
+        remote_src: yes
+
+    - name: Set the contents of a file
+      ansible.windows.win_copy:
+        content: abc123
+        dest: C:\Temp\foo.txt
+
+    - name: Copy a single file as another user
+      ansible.windows.win_copy:
+        src: NuGet.config
+        dest: '%AppData%\NuGet\NuGet.config'
+      vars:
+        ansible_become_user: user
+        ansible_become_password: pass
+        # The tmp dir must be set when using win_copy as another user
+        # This ensures the become user will have permissions for the operation
+        # Make sure to specify a folder both the ansible_user and the become_user have access to (i.e not %TEMP% which is user specific and requires Admin)
+        ansible_remote_tmp: 'c:\tmp'
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>backup_file</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>if backup=yes</td>
+                <td>
+                                                                        <div>Name of the backup file that was created.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">C:\Path\To\File.txt.11540.20150212-220915.bak</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>checksum</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, src is a file</td>
+                <td>
+                                                                        <div>SHA1 checksum of the file after running copy.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">6e642bb8dd5c2e027bf21dd923337cbb4214f827</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>dest</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>changed</td>
+                <td>
+                                                                        <div>Destination file/path.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">C:\Temp\</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>operation</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>Whether a single file copy took place or a folder copy.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">file_copy</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>original_basename</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>changed, src is a file</td>
+                <td>
+                                                                        <div>Basename of the copied file.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">foo.txt</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>size</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>changed, src is a file</td>
+                <td>
+                                                                        <div>Size of the target, after execution.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1220</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>src</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>changed</td>
+                <td>
+                                                                        <div>Source file used for the copy on the target machine.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">/home/httpd/.ansible/tmp/ansible-tmp-1423796390.97-147729857856000/source</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Jon Hawkesworth (@jhawkesworth)
+- Jordan Borean (@jborean93)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_dns_client.rst
+++ b/docs/ansible.windows.win_dns_client.rst
@@ -1,0 +1,124 @@
+:orphan:
+
+.. _ansible.windows.win_dns_client_module:
+
+
+******************************
+ansible.windows.win_dns_client
+******************************
+
+**Configures DNS lookup on Windows hosts**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- The :ref:`ansible.windows.win_dns_client <ansible.windows.win_dns_client_module>` module configures the DNS client on Windows network adapters.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>adapter_names</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Adapter name or list of adapter names for which to manage DNS settings (&#x27;*&#x27; is supported as a wildcard value).</div>
+                                            <div>The adapter name used is the connection caption in the Network Control Panel or the InterfaceAlias of <code>Get-DnsClientServerAddress</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dns_servers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Single or ordered list of DNS servers (IPv4 and IPv6 addresses) to configure for lookup.</div>
+                                            <div>An empty list will configure the adapter to use the DHCP-assigned values on connections where DHCP is enabled, or disable DNS lookup on statically-configured connections.</div>
+                                            <div>IPv6 DNS servers can only be set on Windows Server 2012 or newer, older hosts can only set IPv4 addresses.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: ipv4_addresses, ip_addresses, addresses</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Set a single address on the adapter named Ethernet
+      ansible.windows.win_dns_client:
+        adapter_names: Ethernet
+        dns_servers: 192.168.34.5
+
+    - name: Set multiple lookup addresses on all visible adapters (usually physical adapters that are in the Up state), with debug logging to a file
+      ansible.windows.win_dns_client:
+        adapter_names: '*'
+        dns_servers:
+        - 192.168.34.5
+        - 192.168.34.6
+        log_path: C:\dns_log.txt
+
+    - name: Set IPv6 DNS servers on the adapter named Ethernet
+      ansible.windows.win_dns_client:
+        adapter_names: Ethernet
+        dns_servers:
+        - '2001:db8::2'
+        - '2001:db8::3'
+
+    - name: Configure all adapters whose names begin with Ethernet to use DHCP-assigned DNS values
+      ansible.windows.win_dns_client:
+        adapter_names: 'Ethernet*'
+        dns_servers: []
+
+
+
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Matt Davis (@nitzmahone)
+- Brian Scholer (@briantist)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_domain.rst
+++ b/docs/ansible.windows.win_domain.rst
@@ -1,0 +1,315 @@
+:orphan:
+
+.. _ansible.windows.win_domain_module:
+
+
+**************************
+ansible.windows.win_domain
+**************************
+
+**Ensures the existence of a Windows domain**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Ensure that the domain named by ``dns_domain_name`` exists and is reachable.
+- If the domain is not reachable, the domain is created in a new forest on the target Windows Server 2012R2+ host.
+- This module may require subsequent use of the :ref:`ansible.windows.win_reboot <ansible.windows.win_reboot_module>` action if changes are made.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>create_dns_delegation</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether to create a DNS delegation that references the new DNS server that you install along with the domain controller.</div>
+                                            <div>Valid for Active Directory-integrated DNS only.</div>
+                                            <div>The default is computed automatically based on the environment.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>database_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The path to a directory on a fixed disk of the Windows host where the domain database will be created.</div>
+                                            <div>If not set then the default path is <code>%SYSTEMROOT%\NTDS</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dns_domain_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The DNS name of the domain which should exist and be reachable or reside on the target Windows host.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>domain_mode</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>Win2003</li>
+                                                                                                                                                                                                <li>Win2008</li>
+                                                                                                                                                                                                <li>Win2008R2</li>
+                                                                                                                                                                                                <li>Win2012</li>
+                                                                                                                                                                                                <li>Win2012R2</li>
+                                                                                                                                                                                                <li>WinThreshold</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Specifies the domain functional level of the first domain in the creation of a new forest.</div>
+                                            <div>The domain functional level cannot be lower than the forest functional level, but it can be higher.</div>
+                                            <div>The default is automatically computed and set.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>domain_netbios_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The NetBIOS name for the root domain in the new forest.</div>
+                                            <div>For NetBIOS names to be valid for use with this parameter they must be single label names of 15 characters or less, if not it will fail.</div>
+                                            <div>If this parameter is not set, then the default is automatically computed from the value of the <em>domain_name</em> parameter.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>forest_mode</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>Win2003</li>
+                                                                                                                                                                                                <li>Win2008</li>
+                                                                                                                                                                                                <li>Win2008R2</li>
+                                                                                                                                                                                                <li>Win2012</li>
+                                                                                                                                                                                                <li>Win2012R2</li>
+                                                                                                                                                                                                <li>WinThreshold</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Specifies the forest functional level for the new forest.</div>
+                                            <div>The default forest functional level in Windows Server is typically the same as the version you are running.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>install_dns</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether to install the DNS service when creating the domain controller.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>log_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Specifies the fully qualified, non-UNC path to a directory on a fixed disk of the local computer where the log file for this operation is written.</div>
+                                            <div>If not set then the default path is <code>%SYSTEMROOT%\NTDS</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>safe_mode_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Safe mode password for the domain controller.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>sysvol_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The path to a directory on a fixed disk of the Windows host where the Sysvol file will be created.</div>
+                                            <div>If not set then the default path is <code>%SYSTEMROOT%\SYSVOL</code>.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`ansible.windows.win_domain_controller_module`
+      The official documentation on the **ansible.windows.win_domain_controller** module.
+   :ref:`community.windows.win_domain_computer_module`
+      The official documentation on the **community.windows.win_domain_computer** module.
+   :ref:`community.windows.win_domain_group_module`
+      The official documentation on the **community.windows.win_domain_group** module.
+   :ref:`ansible.windows.win_domain_membership_module`
+      The official documentation on the **ansible.windows.win_domain_membership** module.
+   :ref:`community.windows.win_domain_user_module`
+      The official documentation on the **community.windows.win_domain_user** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Create new domain in a new forest on the target host
+      ansible.windows.win_domain:
+        dns_domain_name: ansible.vagrant
+        safe_mode_password: password123!
+
+    - name: Create new Windows domain in a new forest with specific parameters
+      ansible.windows.win_domain:
+        create_dns_delegation: no
+        database_path: C:\Windows\NTDS
+        dns_domain_name: ansible.vagrant
+        domain_mode: Win2012R2
+        domain_netbios_name: ANSIBLE
+        forest_mode: Win2012R2
+        safe_mode_password: password123!
+        sysvol_path: C:\Windows\SYSVOL
+      register: domain_install
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>reboot_required</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>True if changes were made that require a reboot.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Matt Davis (@nitzmahone)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_domain_controller.rst
+++ b/docs/ansible.windows.win_domain_controller.rst
@@ -1,0 +1,372 @@
+:orphan:
+
+.. _ansible.windows.win_domain_controller_module:
+
+
+*************************************
+ansible.windows.win_domain_controller
+*************************************
+
+**Manage domain controller/member server state for a Windows host**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Ensure that a Windows Server 2012+ host is configured as a domain controller or demoted to member server.
+- This module may require subsequent use of the :ref:`ansible.windows.win_reboot <ansible.windows.win_reboot_module>` action if changes are made.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>database_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The path to a directory on a fixed disk of the Windows host where the domain database will be created..</div>
+                                            <div>If not set then the default path is <code>%SYSTEMROOT%\NTDS</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dns_domain_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>When <code>state</code> is <code>domain_controller</code>, the DNS name of the domain for which the targeted Windows host should be a DC.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>domain_admin_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Password for the specified <code>domain_admin_user</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>domain_admin_user</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Username of a domain admin for the target domain (necessary to promote or demote a domain controller).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>domain_log_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Specified the fully qualified, non-UNC path to a directory on a fixed disk of the local computer that will contain the domain log files.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>install_dns</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether to install the DNS service when creating the domain controller.</div>
+                                            <div>If not specified then the <code>-InstallDns</code> option is not supplied to <code>Install-ADDSDomainController</code> command, see <a href='https://docs.microsoft.com/en-us/powershell/module/addsdeployment/install-addsdomaincontroller'>https://docs.microsoft.com/en-us/powershell/module/addsdeployment/install-addsdomaincontroller</a>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>local_admin_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Password to be assigned to the local <code>Administrator</code> user (required when <code>state</code> is <code>member_server</code>).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>log_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The path to log any debug information when running the module.</div>
+                                            <div>This option is deprecated and should not be used, it will be removed in Ansible 2.14.</div>
+                                            <div>This does not relate to the <code>-LogPath</code> paramter of the install controller cmdlet.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>read_only</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether to install the domain controller as a read only replica for an existing domain.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>safe_mode_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Safe mode password for the domain controller (required when <code>state</code> is <code>domain_controller</code>).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>site_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Specifies the name of an existing site where you can place the new domain controller.</div>
+                                            <div>This option is required when <em>read_only</em> is <code>yes</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>domain_controller</li>
+                                                                                                                                                                                                <li>member_server</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether the target host should be a domain controller or a member server.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>sysvol_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The path to a directory on a fixed disk of the Windows host where the Sysvol folder will be created.</div>
+                                            <div>If not set then the default path is <code>%SYSTEMROOT%\SYSVOL</code>.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`ansible.windows.win_domain_module`
+      The official documentation on the **ansible.windows.win_domain** module.
+   :ref:`ansible.windows.win_domain_computer_module`
+      The official documentation on the **ansible.windows.win_domain_computer** module.
+   :ref:`community.windows.win_domain_group_module`
+      The official documentation on the **community.windows.win_domain_group** module.
+   :ref:`ansible.windows.win_domain_membership_module`
+      The official documentation on the **ansible.windows.win_domain_membership** module.
+   :ref:`community.windows.win_domain_user_module`
+      The official documentation on the **community.windows.win_domain_user** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Ensure a server is a domain controller
+      ansible.windows.win_domain_controller:
+        dns_domain_name: ansible.vagrant
+        domain_admin_user: testguy@ansible.vagrant
+        domain_admin_password: password123!
+        safe_mode_password: password123!
+        state: domain_controller
+
+    # note that without an action wrapper, in the case where a DC is demoted,
+    # the task will fail with a 401 Unauthorized, because the domain credential
+    # becomes invalid to fetch the final output over WinRM. This requires win_async
+    # with credential switching (or other clever credential-switching
+    # mechanism to get the output and trigger the required reboot)
+    - name: Ensure a server is not a domain controller
+      ansible.windows.win_domain_controller:
+        domain_admin_user: testguy@ansible.vagrant
+        domain_admin_password: password123!
+        local_admin_password: password123!
+        state: member_server
+
+    - name: Promote server as a read only domain controller
+      ansible.windows.win_domain_controller:
+        dns_domain_name: ansible.vagrant
+        domain_admin_user: testguy@ansible.vagrant
+        domain_admin_password: password123!
+        safe_mode_password: password123!
+        state: domain_controller
+        read_only: yes
+        site_name: London
+
+    - name: Promote server with custom paths
+      ansible.windows.win_domain_controller:
+        dns_domain_name: ansible.vagrant
+        domain_admin_user: testguy@ansible.vagrant
+        domain_admin_password: password123!
+        safe_mode_password: password123!
+        state: domain_controller
+        sysvol_path: D:\SYSVOL
+        database_path: D:\NTDS
+        domain_log_path: D:\NTDS
+      register: dc_promotion
+
+    - name: Reboot after promotion
+      ansible.windows.win_reboot:
+      when: dc_promotion.reboot_required
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>reboot_required</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>True if changes were made that require a reboot.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Matt Davis (@nitzmahone)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_domain_membership.rst
+++ b/docs/ansible.windows.win_domain_membership.rst
@@ -1,0 +1,263 @@
+:orphan:
+
+.. _ansible.windows.win_domain_membership_module:
+
+
+*************************************
+ansible.windows.win_domain_membership
+*************************************
+
+**Manage domain/workgroup membership for a Windows host**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Manages domain membership or workgroup membership for a Windows host. Also supports hostname changes.
+- This module may require subsequent use of the :ref:`ansible.windows.win_reboot <ansible.windows.win_reboot_module>` action if changes are made.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dns_domain_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>When <code>state</code> is <code>domain</code>, the DNS name of the domain to which the targeted Windows host should be joined.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>domain_admin_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Password for the specified <code>domain_admin_user</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>domain_admin_user</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Username of a domain admin for the target domain (required to join or leave the domain).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>domain_ou_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The desired OU path for adding the computer object.</div>
+                                            <div>This is only used when adding the target host to a domain, if it is already a member then it is ignored.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The desired hostname for the Windows host.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>domain</li>
+                                                                                                                                                                                                <li>workgroup</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether the target host should be a member of a domain or workgroup.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>workgroup_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>When <code>state</code> is <code>workgroup</code>, the name of the workgroup that the Windows host should be in.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`ansible.windows.win_domain_module`
+      The official documentation on the **ansible.windows.win_domain** module.
+   :ref:`ansible.windows.win_domain_controller_module`
+      The official documentation on the **ansible.windows.win_domain_controller** module.
+   :ref:`community.windows.win_domain_computer_module`
+      The official documentation on the **community.windows.win_domain_computer** module.
+   :ref:`community.windows.win_domain_group_module`
+      The official documentation on the **community.windows.win_domain_group** module.
+   :ref:`community.windows.win_domain_user_module`
+      The official documentation on the **community.windows.win_domain_user** module.
+   :ref:`ansible.windows.win_group_module`
+      The official documentation on the **ansible.windows.win_group** module.
+   :ref:`ansible.windows.win_group_membership_module`
+      The official documentation on the **ansible.windows.win_group_membership** module.
+   :ref:`ansible.windows.win_user_module`
+      The official documentation on the **ansible.windows.win_user** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+
+    # host should be a member of domain ansible.vagrant; module will ensure the hostname is mydomainclient
+    # and will use the passed credentials to join domain if necessary.
+    # Ansible connection should use local credentials if possible.
+    # If a reboot is required, the second task will trigger one and wait until the host is available.
+    - hosts: winclient
+      gather_facts: no
+      tasks:
+      - ansible.windows.win_domain_membership:
+          dns_domain_name: ansible.vagrant
+          hostname: mydomainclient
+          domain_admin_user: testguy@ansible.vagrant
+          domain_admin_password: password123!
+          domain_ou_path: "OU=Windows,OU=Servers,DC=ansible,DC=vagrant"
+          state: domain
+        register: domain_state
+
+      - ansible.windows.win_reboot:
+        when: domain_state.reboot_required
+
+
+
+    # Host should be in workgroup mywg- module will use the passed credentials to clean-unjoin domain if possible.
+    # Ansible connection should use local credentials if possible.
+    # The domain admin credentials can be sourced from a vault-encrypted variable
+    - hosts: winclient
+      gather_facts: no
+      tasks:
+      - ansible.windows.win_domain_membership:
+          workgroup_name: mywg
+          domain_admin_user: '{{ win_domain_admin_user }}'
+          domain_admin_password: '{{ win_domain_admin_password }}'
+          state: workgroup
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>reboot_required</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>True if changes were made that require a reboot.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Matt Davis (@nitzmahone)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_dsc.rst
+++ b/docs/ansible.windows.win_dsc.rst
@@ -1,0 +1,295 @@
+:orphan:
+
+.. _ansible.windows.win_dsc_module:
+
+
+***********************
+ansible.windows.win_dsc
+***********************
+
+**Invokes a PowerShell DSC configuration**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Configures a resource using PowerShell DSC.
+- Requires PowerShell version 5.0 or newer.
+- Most of the options for this module are dynamic and will vary depending on the DSC Resource specified in *resource_name*.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>free_form</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The <span class='module'>ansible.windows.win_dsc</span> module takes in multiple free form options based on the DSC resource being invoked by <em>resource_name</em>.</div>
+                                            <div>There is no option actually named <code>free_form</code> so see the examples.</div>
+                                            <div>This module will try and convert the option to the correct type required by the DSC resource and throw a warning if it fails.</div>
+                                            <div>If the type of the DSC resource option is a <code>CimInstance</code> or <code>CimInstance[]</code>, this means the value should be a dictionary or list of dictionaries based on the values required by that option.</div>
+                                            <div>If the type of the DSC resource option is a <code>PSCredential</code> then there needs to be 2 options set in the Ansible task definition suffixed with <code>_username</code> and <code>_password</code>.</div>
+                                            <div>If the type of the DSC resource option is an array, then a list should be provided but a comma separated string also work. Use a list where possible as no escaping is required and it works with more complex types list <code>CimInstance[]</code>.</div>
+                                            <div>If the type of the DSC resource option is a <code>DateTime</code>, you should use a string in the form of an ISO 8901 string to ensure the exact date is used.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>module_version</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"latest"</div>
+                                    </td>
+                                                                <td>
+                                            <div>Can be used to configure the exact version of the DSC resource to be invoked.</div>
+                                            <div>Useful if the target node has multiple versions installed of the module containing the DSC resource.</div>
+                                            <div>If not specified, the module will follow standard PowerShell convention and use the highest version available.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>resource_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The name of the DSC Resource to use.</div>
+                                            <div>Must be accessible to PowerShell using any of the default paths.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - By default there are a few builtin resources that come with PowerShell 5.0, see https://docs.microsoft.com/en-us/powershell/scripting/dsc/resources/resources for more information on these resources.
+   - Custom DSC resources can be installed with :ref:`community.windows.win_psmodule <community.windows.win_psmodule_module>` using the *name* option.
+   - The DSC engine run's each task as the SYSTEM account, any resources that need to be accessed with a different account need to have ``PsDscRunAsCredential`` set.
+   - To see the valid options for a DSC resource, run the module with ``-vvv`` to show the possible module invocation. Default values are not shown in this output but are applied within the DSC engine.
+   - The DSC engine requires the HTTP WSMan listener to be online and its port configured as the default listener for HTTP. This is set up by default but if a custom HTTP port is used or only a HTTPS listener is present then the module will fail. See the examples for a way to check this out in PowerShell.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Verify the WSMan HTTP listener is active and configured correctly
+      ansible.windows.win_shell: |
+        $port = (Get-Item -LiteralPath WSMan:\localhost\Client\DefaultPorts\HTTP).Value
+        $onlinePorts = @(Get-ChildItem -LiteralPath WSMan:\localhost\Listener |
+            Where-Object { 'Transport=HTTP' -in $_.Keys } |
+            Get-ChildItem |
+            Where-Object Name -eq Port |
+            Select-Object -ExpandProperty Value)
+
+        if ($port -notin $onlinePorts) {
+            "The default client port $port is not set up as a WSMan HTTP listener, win_dsc will not work."
+        }
+
+    - name: Extract zip file
+      ansible.windows.win_dsc:
+        resource_name: Archive
+        Ensure: Present
+        Path: C:\Temp\zipfile.zip
+        Destination: C:\Temp\Temp2
+
+    - name: Install a Windows feature with the WindowsFeature resource
+      ansible.windows.win_dsc:
+        resource_name: WindowsFeature
+        Name: telnet-client
+
+    - name: Edit HKCU reg key under specific user
+      ansible.windows.win_dsc:
+        resource_name: Registry
+        Ensure: Present
+        Key: HKEY_CURRENT_USER\ExampleKey
+        ValueName: TestValue
+        ValueData: TestData
+        PsDscRunAsCredential_username: '{{ansible_user}}'
+        PsDscRunAsCredential_password: '{{ansible_password}}'
+      no_log: true
+
+    - name: Create file with multiple attributes
+      ansible.windows.win_dsc:
+        resource_name: File
+        DestinationPath: C:\ansible\dsc
+        Attributes: # can also be a comma separated string, e.g. 'Hidden, System'
+        - Hidden
+        - System
+        Ensure: Present
+        Type: Directory
+
+    - name: Call DSC resource with DateTime option
+      ansible.windows.win_dsc:
+        resource_name: DateTimeResource
+        DateTimeOption: '2019-02-22T13:57:31.2311892+00:00'
+
+    # more complex example using custom DSC resource and dict values
+    - name: Setup the xWebAdministration module
+      ansible.windows.win_psmodule:
+        name: xWebAdministration
+        state: present
+
+    - name: Create IIS Website with Binding and Authentication options
+      ansible.windows.win_dsc:
+        resource_name: xWebsite
+        Ensure: Present
+        Name: DSC Website
+        State: Started
+        PhysicalPath: C:\inetpub\wwwroot
+        BindingInfo: # Example of a CimInstance[] DSC parameter (list of dicts)
+        - Protocol: https
+          Port: 1234
+          CertificateStoreName: MY
+          CertificateThumbprint: C676A89018C4D5902353545343634F35E6B3A659
+          HostName: DSCTest
+          IPAddress: '*'
+          SSLFlags: '1'
+        - Protocol: http
+          Port: 4321
+          IPAddress: '*'
+        AuthenticationInfo: # Example of a CimInstance DSC parameter (dict)
+          Anonymous: no
+          Basic: true
+          Digest: false
+          Windows: yes
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>module_version</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The version of the dsc resource/module used.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1.0.1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>reboot_required</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>Flag returned from the DSC engine indicating whether or not the machine requires a reboot for the invoked changes to take effect.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>verbose_set</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>Ansible verbosity is -vvv or greater and a change occurred</td>
+                <td>
+                                                                        <div>The verbose output as a list from executing the DSC Set method.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&quot;Perform operation &#x27;Invoke CimMethod&#x27; with the following parameters, &quot;, &#x27;[SERVER]: LCM: [Start Set ] [[File]DirectResourceAccess]&#x27;, &quot;Operation &#x27;Invoke CimMethod&#x27; complete.&quot;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>verbose_test</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>Ansible verbosity is -vvv or greater</td>
+                <td>
+                                                                        <div>The verbose output as a list from executing the DSC test method.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&quot;Perform operation &#x27;Invoke CimMethod&#x27; with the following parameters, &quot;, &#x27;[SERVER]: LCM: [Start Test ] [[File]DirectResourceAccess]&#x27;, &quot;Operation &#x27;Invoke CimMethod&#x27; complete.&quot;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Trond Hindenes (@trondhindenes)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_environment.rst
+++ b/docs/ansible.windows.win_environment.rst
@@ -1,0 +1,217 @@
+:orphan:
+
+.. _ansible.windows.win_environment_module:
+
+
+*******************************
+ansible.windows.win_environment
+*******************************
+
+**Modify environment variables on windows hosts**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Uses .net Environment to set or remove environment variables and can set at User, Machine or Process level.
+- User level environment variables will be set, but not available until the user has logged off and on again.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>level</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>machine</li>
+                                                                                                                                                                                                <li>process</li>
+                                                                                                                                                                                                <li>user</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>The level at which to set the environment variable.</div>
+                                            <div>Use <code>machine</code> to set for all users.</div>
+                                            <div>Use <code>user</code> to set for the current user that ansible is connected as.</div>
+                                            <div>Use <code>process</code> to set for the current process.  Probably not that useful.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The name of the environment variable.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Set to <code>present</code> to ensure environment variable is set.</div>
+                                            <div>Set to <code>absent</code> to ensure it is removed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>value</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The value to store in the environment variable.</div>
+                                            <div>Must be set when <code>state=present</code> and cannot be an empty string.</div>
+                                            <div>Can be omitted for <code>state=absent</code>.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module is best-suited for setting the entire value of an environment variable. For safe element-based management of path-like environment vars, use the :ref:`ansible.windows.win_path <ansible.windows.win_path_module>` module.
+   - This module does not broadcast change events. This means that the minority of windows applications which can have their environment changed without restarting will not be notified and therefore will need restarting to pick up new environment settings. User level environment variables will require the user to log out and in again before they become available.
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`ansible.windows.win_path_module`
+      The official documentation on the **ansible.windows.win_path** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Set an environment variable for all users
+      ansible.windows.win_environment:
+        state: present
+        name: TestVariable
+        value: Test value
+        level: machine
+
+    - name: Remove an environment variable for the current user
+      ansible.windows.win_environment:
+        state: absent
+        name: TestVariable
+        level: user
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>before_value</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>the value of the environment key before a change, this is null if it didn&#x27;t exist</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">C:\Windows\System32</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>value</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>the value the environment key has been set to, this is null if removed</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">C:\Program Files\jdk1.8</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Jon Hawkesworth (@jhawkesworth)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_feature.rst
+++ b/docs/ansible.windows.win_feature.rst
@@ -1,0 +1,386 @@
+:orphan:
+
+.. _ansible.windows.win_feature_module:
+
+
+***************************
+ansible.windows.win_feature
+***************************
+
+**Installs and uninstalls Windows Features on Windows Server**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Installs or uninstalls Windows Roles or Features on Windows Server.
+- This module uses the Add/Remove-WindowsFeature Cmdlets on Windows 2008 R2 and Install/Uninstall-WindowsFeature Cmdlets on Windows 2012, which are not available on client os machines.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>include_management_tools</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Adds the corresponding management tools to the specified feature.</div>
+                                            <div>Not supported in Windows 2008 R2 and will be ignored.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>include_sub_features</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Adds all subfeatures of the specified feature.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Names of roles or features to install as a single feature or a comma-separated list of features.</div>
+                                            <div>To list all available features use the PowerShell command <code>Get-WindowsFeature</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>source</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Specify a source to install the feature from.</div>
+                                            <div>Not supported in Windows 2008 R2 and will be ignored.</div>
+                                            <div>Can either be <code>{driveletter}:\sources\sxs</code> or <code>\\{IP}\share\sources\sxs</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>State of the features or roles on the system.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`chocolatey.chocolatey.win_chocolatey_module`
+      The official documentation on the **chocolatey.chocolatey.win_chocolatey** module.
+   :ref:`ansible.windows.win_package_module`
+      The official documentation on the **ansible.windows.win_package** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Install IIS (Web-Server only)
+      ansible.windows.win_feature:
+        name: Web-Server
+        state: present
+
+    - name: Install IIS (Web-Server and Web-Common-Http)
+      ansible.windows.win_feature:
+        name:
+        - Web-Server
+        - Web-Common-Http
+        state: present
+
+    - name: Install NET-Framework-Core from file
+      ansible.windows.win_feature:
+        name: NET-Framework-Core
+        source: C:\Temp\iso\sources\sxs
+        state: present
+
+    - name: Install IIS Web-Server with sub features and management tools
+      ansible.windows.win_feature:
+        name: Web-Server
+        state: present
+        include_sub_features: yes
+        include_management_tools: yes
+      register: win_feature
+
+    - name: Reboot if installing Web-Server feature requires it
+      ansible.windows.win_reboot:
+      when: win_feature.reboot_required
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>exitcode</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The stringified exit code from the feature installation/removal command.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Success</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>feature_result</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">complex</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>List of features that were installed or removed.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>display_name</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>Feature display name.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Telnet Client</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>id</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>A list of KB article IDs that apply to the update.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">44</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>message</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                       / <span style="color: purple">elements=string</span>                    </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>Any messages returned from the feature subsystem that occurred during installation or removal of this feature.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>reboot_required</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>True when the target server requires a reboot as a result of installing or removing this feature.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>restart_needed</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>DEPRECATED in Ansible 2.4 (refer to <code>reboot_required</code> instead). True when the target server requires a reboot as a result of installing or removing this feature.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>skip_reason</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The reason a feature installation or removal was skipped.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">NotSkipped</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>success</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>If the feature installation or removal was successful.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>reboot_required</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>True when the target server requires a reboot to complete updates (no further updates can be installed until after a reboot).</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Paul Durivage (@angstwad)
+- Trond Hindenes (@trondhindenes)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_file.rst
+++ b/docs/ansible.windows.win_file.rst
@@ -1,0 +1,142 @@
+:orphan:
+
+.. _ansible.windows.win_file_module:
+
+
+************************
+ansible.windows.win_file
+************************
+
+**Creates, touches or removes files or directories**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Creates (empty) files, updates file modification stamps of existing files, and can create or remove directories.
+- Unlike :ref:`file <file_module>`, does not modify ownership, permissions or manipulate links.
+- For non-Windows targets, use the :ref:`file <file_module>` module instead.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Path to the file being managed.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: dest, name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li>directory</li>
+                                                                                                                                                                                                <li>file</li>
+                                                                                                                                                                                                <li>touch</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>If <code>directory</code>, all immediate subdirectories will be created if they do not exist.</div>
+                                            <div>If <code>file</code>, the file will NOT be created if it does not exist, see the <span class='module'>copy</span> or <span class='module'>template</span> module if you want that behavior.</div>
+                                            <div>If <code>absent</code>, directories will be recursively deleted, and files will be removed.</div>
+                                            <div>If <code>touch</code>, an empty file will be created if the <code>path</code> does not exist, while an existing file or directory will receive updated file access and modification times (similar to the way <code>touch</code> works from the command line).</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`file_module`
+      The official documentation on the **file** module.
+   :ref:`ansible.windows.win_acl_module`
+      The official documentation on the **ansible.windows.win_acl** module.
+   :ref:`ansible.windows.win_acl_inheritance_module`
+      The official documentation on the **ansible.windows.win_acl_inheritance** module.
+   :ref:`ansible.windows.win_owner_module`
+      The official documentation on the **ansible.windows.win_owner** module.
+   :ref:`ansible.windows.win_stat_module`
+      The official documentation on the **ansible.windows.win_stat** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Touch a file (creates if not present, updates modification time if present)
+      ansible.windows.win_file:
+        path: C:\Temp\foo.conf
+        state: touch
+
+    - name: Remove a file, if present
+      ansible.windows.win_file:
+        path: C:\Temp\foo.conf
+        state: absent
+
+    - name: Create directory structure
+      ansible.windows.win_file:
+        path: C:\Temp\folder\subfolder
+        state: directory
+
+    - name: Remove directory structure
+      ansible.windows.win_file:
+        path: C:\Temp
+        state: absent
+
+
+
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Jon Hawkesworth (@jhawkesworth)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_find.rst
+++ b/docs/ansible.windows.win_find.rst
@@ -1,0 +1,892 @@
+:orphan:
+
+.. _ansible.windows.win_find_module:
+
+
+************************
+ansible.windows.win_find
+************************
+
+**Return a list of files based on specific criteria**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Return a list of files based on specified criteria.
+- Multiple criteria are AND'd together.
+- For non-Windows targets, use the :ref:`find <find_module>` module instead.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>age</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Select files or folders whose age is equal to or greater than the specified time.</div>
+                                            <div>Use a negative age to find files equal to or less than the specified time.</div>
+                                            <div>You can choose seconds, minutes, hours, days or weeks by specifying the first letter of an of those words (e.g., &quot;2s&quot;, &quot;10d&quot;, 1w&quot;).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>age_stamp</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>atime</li>
+                                                                                                                                                                                                <li>ctime</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>mtime</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Choose the file property against which we compare <code>age</code>.</div>
+                                            <div>The default attribute we compare with is the last modification time.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>checksum_algorithm</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>md5</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>sha1</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>sha256</li>
+                                                                                                                                                                                                <li>sha384</li>
+                                                                                                                                                                                                <li>sha512</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Algorithm to determine the checksum of a file.</div>
+                                            <div>Will throw an error if the host is unable to use specified algorithm.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>file_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>directory</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>file</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Type of file to search for.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>follow</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Set this to <code>yes</code> to follow symlinks in the path.</div>
+                                            <div>This needs to be used in conjunction with <code>recurse</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>get_checksum</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether to return a checksum of the file in the return info (default sha1), use <code>checksum_algorithm</code> to change from the default.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hidden</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Set this to include hidden files or folders.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>paths</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>                         / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>List of paths of directories to search for files or folders in.</div>
+                                            <div>This can be supplied as a single path or a list of paths.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>patterns</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>One or more (powershell or regex) patterns to compare filenames with.</div>
+                                            <div>The type of pattern matching is controlled by <code>use_regex</code> option.</div>
+                                            <div>The patterns restrict the list of files or folders to be returned based on the filenames.</div>
+                                            <div>For a file to be matched it only has to match with one pattern in a list provided.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: regex, regexp</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>recurse</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Will recursively descend into the directory looking for files or folders.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>size</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Select files or folders whose size is equal to or greater than the specified size.</div>
+                                            <div>Use a negative value to find files equal to or less than the specified size.</div>
+                                            <div>You can specify the size with a suffix of the byte type i.e. kilo = k, mega = m...</div>
+                                            <div>Size is not evaluated for symbolic links.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>use_regex</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Will set patterns to run as a regex check if set to <code>yes</code>.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Find files in path
+      ansible.windows.win_find:
+        paths: D:\Temp
+
+    - name: Find hidden files in path
+      ansible.windows.win_find:
+        paths: D:\Temp
+        hidden: yes
+
+    - name: Find files in multiple paths
+      ansible.windows.win_find:
+        paths:
+        - C:\Temp
+        - D:\Temp
+
+    - name: Find files in directory while searching recursively
+      ansible.windows.win_find:
+        paths: D:\Temp
+        recurse: yes
+
+    - name: Find files in directory while following symlinks
+      ansible.windows.win_find:
+        paths: D:\Temp
+        recurse: yes
+        follow: yes
+
+    - name: Find files with .log and .out extension using powershell wildcards
+      ansible.windows.win_find:
+        paths: D:\Temp
+        patterns: [ '*.log', '*.out' ]
+
+    - name: Find files in path based on regex pattern
+      ansible.windows.win_find:
+        paths: D:\Temp
+        patterns: out_\d{8}-\d{6}.log
+
+    - name: Find files older than 1 day
+      ansible.windows.win_find:
+        paths: D:\Temp
+        age: 86400
+
+    - name: Find files older than 1 day based on create time
+      ansible.windows.win_find:
+        paths: D:\Temp
+        age: 86400
+        age_stamp: ctime
+
+    - name: Find files older than 1 day with unit syntax
+      ansible.windows.win_find:
+        paths: D:\Temp
+        age: 1d
+
+    - name: Find files newer than 1 hour
+      ansible.windows.win_find:
+        paths: D:\Temp
+        age: -3600
+
+    - name: Find files newer than 1 hour with unit syntax
+      ansible.windows.win_find:
+        paths: D:\Temp
+        age: -1h
+
+    - name: Find files larger than 1MB
+      ansible.windows.win_find:
+        paths: D:\Temp
+        size: 1048576
+
+    - name: Find files larger than 1GB with unit syntax
+      ansible.windows.win_find:
+        paths: D:\Temp
+        size: 1g
+
+    - name: Find files smaller than 1MB
+      ansible.windows.win_find:
+        paths: D:\Temp
+        size: -1048576
+
+    - name: Find files smaller than 1GB with unit syntax
+      ansible.windows.win_find:
+        paths: D:\Temp
+        size: -1g
+
+    - name: Find folders/symlinks in multiple paths
+      ansible.windows.win_find:
+        paths:
+        - C:\Temp
+        - D:\Temp
+        file_type: directory
+
+    - name: Find files and return SHA256 checksum of files found
+      ansible.windows.win_find:
+        paths: C:\Temp
+        get_checksum: yes
+        checksum_algorithm: sha256
+
+    - name: Find files and do not return the checksum
+      ansible.windows.win_find:
+        paths: C:\Temp
+        get_checksum: no
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>examined</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The number of files/folders that was checked.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>files</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">complex</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>Information on the files/folders that match the criteria returned as a list of dictionary elements for each file matched. The entries are sorted by the path value alphabetically.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>attributes</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>attributes of the file at path in raw form.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Archive, Hidden</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>checksum</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists, path is a file, get_checksum == True</td>
+                <td>
+                                                                        <div>The checksum of a file based on checksum_algorithm specified.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">09cb79e8fc7453c84a07f644e441fd81623b7f98</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>creationtime</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">float</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>The create time of the file represented in seconds since epoch.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1477984205.15</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>exists</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>Whether the file exists, will always be true for <span class='module'>ansible.windows.win_find</span>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>extension</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists, path is a file</td>
+                <td>
+                                                                        <div>The extension of the file at path.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">.ps1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>filename</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>The name of the file.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">temp</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>hlnk_targets</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>List of other files pointing to the same file (hard links), excludes the current file.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;C:\\temp\\file.txt&#x27;, &#x27;C:\\Windows\\update.log&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>isarchive</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>If the path is ready for archiving or not.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>isdir</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>If the path is a directory or not.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>ishidden</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>If the path is hidden or not.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>isjunction</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>If the path is a junction point.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>islnk</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>If the path is a symbolic link.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>isreadonly</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>If the path is read only or not.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>isreg</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>If the path is a regular file or not.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>isshared</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>If the path is shared or not.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>lastaccesstime</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">float</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>The last access time of the file represented in seconds since epoch.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1477984205.15</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>lastwritetime</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">float</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>The last modification time of the file represented in seconds since epoch.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1477984205.15</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>lnk_source</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists, path is a symbolic link or junction point</td>
+                <td>
+                                                                        <div>The target of the symlink normalized for the remote filesystem.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">C:\temp</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>lnk_target</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists, path is a symbolic link or junction point</td>
+                <td>
+                                                                        <div>The target of the symlink. Note that relative paths remain relative, will return null if not a link.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">temp</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>nlink</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>Number of links to the file (hard links)</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>owner</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>The owner of the file.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BUILTIN\Administrators</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>The full absolute path to the file.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BUILTIN\Administrators</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>sharename</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists, path is a directory and isshared == True</td>
+                <td>
+                                                                        <div>The name of share if folder is shared.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">file-share</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>size</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists, path is a file</td>
+                <td>
+                                                                        <div>The size in bytes of the file.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1024</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>matched</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The number of files/folders that match the criteria.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Jordan Borean (@jborean93)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_get_url.rst
+++ b/docs/ansible.windows.win_get_url.rst
@@ -1,0 +1,709 @@
+:orphan:
+
+.. _ansible.windows.win_get_url_module:
+
+
+***************************
+ansible.windows.win_get_url
+***************************
+
+**Downloads file from HTTP, HTTPS, or FTP to node**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Downloads files from HTTP, HTTPS, or FTP to the remote server.
+- The remote server *must* have direct access to the remote resource.
+- For non-Windows targets, use the :ref:`get_url <get_url_module>` module instead.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>checksum</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>If a <em>checksum</em> is passed to this parameter, the digest of the destination file will be calculated after it is downloaded to ensure its integrity and verify that the transfer completed successfully.</div>
+                                            <div>This option cannot be set with <em>checksum_url</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>checksum_algorithm</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>md5</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>sha1</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>sha256</li>
+                                                                                                                                                                                                <li>sha384</li>
+                                                                                                                                                                                                <li>sha512</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Specifies the hashing algorithm used when calculating the checksum of the remote and destination file.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>checksum_url</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Specifies a URL that contains the checksum values for the resource at <em>url</em>.</div>
+                                            <div>Like <code>checksum</code>, this is used to verify the integrity of the remote transfer.</div>
+                                            <div>This option cannot be set with <em>checksum</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>client_cert</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The path to the client certificate (.pfx) that is used for X509 authentication. This path can either be the path to the <code>pfx</code> on the filesystem or the PowerShell certificate path <code>Cert:\CurrentUser\My\&lt;thumbprint&gt;</code>.</div>
+                                            <div>The WinRM connection must be authenticated with <code>CredSSP</code> or <code>become</code> is used on the task if the certificate file is not password protected.</div>
+                                            <div>Other authentication types can set <em>client_cert_password</em> when the cert is password protected.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>client_cert_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The password for <em>client_cert</em> if the cert is password protected.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dest</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The location to save the file at the URL.</div>
+                                            <div>Be sure to include a filename and extension as appropriate.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>follow_redirects</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>all</li>
+                                                                                                                                                                                                <li>none</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>safe</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether or the module should follow redirects.</div>
+                                            <div><code>all</code> will follow all redirect.</div>
+                                            <div><code>none</code> will not follow any redirect.</div>
+                                            <div><code>safe</code> will follow only &quot;safe&quot; redirects, where &quot;safe&quot; means that the client is only doing a <code>GET</code> or <code>HEAD</code> on the URI to which it is being redirected.</div>
+                                            <div>When following a redirected URL, the <code>Authorization</code> header and any credentials set will be dropped and not redirected.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>force</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>If <code>yes</code>, will download the file every time and replace the file if the contents change. If <code>no</code>, will only download the file if it does not exist or the remote file has been modified more recently than the local file.</div>
+                                            <div>This works by sending an http HEAD request to retrieve last modified time of the requested resource, so for this to work, the remote web server must support HEAD requests.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>force_basic_auth</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>By default the authentication header is only sent when a webservice responses to an initial request with a 401 status. Since some basic auth services do not properly send a 401, logins will fail.</div>
+                                            <div>This option forces the sending of the Basic authentication header upon the original request.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Extra headers to set on the request.</div>
+                                            <div>This should be a dictionary where the key is the header name and the value is the value for that header.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>http_agent</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"ansible-httpget"</div>
+                                    </td>
+                                                                <td>
+                                            <div>Header to identify as, generally appears in web server logs.</div>
+                                            <div>This is set to the <code>User-Agent</code> header on a HTTP request.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>maximum_redirection</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">50</div>
+                                    </td>
+                                                                <td>
+                                            <div>Specify how many times the module will redirect a connection to an alternative URI before the connection fails.</div>
+                                            <div>If set to <code>0</code> or <em>follow_redirects</em> is set to <code>none</code>, or <code>safe</code> when not doing a <code>GET</code> or <code>HEAD</code> it prevents all redirection.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The password for <em>proxy_username</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_url</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>An explicit proxy to use for the request.</div>
+                                            <div>By default, the request will use the IE defined proxy unless <em>use_proxy</em> is set to <code>no</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_use_default_credential</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Uses the current user&#x27;s credentials when authenticating with a proxy host protected with <code>NTLM</code>, <code>Kerberos</code>, or <code>Negotiate</code> authentication.</div>
+                                            <div>Proxies that use <code>Basic</code> auth will still require explicit credentials through the <em>proxy_username</em> and <em>proxy_password</em> options.</div>
+                                            <div>The module will only have access to the user&#x27;s credentials if using <code>become</code> with a password, you are connecting with SSH using a password, or connecting with WinRM using <code>CredSSP</code> or <code>Kerberos with delegation</code>.</div>
+                                            <div>If not using <code>become</code> or a different auth method to the ones stated above, there will be no default credentials available and no proxy authentication will occur.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The username to use for proxy authentication.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>url</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The full URL of a file to download.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>url_method</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The HTTP Method of the request.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: method</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>url_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The password for <em>url_username</em>.</div>
+                                            <div>The alias <em>password</em> is deprecated and will be removed on the major release after <code>2022-07-01</code>.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: password</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>url_timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">30</div>
+                                    </td>
+                                                                <td>
+                                            <div>Specifies how long the request can be pending before it times out (in seconds).</div>
+                                            <div>Set to <code>0</code> to specify an infinite timeout.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: timeout</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>url_username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The username to use for authentication.</div>
+                                            <div>The alias <em>user</em> and <em>username</em> is deprecated and will be removed on the major release after <code>2022-07-01</code>.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: user, username</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>use_default_credential</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Uses the current user&#x27;s credentials when authenticating with a server protected with <code>NTLM</code>, <code>Kerberos</code>, or <code>Negotiate</code> authentication.</div>
+                                            <div>Sites that use <code>Basic</code> auth will still require explicit credentials through the <em>url_username</em> and <em>url_password</em> options.</div>
+                                            <div>The module will only have access to the user&#x27;s credentials if using <code>become</code> with a password, you are connecting with SSH using a password, or connecting with WinRM using <code>CredSSP</code> or <code>Kerberos with delegation</code>.</div>
+                                            <div>If not using <code>become</code> or a different auth method to the ones stated above, there will be no default credentials available and no authentication will occur.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>use_proxy</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>If <code>no</code>, it will not use the proxy defined in IE for the current user.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_certs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>If <code>no</code>, SSL certificates will not be validated.</div>
+                                            <div>This should only be used on personally controlled sites using self-signed certificates.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - If your URL includes an escaped slash character (%2F) this module will convert it to a real slash. This is a result of the behaviour of the System.Uri class as described in `the documentation <https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/network/schemesettings-element-uri-settings#remarks>`_.
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`get_url_module`
+      The official documentation on the **get_url** module.
+   :ref:`uri_module`
+      The official documentation on the **uri** module.
+   :ref:`ansible.windows.win_uri_module`
+      The official documentation on the **ansible.windows.win_uri** module.
+   :ref:`community.windows.win_inet_proxy_module`
+      The official documentation on the **community.windows.win_inet_proxy** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Download earthrise.jpg to specified path
+      ansible.windows.win_get_url:
+        url: http://www.example.com/earthrise.jpg
+        dest: C:\Users\RandomUser\earthrise.jpg
+
+    - name: Download earthrise.jpg to specified path only if modified
+      ansible.windows.win_get_url:
+        url: http://www.example.com/earthrise.jpg
+        dest: C:\Users\RandomUser\earthrise.jpg
+        force: no
+
+    - name: Download earthrise.jpg to specified path through a proxy server.
+      ansible.windows.win_get_url:
+        url: http://www.example.com/earthrise.jpg
+        dest: C:\Users\RandomUser\earthrise.jpg
+        proxy_url: http://10.0.0.1:8080
+        proxy_username: username
+        proxy_password: password
+
+    - name: Download file from FTP with authentication
+      ansible.windows.win_get_url:
+        url: ftp://server/file.txt
+        dest: '%TEMP%\ftp-file.txt'
+        url_username: ftp-user
+        url_password: ftp-password
+
+    - name: Download src with sha256 checksum url
+      ansible.windows.win_get_url:
+        url: http://www.example.com/earthrise.jpg
+        dest: C:\temp\earthrise.jpg
+        checksum_url: http://www.example.com/sha256sum.txt
+        checksum_algorithm: sha256
+        force: True
+
+    - name: Download src with sha256 checksum url
+      ansible.windows.win_get_url:
+        url: http://www.example.com/earthrise.jpg
+        dest: C:\temp\earthrise.jpg
+        checksum: a97e6837f60cec6da4491bab387296bbcd72bdba
+        checksum_algorithm: sha1
+        force: True
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>checksum_dest</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success and dest has been downloaded</td>
+                <td>
+                                                                        <div>&lt;algorithm&gt; checksum of the file after the download</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">6e642bb8dd5c2e027bf21dd923337cbb4214f827</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>checksum_src</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>force=yes or dest did not exist</td>
+                <td>
+                                                                        <div>&lt;algorithm&gt; checksum of the remote resource</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">6e642bb8dd5c2e027bf21dd923337cbb4214f827</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>dest</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>destination file/path</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">C:\Users\RandomUser\earthrise.jpg</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>elapsed</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">float</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The elapsed seconds between the start of poll and the end of the module.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2.1406487</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>msg</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>Error message, or HTTP status message from web-server</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">OK</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>size</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>size of the dest file</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1220</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>status_code</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>HTTP status code</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">200</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>url</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>requested url</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">http://www.example.com/earthrise.jpg</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Paul Durivage (@angstwad)
+- Takeshi Kuramochi (@tksarah)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_group.rst
+++ b/docs/ansible.windows.win_group.rst
@@ -1,0 +1,137 @@
+:orphan:
+
+.. _ansible.windows.win_group_module:
+
+
+*************************
+ansible.windows.win_group
+*************************
+
+**Add and remove local groups**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Add and remove local groups.
+- For non-Windows targets, please use the :ref:`group <group_module>` module instead.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>description</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Description of the group.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Name of the group.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Create or remove the group.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`group_module`
+      The official documentation on the **group** module.
+   :ref:`community.windows.win_domain_group_module`
+      The official documentation on the **community.windows.win_domain_group** module.
+   :ref:`ansible.windows.win_group_membership_module`
+      The official documentation on the **ansible.windows.win_group_membership** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Create a new group
+      ansible.windows.win_group:
+        name: deploy
+        description: Deploy Group
+        state: present
+
+    - name: Remove a group
+      ansible.windows.win_group:
+        name: deploy
+        state: absent
+
+
+
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Chris Hoffman (@chrishoffman)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_group_membership.rst
+++ b/docs/ansible.windows.win_group_membership.rst
@@ -1,0 +1,237 @@
+:orphan:
+
+.. _ansible.windows.win_group_membership_module:
+
+
+************************************
+ansible.windows.win_group_membership
+************************************
+
+**Manage Windows local group membership**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Allows the addition and removal of local, service and domain users, and domain groups from a local group.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>members</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A list of members to ensure are present/absent from the group.</div>
+                                            <div>Accepts local users as .\username, and SERVERNAME\username.</div>
+                                            <div>Accepts domain users and groups as DOMAIN\username and username@DOMAIN.</div>
+                                            <div>Accepts service users as NT AUTHORITY\username.</div>
+                                            <div>Accepts all local, domain and service user types as username, favoring domain lookups when in a domain.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Name of the local group to manage membership on.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>pure</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Desired state of the members in the group.</div>
+                                            <div>When <code>state</code> is <code>pure</code>, only the members specified will exist, and all other existing members not specified are removed.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`community.windows.win_domain_group_module`
+      The official documentation on the **community.windows.win_domain_group** module.
+   :ref:`ansible.windows.win_domain_membership_module`
+      The official documentation on the **ansible.windows.win_domain_membership** module.
+   :ref:`ansible.windows.win_group_module`
+      The official documentation on the **ansible.windows.win_group** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Add a local and domain user to a local group
+      ansible.windows.win_group_membership:
+        name: Remote Desktop Users
+        members:
+          - NewLocalAdmin
+          - DOMAIN\TestUser
+        state: present
+
+    - name: Remove a domain group and service user from a local group
+      ansible.windows.win_group_membership:
+        name: Backup Operators
+        members:
+          - DOMAIN\TestGroup
+          - NT AUTHORITY\SYSTEM
+        state: absent
+
+    - name: Ensure only a domain user exists in a local group
+      ansible.windows.win_group_membership:
+        name: Remote Desktop Users
+        members:
+          - DOMAIN\TestUser
+        state: pure
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>added</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>success and <code>state</code> is <code>present</code></td>
+                <td>
+                                                                        <div>A list of members added when <code>state</code> is <code>present</code> or <code>pure</code>; this is empty if no members are added.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;SERVERNAME\\NewLocalAdmin&#x27;, &#x27;DOMAIN\\TestUser&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>members</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>A list of all local group members at completion; this is empty if the group contains no members.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;DOMAIN\\TestUser&#x27;, &#x27;SERVERNAME\\NewLocalAdmin&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The name of the target local group.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Administrators</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>removed</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>success and <code>state</code> is <code>absent</code></td>
+                <td>
+                                                                        <div>A list of members removed when <code>state</code> is <code>absent</code> or <code>pure</code>; this is empty if no members are removed.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;DOMAIN\\TestGroup&#x27;, &#x27;NT AUTHORITY\\SYSTEM&#x27;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Andrew Saraceni (@andrewsaraceni)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_hostname.rst
+++ b/docs/ansible.windows.win_hostname.rst
@@ -1,0 +1,146 @@
+:orphan:
+
+.. _ansible.windows.win_hostname_module:
+
+
+****************************
+ansible.windows.win_hostname
+****************************
+
+**Manages local Windows computer name**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Manages local Windows computer name.
+- A reboot is required for the computer name to take effect.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The hostname to set for the computer.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`ansible.windows.win_dns_client_module`
+      The official documentation on the **ansible.windows.win_dns_client** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Change the hostname to sample-hostname
+      ansible.windows.win_hostname:
+        name: sample-hostname
+      register: res
+
+    - name: Reboot
+      ansible.windows.win_reboot:
+      when: res.reboot_required
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>old_name</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The original hostname that was set before it was changed.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">old_hostname</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>reboot_required</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>Whether a reboot is required to complete the hostname change.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Ripon Banik (@riponbanik)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_optional_feature.rst
+++ b/docs/ansible.windows.win_optional_feature.rst
@@ -1,0 +1,208 @@
+:orphan:
+
+.. _ansible.windows.win_optional_feature_module:
+
+
+************************************
+ansible.windows.win_optional_feature
+************************************
+
+**Manage optional Windows features**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Install or uninstall optional Windows features on non-Server Windows.
+- This module uses the ``Enable-WindowsOptionalFeature`` and ``Disable-WindowsOptionalFeature`` cmdlets.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>include_parent</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether to enable the parent feature and the parent&#x27;s dependencies.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>                         / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The name(s) of the feature to install.</div>
+                                            <div>This relates to <code>FeatureName</code> in the Powershell cmdlet.</div>
+                                            <div>To list all available features use the PowerShell command <code>Get-WindowsOptionalFeature</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>source</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Specify a source to install the feature from.</div>
+                                            <div>Can either be <code>{driveletter}:\sources\sxs</code> or <code>\\{IP}\share\sources\sxs</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether to ensure the feature is absent or present on the system.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`chocolatey.chocolatey.win_chocolatey_module`
+      The official documentation on the **chocolatey.chocolatey.win_chocolatey** module.
+   :ref:`ansible.windows.win_feature_module`
+      The official documentation on the **ansible.windows.win_feature** module.
+   :ref:`ansible.windows.win_package_module`
+      The official documentation on the **ansible.windows.win_package** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Install .Net 3.5
+      ansible.windows.win_optional_feature:
+        name: NetFx3
+        state: present
+
+    - name: Install .Net 3.5 from source
+      ansible.windows.win_optional_feature:
+        name: NetFx3
+        source: \\share01\win10\sources\sxs
+        state: present
+
+    - name: Install Microsoft Subsystem for Linux
+      ansible.windows.win_optional_feature:
+        name: Microsoft-Windows-Subsystem-Linux
+        state: present
+      register: wsl_status
+
+    - name: Reboot if installing Linux Subsytem as feature requires it
+      ansible.windows.win_reboot:
+      when: wsl_status.reboot_required
+
+    - name: Install multiple features in one task
+      ansible.windows.win_optional_feature:
+        name:
+        - NetFx3
+        - Microsoft-Windows-Subsystem-Linux
+        state: present
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>reboot_required</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>True when the target server requires a reboot to complete updates</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Carson Anderson (@rcanderson23)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_owner.rst
+++ b/docs/ansible.windows.win_owner.rst
@@ -1,0 +1,137 @@
+:orphan:
+
+.. _ansible.windows.win_owner_module:
+
+
+*************************
+ansible.windows.win_owner
+*************************
+
+**Set owner**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Set owner of files or directories.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Path to be used for changing owner.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>recurse</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Indicates if the owner should be changed recursively.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>user</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Name to be used for changing owner.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`ansible.windows.win_acl_module`
+      The official documentation on the **ansible.windows.win_acl** module.
+   :ref:`ansible.windows.win_file_module`
+      The official documentation on the **ansible.windows.win_file** module.
+   :ref:`ansible.windows.win_stat_module`
+      The official documentation on the **ansible.windows.win_stat** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Change owner of path
+      ansible.windows.win_owner:
+        path: C:\apache
+        user: apache
+        recurse: yes
+
+    - name: Set the owner of root directory
+      ansible.windows.win_owner:
+        path: C:\apache
+        user: SYSTEM
+        recurse: no
+
+
+
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Hans-Joachim Kliemeck (@h0nIg)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_package.rst
+++ b/docs/ansible.windows.win_package.rst
@@ -1,0 +1,861 @@
+:orphan:
+
+.. _ansible.windows.win_package_module:
+
+
+***************************
+ansible.windows.win_package
+***************************
+
+**Installs/uninstalls an installable package**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Installs or uninstalls software packages for Windows.
+- Supports ``.exe``, ``.msi``, ``.msp``, ``.appx``, ``.appxbundle``, ``.msix``, and ``.msixbundle``.
+- These packages can be sourced from the local file system, network file share or a url.
+- See *provider* for more info on each package type that is supported.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>arguments</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">raw</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Any arguments the installer needs to either install or uninstall the package.</div>
+                                            <div>If the package is an MSI do not supply the <code>/qn</code>, <code>/log</code> or <code>/norestart</code> arguments.</div>
+                                            <div>This is only used for the <code>msi</code>, <code>msp</code>, and <code>registry</code> providers.</div>
+                                            <div>Can be a list of arguments and the module will escape the arguments as necessary, it is recommended to use a string when dealing with MSI packages due to the unique escaping issues with msiexec.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>chdir</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Set the specified path as the current working directory before installing or uninstalling a package.</div>
+                                            <div>This is only used for the <code>msi</code>, <code>msp</code>, and <code>registry</code> providers.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>client_cert</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The path to the client certificate (.pfx) that is used for X509 authentication. This path can either be the path to the <code>pfx</code> on the filesystem or the PowerShell certificate path <code>Cert:\CurrentUser\My\&lt;thumbprint&gt;</code>.</div>
+                                            <div>The WinRM connection must be authenticated with <code>CredSSP</code> or <code>become</code> is used on the task if the certificate file is not password protected.</div>
+                                            <div>Other authentication types can set <em>client_cert_password</em> when the cert is password protected.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>client_cert_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The password for <em>client_cert</em> if the cert is password protected.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>creates_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Will check the existence of the path specified and use the result to determine whether the package is already installed.</div>
+                                            <div>You can use this in conjunction with <code>product_id</code> and other <code>creates_*</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>creates_service</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Will check the existing of the service specified and use the result to determine whether the package is already installed.</div>
+                                            <div>You can use this in conjunction with <code>product_id</code> and other <code>creates_*</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>creates_version</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Will check the file version property of the file at <code>creates_path</code> and use the result to determine whether the package is already installed.</div>
+                                            <div><code>creates_path</code> MUST be set and is a file.</div>
+                                            <div>You can use this in conjunction with <code>product_id</code> and other <code>creates_*</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>expected_return_code</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=integer</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">[0, 3010]</div>
+                                    </td>
+                                                                <td>
+                                            <div>One or more return codes from the package installation that indicates success.</div>
+                                            <div>The return codes are read as a signed integer, any values greater than 2147483647 need to be represented as the signed equivalent, i.e. <code>4294967295</code> is <code>-1</code>.</div>
+                                            <div>To convert a unsigned number to the signed equivalent you can run &quot;[Int32](&quot;0x{0:X}&quot; -f ([UInt32]3221225477))&quot;.</div>
+                                            <div>A return code of <code>3010</code> usually means that a reboot is required, the <code>reboot_required</code> return value is set if the return code is <code>3010</code>.</div>
+                                            <div>This is only used for the <code>msi</code>, <code>msp</code>, and <code>registry</code> providers.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>follow_redirects</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>all</li>
+                                                                                                                                                                                                <li>none</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>safe</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether or the module should follow redirects.</div>
+                                            <div><code>all</code> will follow all redirect.</div>
+                                            <div><code>none</code> will not follow any redirect.</div>
+                                            <div><code>safe</code> will follow only &quot;safe&quot; redirects, where &quot;safe&quot; means that the client is only doing a <code>GET</code> or <code>HEAD</code> on the URI to which it is being redirected.</div>
+                                            <div>When following a redirected URL, the <code>Authorization</code> header and any credentials set will be dropped and not redirected.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>force_basic_auth</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>By default the authentication header is only sent when a webservice responses to an initial request with a 401 status. Since some basic auth services do not properly send a 401, logins will fail.</div>
+                                            <div>This option forces the sending of the Basic authentication header upon the original request.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Extra headers to set on the request.</div>
+                                            <div>This should be a dictionary where the key is the header name and the value is the value for that header.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>http_agent</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"ansible-httpget"</div>
+                                    </td>
+                                                                <td>
+                                            <div>Header to identify as, generally appears in web server logs.</div>
+                                            <div>This is set to the <code>User-Agent</code> header on a HTTP request.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>log_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Specifies the path to a log file that is persisted after a package is installed or uninstalled.</div>
+                                            <div>This is only used for the <code>msi</code> or <code>msp</code> provider.</div>
+                                            <div>When omitted, a temporary log file is used instead for those providers.</div>
+                                            <div>This is only valid for MSI files, use <code>arguments</code> for the <code>registry</code> provider.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>maximum_redirection</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">50</div>
+                                    </td>
+                                                                <td>
+                                            <div>Specify how many times the module will redirect a connection to an alternative URI before the connection fails.</div>
+                                            <div>If set to <code>0</code> or <em>follow_redirects</em> is set to <code>none</code>, or <code>safe</code> when not doing a <code>GET</code> or <code>HEAD</code> it prevents all redirection.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The password for <code>user_name</code>, must be set when <code>user_name</code> is.</div>
+                                            <div>This option is deprecated in favour of using become, see examples for more information. Will be removed on the major release after <code>2022-07-01</code>.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: user_password</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Location of the package to be installed or uninstalled.</div>
+                                            <div>This package can either be on the local file system, network share or a url.</div>
+                                            <div>When <code>state=present</code>, <code>product_id</code> is not set and the path is a URL, this file will always be downloaded to a temporary directory for idempotency checks, otherwise the file will only be downloaded if the package has not been installed based on the <code>product_id</code> checks.</div>
+                                            <div>If <code>state=present</code> then this value MUST be set.</div>
+                                            <div>If <code>state=absent</code> then this value does not need to be set if <code>product_id</code> is.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>product_id</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The product id of the installed packaged.</div>
+                                            <div>This is used for checking whether the product is already installed and getting the uninstall information if <code>state=absent</code>.</div>
+                                            <div>For msi packages, this is the <code>ProductCode</code> (GUID) of the package. This can be found under the same registry paths as the <code>registry</code> provider.</div>
+                                            <div>For msp packages, this is the <code>PatchCode</code> (GUID) of the package which can found under the <code>Details -&gt; Revision number</code> of the file&#x27;s properties.</div>
+                                            <div>For msix packages, this is the <code>Name</code> or <code>PackageFullName</code> of the package found under the <code>Get-AppxPackage</code> cmdlet.</div>
+                                            <div>For registry (exe) packages, this is the registry key name under the registry paths specified in <em>provider</em>.</div>
+                                            <div>This value is ignored if <code>path</code> is set to a local accesible file path and the package is not an <code>exe</code>.</div>
+                                            <div>This SHOULD be set when the package is an <code>exe</code>, or the path is a url or a network share and credential delegation is not being used. The <code>creates_*</code> options can be used instead but is not recommended.</div>
+                                            <div>The alias <em>productid</em> is deprecated and will be removed on the major release after <code>2022-07-01</code>.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: productid</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>auto</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>msi</li>
+                                                                                                                                                                                                <li>msix</li>
+                                                                                                                                                                                                <li>msp</li>
+                                                                                                                                                                                                <li>registry</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Set the package provider to use when searching for a package.</div>
+                                            <div>The <code>auto</code> provider will select the proper provider if <em>path</em> otherwise it scans all the other providers based on the <em>product_id</em>.</div>
+                                            <div>The <code>msi</code> provider scans for MSI packages installed on a machine wide and current user context based on the <code>ProductCode</code> of the MSI.</div>
+                                            <div>The <code>msix</code> provider is used to install <code>.appx</code>, <code>.msix</code>, <code>.appxbundle</code>, or <code>.msixbundle</code> packages. These packages are only installed or removed on the current use. The host must be set to allow sideloaded apps or in developer mode. See the examples for how to enable this. If a package is already installed but <code>path</code> points to an updated package, this will be installed over the top of the existing one.</div>
+                                            <div>The <code>msp</code> provider scans for all MSP patches installed on a machine wide and current user context based on the <code>PatchCode</code> of the MSP. A <code>msp</code> will be applied or removed on all <code>msi</code> products that it applies to and is installed. If the patch is obsoleted or superseded then no action will be taken.</div>
+                                            <div>The <code>registry</code> provider is used for traditional <code>exe</code> installers and uses the following registry path to determine if a product was installed; <code>HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall</code>, <code>HKLM:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall</code>, <code>HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall</code>, and <code>HKCU:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The password for <em>proxy_username</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_url</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>An explicit proxy to use for the request.</div>
+                                            <div>By default, the request will use the IE defined proxy unless <em>use_proxy</em> is set to <code>no</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_use_default_credential</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Uses the current user&#x27;s credentials when authenticating with a proxy host protected with <code>NTLM</code>, <code>Kerberos</code>, or <code>Negotiate</code> authentication.</div>
+                                            <div>Proxies that use <code>Basic</code> auth will still require explicit credentials through the <em>proxy_username</em> and <em>proxy_password</em> options.</div>
+                                            <div>The module will only have access to the user&#x27;s credentials if using <code>become</code> with a password, you are connecting with SSH using a password, or connecting with WinRM using <code>CredSSP</code> or <code>Kerberos with delegation</code>.</div>
+                                            <div>If not using <code>become</code> or a different auth method to the ones stated above, there will be no default credentials available and no proxy authentication will occur.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The username to use for proxy authentication.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether to install or uninstall the package.</div>
+                                            <div>The module uses <em>product_id</em> to determine whether the package is installed or not.</div>
+                                            <div>For all providers but <code>auto</code>, the <em>path</em> can be used for idempotency checks if it is locally accesible filesystem path.</div>
+                                            <div>The alias <em>ensure</em> is deprecated and will be removed on the major release after <code>2022-07-01</code>.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: ensure</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>url_method</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The HTTP Method of the request.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>url_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The password for <em>url_username</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>url_timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">30</div>
+                                    </td>
+                                                                <td>
+                                            <div>Specifies how long the request can be pending before it times out (in seconds).</div>
+                                            <div>Set to <code>0</code> to specify an infinite timeout.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>url_username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The username to use for authentication.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>use_default_credential</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Uses the current user&#x27;s credentials when authenticating with a server protected with <code>NTLM</code>, <code>Kerberos</code>, or <code>Negotiate</code> authentication.</div>
+                                            <div>Sites that use <code>Basic</code> auth will still require explicit credentials through the <em>url_username</em> and <em>url_password</em> options.</div>
+                                            <div>The module will only have access to the user&#x27;s credentials if using <code>become</code> with a password, you are connecting with SSH using a password, or connecting with WinRM using <code>CredSSP</code> or <code>Kerberos with delegation</code>.</div>
+                                            <div>If not using <code>become</code> or a different auth method to the ones stated above, there will be no default credentials available and no authentication will occur.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>use_proxy</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>If <code>no</code>, it will not use the proxy defined in IE for the current user.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Username of an account with access to the package if it is located on a file share.</div>
+                                            <div>This is only needed if the WinRM transport is over an auth method that does not support credential delegation like Basic or NTLM or become is not used.</div>
+                                            <div>This option is deprecated in favour of using become, see examples for more information. Will be removed on the major release after <code>2022-07-01</code>.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: user_name</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_certs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>If <code>no</code>, SSL certificates will not be validated.</div>
+                                            <div>This should only be used on personally controlled sites using self-signed certificates.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - When ``state=absent`` and the product is an exe, the path may be different from what was used to install the package originally. If path is not set then the path used will be what is set under ``QuietUninstallString`` or ``UninstallString`` in the registry for that *product_id*.
+   - By default all msi installs and uninstalls will be run with the arguments ``/log, /qn, /norestart``.
+   - All the installation checks under ``product_id`` and ``creates_*`` add together, if one fails then the program is considered to be absent.
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`chocolatey.chocolatey.win_chocolatey_module`
+      The official documentation on the **chocolatey.chocolatey.win_chocolatey** module.
+   :ref:`community.windows.win_hotfix_module`
+      The official documentation on the **community.windows.win_hotfix** module.
+   :ref:`ansible.windows.win_updates_module`
+      The official documentation on the **ansible.windows.win_updates** module.
+   :ref:`community.windows.win_inet_proxy_module`
+      The official documentation on the **community.windows.win_inet_proxy** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Install the Visual C thingy
+      ansible.windows.win_package:
+        path: http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe
+        product_id: '{CF2BEA3C-26EA-32F8-AA9B-331F7E34BA97}'
+        arguments: /install /passive /norestart
+
+    - name: Install Visual C thingy with list of arguments instead of a string
+      ansible.windows.win_package:
+        path: http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe
+        product_id: '{CF2BEA3C-26EA-32F8-AA9B-331F7E34BA97}'
+        arguments:
+        - /install
+        - /passive
+        - /norestart
+
+    - name: Install Remote Desktop Connection Manager from msi with a permanent log
+      ansible.windows.win_package:
+        path: https://download.microsoft.com/download/A/F/0/AF0071F3-B198-4A35-AA90-C68D103BDCCF/rdcman.msi
+        product_id: '{0240359E-6A4C-4884-9E94-B397A02D893C}'
+        state: present
+        log_path: D:\logs\vcredist_x64-exe-{{lookup('pipe', 'date +%Y%m%dT%H%M%S')}}.log
+
+    - name: Uninstall Remote Desktop Connection Manager
+      ansible.windows.win_package:
+        product_id: '{0240359E-6A4C-4884-9E94-B397A02D893C}'
+        state: absent
+
+    - name: Install Remote Desktop Connection Manager locally omitting the product_id
+      ansible.windows.win_package:
+        path: C:\temp\rdcman.msi
+        state: present
+
+    - name: Uninstall Remote Desktop Connection Manager from local MSI omitting the product_id
+      ansible.windows.win_package:
+        path: C:\temp\rdcman.msi
+        state: absent
+
+    # 7-Zip exe doesn't use a guid for the Product ID
+    - name: Install 7zip from a network share with specific credentials
+      ansible.windows.win_package:
+        path: \\domain\programs\7z.exe
+        product_id: 7-Zip
+        arguments: /S
+        state: present
+      become: yes
+      become_method: runas
+      become_flags: logon_type=new_credential logon_flags=netcredentials_only
+      vars:
+        ansible_become_user: DOMAIN\User
+        ansible_become_password: Password
+
+    - name: Install 7zip and use a file version for the installation check
+      ansible.windows.win_package:
+        path: C:\temp\7z.exe
+        creates_path: C:\Program Files\7-Zip\7z.exe
+        creates_version: 16.04
+        state: present
+
+    - name: Uninstall 7zip from the exe
+      ansible.windows.win_package:
+        path: C:\Program Files\7-Zip\Uninstall.exe
+        product_id: 7-Zip
+        arguments: /S
+        state: absent
+
+    - name: Uninstall 7zip without specifying the path
+      ansible.windows.win_package:
+        product_id: 7-Zip
+        arguments: /S
+        state: absent
+
+    - name: Install application and override expected return codes
+      ansible.windows.win_package:
+        path: https://download.microsoft.com/download/1/6/7/167F0D79-9317-48AE-AEDB-17120579F8E2/NDP451-KB2858728-x86-x64-AllOS-ENU.exe
+        product_id: '{7DEBE4EB-6B40-3766-BB35-5CBBC385DA37}'
+        arguments: '/q /norestart'
+        state: present
+        expected_return_code: [0, 666, 3010]
+
+    - name: Install a .msp patch
+      ansible.windows.win_package:
+        path: C:\Patches\Product.msp
+        state: present
+
+    - name: Remove a .msp patch
+      ansible.windows.win_package:
+        product_id: '{AC76BA86-A440-FFFF-A440-0C13154E5D00}'
+        state: absent
+
+    - name: Enable installation of 3rd party MSIX packages
+      ansible.windows.win_regedit:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock
+        name: AllowAllTrustedApps
+        data: 1
+        type: dword
+        state: present
+
+    - name: Install an MSIX package for the current user
+      ansible.windows.win_package:
+        path: C:\Installers\Calculator.msix  # Can be .appx, .msixbundle, or .appxbundle
+        state: present
+
+    - name: Uninstall an MSIX package using the product_id
+      ansible.windows.win_package:
+        product_id: InputApp
+        state: absent
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>log</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>installation/uninstallation failure for MSI or MSP packages</td>
+                <td>
+                                                                        <div>The contents of the MSI or MSP log.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Installation completed successfully</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>rc</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>change occurred</td>
+                <td>
+                                                                        <div>The return code of the package process.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>reboot_required</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>Whether a reboot is required to finalise package. This is set to true if the executable return code is 3010.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>stderr</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>failure during install or uninstall</td>
+                <td>
+                                                                        <div>The stderr stream of the package process.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Failed to install program</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>stdout</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>failure during install or uninstall</td>
+                <td>
+                                                                        <div>The stdout stream of the package process.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Installing program</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Trond Hindenes (@trondhindenes)
+- Jordan Borean (@jborean93)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_path.rst
+++ b/docs/ansible.windows.win_path.rst
@@ -1,0 +1,167 @@
+:orphan:
+
+.. _ansible.windows.win_path_module:
+
+
+************************
+ansible.windows.win_path
+************************
+
+**Manage Windows path environment variables**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Allows element-based ordering, addition, and removal of Windows path environment variables.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>elements</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A single path element, or a list of path elements (ie, directories) to add or remove.</div>
+                                            <div>When multiple elements are included in the list (and <code>state</code> is <code>present</code>), the elements are guaranteed to appear in the same relative order in the resultant path value.</div>
+                                            <div>Variable expansions (eg, <code>%VARNAME%</code>) are allowed, and are stored unexpanded in the target path element.</div>
+                                            <div>Any existing path elements not mentioned in <code>elements</code> are always preserved in their current order.</div>
+                                            <div>New path elements are appended to the path, and existing path elements may be moved closer to the end to satisfy the requested ordering.</div>
+                                            <div>Paths are compared in a case-insensitive fashion, and trailing backslashes are ignored for comparison purposes. However, note that trailing backslashes in YAML require quotes.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"PATH"</div>
+                                    </td>
+                                                                <td>
+                                            <div>Target path environment variable name.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>scope</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>machine</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>user</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>The level at which the environment variable specified by <code>name</code> should be managed (either for the current user or global machine scope).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li>present</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether the path elements specified in <code>elements</code> should be present or absent.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module is for modifying individual elements of path-like environment variables. For general-purpose management of other environment vars, use the :ref:`ansible.windows.win_environment <ansible.windows.win_environment_module>` module.
+   - This module does not broadcast change events. This means that the minority of windows applications which can have their environment changed without restarting will not be notified and therefore will need restarting to pick up new environment settings.
+   - User level environment variables will require an interactive user to log out and in again before they become available.
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`ansible.windows.win_environment_module`
+      The official documentation on the **ansible.windows.win_environment** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Ensure that system32 and Powershell are present on the global system path, and in the specified order
+      ansible.windows.win_path:
+        elements:
+        - '%SystemRoot%\system32'
+        - '%SystemRoot%\system32\WindowsPowerShell\v1.0'
+
+    - name: Ensure that C:\Program Files\MyJavaThing is not on the current user's CLASSPATH
+      ansible.windows.win_path:
+        name: CLASSPATH
+        elements: C:\Program Files\MyJavaThing
+        scope: user
+        state: absent
+
+
+
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Matt Davis (@nitzmahone)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_ping.rst
+++ b/docs/ansible.windows.win_ping.rst
@@ -1,0 +1,134 @@
+:orphan:
+
+.. _ansible.windows.win_ping_module:
+
+
+************************
+ansible.windows.win_ping
+************************
+
+**A windows version of the classic ping module**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Checks management connectivity of a windows host.
+- This is NOT ICMP ping, this is just a trivial test module.
+- For non-Windows targets, use the :ref:`ping <ping_module>` module instead.
+- For Network targets, use the :ref:`net_ping <net_ping_module>` module instead.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>data</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"pong"</div>
+                                    </td>
+                                                                <td>
+                                            <div>Alternate data to return instead of &#x27;pong&#x27;.</div>
+                                            <div>If this parameter is set to <code>crash</code>, the module will cause an exception.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`ping_module`
+      The official documentation on the **ping** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    # Test connectivity to a windows host
+    # ansible winserver -m ansible.windows.win_ping
+
+    - name: Example from an Ansible Playbook
+      ansible.windows.win_ping:
+
+    - name: Induce an exception to see what happens
+      ansible.windows.win_ping:
+        data: crash
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>ping</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>Value provided with the data parameter.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">pong</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Chris Church (@cchurch)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_reboot.rst
+++ b/docs/ansible.windows.win_reboot.rst
@@ -1,0 +1,283 @@
+:orphan:
+
+.. _ansible.windows.win_reboot_module:
+
+
+**************************
+ansible.windows.win_reboot
+**************************
+
+**Reboot a windows machine**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Reboot a Windows machine, wait for it to go down, come back up, and respond to commands.
+- For non-Windows targets, use the :ref:`reboot <reboot_module>` module instead.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>boot_time_command</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"(Get-WmiObject -ClassName Win32_OperatingSystem).LastBootUpTime"</div>
+                                    </td>
+                                                                <td>
+                                            <div>Command to run that returns a unique string indicating the last time the system was booted.</div>
+                                            <div>Setting this to a command that has different output each time it is run will cause the task to fail.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>connect_timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">5</div>
+                                    </td>
+                                                                <td>
+                                            <div>Maximum seconds to wait for a single successful TCP connection to the WinRM endpoint before trying again.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: connect_timeout_sec</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>msg</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"Reboot initiated by Ansible"</div>
+                                    </td>
+                                                                <td>
+                                            <div>Message to display to users.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>post_reboot_delay</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">0</div>
+                                    </td>
+                                                                <td>
+                                            <div>Seconds to wait after the reboot command was successful before attempting to validate the system rebooted successfully.</div>
+                                            <div>This is useful if you want wait for something to settle despite your connection already working.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: post_reboot_delay_sec</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>pre_reboot_delay</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">2</div>
+                                    </td>
+                                                                <td>
+                                            <div>Seconds to wait before reboot. Passed as a parameter to the reboot command.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: pre_reboot_delay_sec</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>reboot_timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">600</div>
+                                    </td>
+                                                                <td>
+                                            <div>Maximum seconds to wait for machine to re-appear on the network and respond to a test command.</div>
+                                            <div>This timeout is evaluated separately for both reboot verification and test command success so maximum clock time is actually twice this value.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: reboot_timeout_sec</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>test_command</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"whoami"</div>
+                                    </td>
+                                                                <td>
+                                            <div>Command to expect success for to determine the machine is ready for management.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - If a shutdown was already scheduled on the system, :ref:`ansible.windows.win_reboot <ansible.windows.win_reboot_module>` will abort the scheduled shutdown and enforce its own shutdown.
+   - Beware that when :ref:`ansible.windows.win_reboot <ansible.windows.win_reboot_module>` returns, the Windows system may not have settled yet and some base services could be in limbo. This can result in unexpected behavior. Check the examples for ways to mitigate this.
+   - The connection user must have the ``SeRemoteShutdownPrivilege`` privilege enabled, see https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/force-shutdown-from-a-remote-system for more information.
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`reboot_module`
+      The official documentation on the **reboot** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Reboot the machine with all defaults
+      ansible.windows.win_reboot:
+
+    - name: Reboot a slow machine that might have lots of updates to apply
+      ansible.windows.win_reboot:
+        reboot_timeout: 3600
+
+    # Install a Windows feature and reboot if necessary
+    - name: Install IIS Web-Server
+      ansible.windows.win_feature:
+        name: Web-Server
+      register: iis_install
+
+    - name: Reboot when Web-Server feature requires it
+      ansible.windows.win_reboot:
+      when: iis_install.reboot_required
+
+    # One way to ensure the system is reliable, is to set WinRM to a delayed startup
+    - name: Ensure WinRM starts when the system has settled and is ready to work reliably
+      ansible.windows.win_service:
+        name: WinRM
+        start_mode: delayed
+
+
+    # Additionally, you can add a delay before running the next task
+    - name: Reboot a machine that takes time to settle after being booted
+      ansible.windows.win_reboot:
+        post_reboot_delay: 120
+
+    # Or you can make win_reboot validate exactly what you need to work before running the next task
+    - name: Validate that the netlogon service has started, before running the next task
+      ansible.windows.win_reboot:
+        test_command: 'exit (Get-Service -Name Netlogon).Status -ne "Running"'
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>elapsed</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">float</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The number of seconds that elapsed waiting for the system to be rebooted.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">23.2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>rebooted</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>True if the machine was rebooted.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Matt Davis (@nitzmahone)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_reg_stat.rst
+++ b/docs/ansible.windows.win_reg_stat.rst
@@ -1,0 +1,266 @@
+:orphan:
+
+.. _ansible.windows.win_reg_stat_module:
+
+
+****************************
+ansible.windows.win_reg_stat
+****************************
+
+**Get information about Windows registry keys**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Like :ref:`ansible.windows.win_file <ansible.windows.win_file_module>`, :ref:`ansible.windows.win_reg_stat <ansible.windows.win_reg_stat_module>` will return whether the key/property exists.
+- It also returns the sub keys and properties of the key specified.
+- If specifying a property name through *property*, it will return the information specific for that property.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The registry property name to get information for, the return json will not include the sub_keys and properties entries for the <em>key</em> specified.</div>
+                                            <div>Set to an empty string to target the registry key&#x27;s <code>(Default</code>) property value.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: entry, value, property</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The full registry key path including the hive to search for.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: key</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - The ``properties`` return value will contain an empty string key ``""`` that refers to the key's ``Default`` value. If the value has not been set then this key is not returned.
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`ansible.windows.win_regedit_module`
+      The official documentation on the **ansible.windows.win_regedit** module.
+   :ref:`ansible.windows.win_regmerge_module`
+      The official documentation on the **ansible.windows.win_regmerge** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Obtain information about a registry key using short form
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion
+      register: current_version
+
+    - name: Obtain information about a registry key property
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion
+        name: CommonFilesDir
+      register: common_files_dir
+
+    - name: Obtain the registry key's (Default) property
+      ansible.windows.win_reg_stat:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion
+        name: ''
+      register: current_version_default
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>changed</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>Whether anything was changed.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>exists</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success and path/property exists</td>
+                <td>
+                                                                        <div>States whether the registry key/property exists.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>properties</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists and property not specified</td>
+                <td>
+                                                                        <div>A dictionary containing all the properties and their values in the registry key.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;&#x27;: {&#x27;raw_value&#x27;: &#x27;&#x27;, &#x27;type&#x27;: &#x27;REG_SZ&#x27;, &#x27;value&#x27;: &#x27;&#x27;}, &#x27;binary_property&#x27;: {&#x27;raw_value&#x27;: [&#x27;0x01&#x27;, &#x27;0x16&#x27;], &#x27;type&#x27;: &#x27;REG_BINARY&#x27;, &#x27;value&#x27;: [1, 22]}, &#x27;multi_string_property&#x27;: {&#x27;raw_value&#x27;: [&#x27;a&#x27;, &#x27;b&#x27;], &#x27;type&#x27;: &#x27;REG_MULTI_SZ&#x27;, &#x27;value&#x27;: [&#x27;a&#x27;, &#x27;b&#x27;]}}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>raw_value</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path/property exists and property specified</td>
+                <td>
+                                                                        <div>Returns the raw value of the registry property, REG_EXPAND_SZ has no string expansion, REG_BINARY or REG_NONE is in hex 0x format. REG_NONE, this value is a hex string in the 0x format.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">%ProgramDir%\\Common Files</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>sub_keys</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists and property not specified</td>
+                <td>
+                                                                        <div>A list of all the sub keys of the key specified.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;AppHost&#x27;, &#x27;Casting&#x27;, &#x27;DateTime&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>type</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path/property exists and property specified</td>
+                <td>
+                                                                        <div>The property type.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">REG_EXPAND_SZ</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>value</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path/property exists and property specified</td>
+                <td>
+                                                                        <div>The value of the property.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">C:\\Program Files\\Common Files</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Jordan Borean (@jborean93)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_regedit.rst
+++ b/docs/ansible.windows.win_regedit.rst
@@ -1,0 +1,361 @@
+:orphan:
+
+.. _ansible.windows.win_regedit_module:
+
+
+***************************
+ansible.windows.win_regedit
+***************************
+
+**Add, change, or remove registry keys and values**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Add, modify or remove registry keys and values.
+- More information about the windows registry from Wikipedia https://en.wikipedia.org/wiki/Windows_Registry.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>data</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Value of the registry entry <code>name</code> in <code>path</code>.</div>
+                                            <div>If not specified then the value for the property will be null for the corresponding <code>type</code>.</div>
+                                            <div>Binary and None data should be expressed in a yaml byte array or as comma separated hex values.</div>
+                                            <div>An easy way to generate this is to run <code>regedit.exe</code> and use the <em>export</em> option to save the registry values to a file.</div>
+                                            <div>In the exported file, binary value will look like <code>hex:be,ef,be,ef</code>, the <code>hex:</code> prefix is optional.</div>
+                                            <div>DWORD and QWORD values should either be represented as a decimal number or a hex value.</div>
+                                            <div>Multistring values should be passed in as a list.</div>
+                                            <div>See the examples for more details on how to format this data.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>delete_key</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>When <code>state</code> is &#x27;absent&#x27; then this will delete the entire key.</div>
+                                            <div>If <code>no</code> then it will only clear out the &#x27;(Default)&#x27; property for that key.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hive</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A path to a hive key like C:\Users\Default\NTUSER.DAT to load in the registry.</div>
+                                            <div>This hive is loaded under the HKLM:\ANSIBLE key which can then be used in <em>name</em> like any other path.</div>
+                                            <div>This can be used to load the default user profile registry hive or any other hive saved as a file.</div>
+                                            <div>Using this function requires the user to have the <code>SeRestorePrivilege</code> and <code>SeBackupPrivilege</code> privileges enabled.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Name of the registry entry in the above <code>path</code> parameters.</div>
+                                            <div>If not provided, or empty then the &#x27;(Default)&#x27; property for the key will be used.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: entry, value</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Name of the registry path.</div>
+                                            <div>Should be in one of the following registry hives: HKCC, HKCR, HKCU, HKLM, HKU.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: key</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>The state of the registry entry.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>binary</li>
+                                                                                                                                                                                                <li>dword</li>
+                                                                                                                                                                                                <li>expandstring</li>
+                                                                                                                                                                                                <li>multistring</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>string</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>qword</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>The registry value data type.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: datatype</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - Check-mode ``-C/--check`` and diff output ``-D/--diff`` are supported, so that you can test every change against the active configuration before applying changes.
+   - Beware that some registry hives (``HKEY_USERS`` in particular) do not allow to create new registry paths in the root folder.
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`ansible.windows.win_reg_stat_module`
+      The official documentation on the **ansible.windows.win_reg_stat** module.
+   :ref:`ansible.windows.win_regmerge_module`
+      The official documentation on the **ansible.windows.win_regmerge** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Create registry path MyCompany
+      ansible.windows.win_regedit:
+        path: HKCU:\Software\MyCompany
+
+    - name: Add or update registry path MyCompany, with entry 'hello', and containing 'world'
+      ansible.windows.win_regedit:
+        path: HKCU:\Software\MyCompany
+        name: hello
+        data: world
+
+    - name: Add or update registry path MyCompany, with dword entry 'hello', and containing 1337 as the decimal value
+      ansible.windows.win_regedit:
+        path: HKCU:\Software\MyCompany
+        name: hello
+        data: 1337
+        type: dword
+
+    - name: Add or update registry path MyCompany, with dword entry 'hello', and containing 0xff2500ae as the hex value
+      ansible.windows.win_regedit:
+        path: HKCU:\Software\MyCompany
+        name: hello
+        data: 0xff2500ae
+        type: dword
+
+    - name: Add or update registry path MyCompany, with binary entry 'hello', and containing binary data in hex-string format
+      ansible.windows.win_regedit:
+        path: HKCU:\Software\MyCompany
+        name: hello
+        data: hex:be,ef,be,ef,be,ef,be,ef,be,ef
+        type: binary
+
+    - name: Add or update registry path MyCompany, with binary entry 'hello', and containing binary data in yaml format
+      ansible.windows.win_regedit:
+        path: HKCU:\Software\MyCompany
+        name: hello
+        data: [0xbe,0xef,0xbe,0xef,0xbe,0xef,0xbe,0xef,0xbe,0xef]
+        type: binary
+
+    - name: Add or update registry path MyCompany, with expand string entry 'hello'
+      ansible.windows.win_regedit:
+        path: HKCU:\Software\MyCompany
+        name: hello
+        data: '%appdata%\local'
+        type: expandstring
+
+    - name: Add or update registry path MyCompany, with multi string entry 'hello'
+      ansible.windows.win_regedit:
+        path: HKCU:\Software\MyCompany
+        name: hello
+        data: ['hello', 'world']
+        type: multistring
+
+    - name: Disable keyboard layout hotkey for all users (changes existing)
+      ansible.windows.win_regedit:
+        path: HKU:\.DEFAULT\Keyboard Layout\Toggle
+        name: Layout Hotkey
+        data: 3
+        type: dword
+
+    - name: Disable language hotkey for current users (adds new)
+      ansible.windows.win_regedit:
+        path: HKCU:\Keyboard Layout\Toggle
+        name: Language Hotkey
+        data: 3
+        type: dword
+
+    - name: Remove registry path MyCompany (including all entries it contains)
+      ansible.windows.win_regedit:
+        path: HKCU:\Software\MyCompany
+        state: absent
+        delete_key: yes
+
+    - name: Clear the existing (Default) entry at path MyCompany
+      ansible.windows.win_regedit:
+        path: HKCU:\Software\MyCompany
+        state: absent
+        delete_key: no
+
+    - name: Remove entry 'hello' from registry path MyCompany
+      ansible.windows.win_regedit:
+        path: HKCU:\Software\MyCompany
+        name: hello
+        state: absent
+
+    - name: Change default mouse trailing settings for new users
+      ansible.windows.win_regedit:
+        path: HKLM:\ANSIBLE\Control Panel\Mouse
+        name: MouseTrails
+        data: 10
+        type: str
+        state: present
+        hive: C:\Users\Default\NTUSER.dat
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>data_changed</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>Whether this invocation changed the data in the registry value.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>data_type_changed</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>Whether this invocation changed the datatype of the registry value.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Adam Keech (@smadam813)
+- Josh Ludwig (@joshludwig)
+- Jordan Borean (@jborean93)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_service.rst
+++ b/docs/ansible.windows.win_service.rst
@@ -1,0 +1,966 @@
+:orphan:
+
+.. _ansible.windows.win_service_module:
+
+
+***************************
+ansible.windows.win_service
+***************************
+
+**Manage and query Windows services**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Manage and query Windows services.
+- For non-Windows targets, use the :ref:`service <service_module>` module instead.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dependencies</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A list of service dependencies to set for this particular service.</div>
+                                            <div>This should be a list of service names and not the display name of the service.</div>
+                                            <div>This works by <code>dependency_action</code> to either add/remove or set the services in this list.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dependency_action</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>add</li>
+                                                                                                                                                                                                <li>remove</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>set</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Used in conjunction with <code>dependency</code> to either add the dependencies to the existing service dependencies.</div>
+                                            <div>Remove the dependencies to the existing dependencies.</div>
+                                            <div>Set the dependencies to only the values in the list replacing the existing dependencies.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>description</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The description to set for the service.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>desktop_interact</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether to allow the service user to interact with the desktop.</div>
+                                            <div>This can only be set to <code>yes</code> when using the <code>LocalSystem</code> username.</div>
+                                            <div>This can only be set to <code>yes</code> when the <em>service_type</em> is <code>win32_own_process</code> or <code>win32_share_process</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>display_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The display name to set for the service.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>error_control</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>critical</li>
+                                                                                                                                                                                                <li>ignore</li>
+                                                                                                                                                                                                <li>normal</li>
+                                                                                                                                                                                                <li>severe</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>The severity of the error and action token if the service fails to start.</div>
+                                            <div>A new service defaults to <code>normal</code>.</div>
+                                            <div><code>critical</code> will log the error and restart the system with the last-known good configuration. If the startup fails on reboot then the system will fail to operate.</div>
+                                            <div><code>ignore</code> ignores the error.</div>
+                                            <div><code>normal</code> logs the error in the event log but continues.</div>
+                                            <div><code>severe</code> is like <code>critical</code> but a failure on the last-known good configuration reboot startup will be ignored.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>failure_actions</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A list of failure actions the service controller should take on each failure of a service.</div>
+                                            <div>The service manager will run the actions from first to last defined until the service starts. If <em>failure_reset_period_sec</em> has been exceeded then the failure actions will restart from the beginning.</div>
+                                            <div>If all actions have been performed the the service manager will repeat the last service defined.</div>
+                                            <div>The existing actions will be replaced with the list defined in the task if there is a mismatch with any of them.</div>
+                                            <div>Set to an empty list to delete all failure actions on a service otherwise an omitted or null value preserves the existing actions on the service.</div>
+                                                        </td>
+            </tr>
+                                                            <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>delay_ms</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">raw</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">0</div>
+                                    </td>
+                                                                <td>
+                                            <div>The time to wait, in milliseconds, before performing the specified action.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: delay</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                    <td class="elbow-placeholder"></td>
+                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>none</li>
+                                                                                                                                                                                                <li>reboot</li>
+                                                                                                                                                                                                <li>restart</li>
+                                                                                                                                                                                                <li>run_command</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>The action to be performed.</div>
+                                            <div><code>none</code> will perform no action, when used this should only be set as the last action.</div>
+                                            <div><code>reboot</code> will reboot the host, when used this should only be set as the last action as the reboot will reset the action list back to the beginning.</div>
+                                            <div><code>restart</code> will restart the service.</div>
+                                            <div><code>run_command</code> will run the command specified by <em>failure_command</em>.</div>
+                                                        </td>
+            </tr>
+                    
+                                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>failure_actions_on_non_crash_failure</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Controls whether failure actions will be performed on non crash failures or not.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>failure_command</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The command to run for a <code>run_command</code> failure action.</div>
+                                            <div>Set to an empty string to remove the command.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>failure_reboot_msg</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The message to be broadcast to users logged on the host for a <code>reboot</code> failure action.</div>
+                                            <div>Set to an empty string to remove the message.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>failure_reset_period_sec</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">raw</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The time in seconds after which the failure action list begings from the start if there are no failures.</div>
+                                            <div>To set this value, <em>failure_actions</em> must have at least 1 action present.</div>
+                                            <div>Specify <code>&#x27;0xFFFFFFFF&#x27;</code> to set an infinite reset period.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: failure_reset_period</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>force_dependent_services</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>If <code>yes</code>, stopping or restarting a service with dependent services will force the dependent services to stop or restart also.</div>
+                                            <div>If <code>no</code>, stopping or restarting a service with dependent services may fail.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>load_order_group</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The name of the load ordering group of which this service is a member.</div>
+                                            <div>Specify an empty string to remove the existing load order group of a service.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Name of the service.</div>
+                                            <div>If only the name parameter is specified, the module will report on whether the service exists or not without making any changes.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The password to set the service to start as.</div>
+                                            <div>This and the <code>username</code> argument should be supplied together when using a local or domain account.</div>
+                                            <div>If omitted then the password will continue to use the existing value password set.</div>
+                                            <div>If specifying <code>LocalSystem</code>, <code>NetworkService</code>, <code>LocalService</code>, the <code>NT SERVICE</code>, or a gMSA this field can be omitted as those accounts have no password.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The path to the executable to set for the service.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>pre_shutdown_timeout_ms</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">raw</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The time in which the service manager waits after sending a preshutdown notification to the service until it proceeds to continue with the other shutdown actions.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: pre_shutdown_timeout</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>required_privileges</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A list of privileges the service must have when starting up.</div>
+                                            <div>When set the service will only have the privileges specified on its access token.</div>
+                                            <div>The <em>username</em> of the service must already have the privileges assigned.</div>
+                                            <div>The existing privileges will be replace with the list defined in the task if there is a mismatch with any of them.</div>
+                                            <div>Set to an empty list to remove all required privileges, otherwise an omitted or null value will keep the existing privileges.</div>
+                                            <div>See <a href='https://docs.microsoft.com/en-us/windows/win32/secauthz/privilege-constants'>privilege text constants</a> for a list of privilege constants that can be used.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>service_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>user_own_process</li>
+                                                                                                                                                                                                <li>user_share_process</li>
+                                                                                                                                                                                                <li>win32_own_process</li>
+                                                                                                                                                                                                <li>win32_share_process</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>The type of service.</div>
+                                            <div>The default type of a new service is <code>win32_own_process</code>.</div>
+                                            <div><em>desktop_interact</em> can only be set if the service type is <code>win32_own_process</code> or <code>win32_share_process</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>sid_info</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>none</li>
+                                                                                                                                                                                                <li>restricted</li>
+                                                                                                                                                                                                <li>unrestricted</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Used to define the behaviour of the service&#x27;s access token groups.</div>
+                                            <div><code>none</code> will not add any groups to the token.</div>
+                                            <div><code>restricted</code> will add the <code>NT SERVICE\&lt;service name&gt;</code> SID to the access token&#x27;s groups and restricted groups.</div>
+                                            <div><code>unrestricted</code> will add the <code>NT SERVICE\&lt;service name&gt;</code> SID to the access token&#x27;s groups.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>start_mode</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>auto</li>
+                                                                                                                                                                                                <li>delayed</li>
+                                                                                                                                                                                                <li>disabled</li>
+                                                                                                                                                                                                <li>manual</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Set the startup type for the service.</div>
+                                            <div>A newly created service will default to <code>auto</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li>paused</li>
+                                                                                                                                                                                                <li>started</li>
+                                                                                                                                                                                                <li>stopped</li>
+                                                                                                                                                                                                <li>restarted</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>The desired state of the service.</div>
+                                            <div><code>started</code>/<code>stopped</code>/<code>absent</code>/<code>paused</code> are idempotent actions that will not run commands unless necessary.</div>
+                                            <div><code>restarted</code> will always bounce the service.</div>
+                                            <div>Only services that support the paused state can be paused, you can check the return value <code>can_pause_and_continue</code>.</div>
+                                            <div>You can only pause a service that is already started.</div>
+                                            <div>A newly created service will default to <code>stopped</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>update_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>always</li>
+                                                                                                                                                                                                <li>on_create</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>When set to <code>always</code> and <em>password</em> is set, the module will always report a change and set the password.</div>
+                                            <div>Set to <code>on_create</code> to only set the password if the module needs to create the service.</div>
+                                            <div>If <em>username</em> was specified and the service changed to that username then <em>password</em> will also be changed if specified.</div>
+                                            <div>The current default is <code>on_create</code> but this behaviour may change in the future, it is best to be explicit here.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The username to set the service to start as.</div>
+                                            <div>Can also be set to <code>LocalSystem</code> or <code>SYSTEM</code> to use the SYSTEM account.</div>
+                                            <div>A newly created service will default to <code>LocalSystem</code>.</div>
+                                            <div>If using a custom user account, it must have the <code>SeServiceLogonRight</code> granted to be able to start up. You can use the <span class='module'>ansible.windows.win_user_right</span> module to grant this user right for you.</div>
+                                            <div>Set to <code>NT SERVICE\service name</code> to run as the NT SERVICE account for that service.</div>
+                                            <div>This can also be a gMSA in the form <code>DOMAIN\gMSA$</code>.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - This module historically returning information about the service in its return values. These should be avoided in favour of the :ref:`ansible.windows.win_service_info <ansible.windows.win_service_info_module>` module.
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`service_module`
+      The official documentation on the **service** module.
+   :ref:`community.windows.win_nssm_module`
+      The official documentation on the **community.windows.win_nssm** module.
+   :ref:`ansible.windows.win_service_info_module`
+      The official documentation on the **ansible.windows.win_service_info** module.
+   :ref:`ansible.windows.win_user_right_module`
+      The official documentation on the **ansible.windows.win_user_right** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Restart a service
+      ansible.windows.win_service:
+        name: spooler
+        state: restarted
+
+    - name: Set service startup mode to auto and ensure it is started
+      ansible.windows.win_service:
+        name: spooler
+        start_mode: auto
+        state: started
+
+    - name: Pause a service
+      ansible.windows.win_service:
+        name: Netlogon
+        state: paused
+
+    - name: Ensure that WinRM is started when the system has settled
+      ansible.windows.win_service:
+        name: WinRM
+        start_mode: delayed
+
+    # A new service will also default to the following values:
+    # - username: LocalSystem
+    # - state: stopped
+    # - start_mode: auto
+    - name: Create a new service
+      ansible.windows.win_service:
+        name: service name
+        path: C:\temp\test.exe
+
+    - name: Create a new service with extra details
+      ansible.windows.win_service:
+        name: service name
+        path: C:\temp\test.exe
+        display_name: Service Name
+        description: A test service description
+
+    - name: Remove a service
+      ansible.windows.win_service:
+        name: service name
+        state: absent
+
+    # This is required to be set for non-service accounts that need to run as a service
+    - name: Grant domain account the SeServiceLogonRight user right
+      ansible.windows.win_user_right:
+        name: SeServiceLogonRight
+        users:
+        - DOMAIN\User
+        action: add
+
+    - name: Set the log on user to a domain account
+      ansible.windows.win_service:
+        name: service name
+        state: restarted
+        username: DOMAIN\User
+        password: Password
+
+    - name: Set the log on user to a local account
+      ansible.windows.win_service:
+        name: service name
+        state: restarted
+        username: .\Administrator
+        password: Password
+
+    - name: Set the log on user to Local System
+      ansible.windows.win_service:
+        name: service name
+        state: restarted
+        username: SYSTEM
+
+    - name: Set the log on user to Local System and allow it to interact with the desktop
+      ansible.windows.win_service:
+        name: service name
+        state: restarted
+        username: SYSTEM
+        desktop_interact: yes
+
+    - name: Set the log on user to Network Service
+      ansible.windows.win_service:
+        name: service name
+        state: restarted
+        username: NT AUTHORITY\NetworkService
+
+    - name: Set the log on user to Local Service
+      ansible.windows.win_service:
+        name: service name
+        state: restarted
+        username: NT AUTHORITY\LocalService
+
+    - name: Set the log on user as the services' virtual account
+      ansible.windows.win_service:
+        name: service name
+        username: NT SERVICE\service name
+
+    - name: Set the log on user as a gMSA
+      ansible.windows.win_service:
+        name: service name
+        username: DOMAIN\gMSA$  # The end $ is important and should be set for all gMSA
+
+    - name: Set dependencies to ones only in the list
+      ansible.windows.win_service:
+        name: service name
+        dependencies: [ service1, service2 ]
+
+    - name: Add dependencies to existing dependencies
+      ansible.windows.win_service:
+        name: service name
+        dependencies: [ service1, service2 ]
+        dependency_action: add
+
+    - name: Remove dependencies from existing dependencies
+      ansible.windows.win_service:
+        name: service name
+        dependencies:
+        - service1
+        - service2
+        dependency_action: remove
+
+    - name: Set required privileges for a service
+      ansible.windows.win_service:
+        name: service name
+        username: NT SERVICE\LocalService
+        required_privileges:
+        - SeBackupPrivilege
+        - SeRestorePrivilege
+
+    - name: Remove all required privileges for a service
+      ansible.windows.win_service:
+        name: service name
+        username: NT SERVICE\LocalService
+        required_privileges: []
+
+    - name: Set failure actions for a service with no reset period
+      ansible.windows.win_service:
+        name: service name
+        failure_actions:
+        - type: restart
+        - type: run_command
+          delay_ms: 1000
+        - type: restart
+          delay_ms: 5000
+        - type: reboot
+        failure_command: C:\Windows\System32\cmd.exe /c mkdir C:\temp
+        failure_reboot_msg: Restarting host because service name has failed
+        failure_reset_period_sec: '0xFFFFFFFF'
+
+    - name: Set only 1 failure action without a repeat of the last action
+      ansible.windows.win_service:
+        name: service name
+        failure_actions:
+        - type: restart
+          delay_ms: 5000
+        - type: none
+
+    - name: Remove failure action information
+      ansible.windows.win_service:
+        name: service name
+        failure_actions: []
+        failure_command: ''  # removes the existing command
+        failure_reboot_msg: ''  # removes the existing reboot msg
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>can_pause_and_continue</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success and service exists</td>
+                <td>
+                                                                        <div>Whether the service can be paused and unpaused.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>depended_by</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>success and service exists</td>
+                <td>
+                                                                        <div>A list of services that depend on this service.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>dependencies</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>success and service exists</td>
+                <td>
+                                                                        <div>A list of services that is depended by this service.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>description</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success and service exists</td>
+                <td>
+                                                                        <div>The description of the service.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Manages communication between system components.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>desktop_interact</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success and service exists</td>
+                <td>
+                                                                        <div>Whether the current user is allowed to interact with the desktop.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>display_name</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success and service exists</td>
+                <td>
+                                                                        <div>The display name of the installed service.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">CoreMessaging</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>exists</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>Whether the service exists or not.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success and service exists</td>
+                <td>
+                                                                        <div>The service name or id of the service.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">CoreMessagingRegistrar</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success and service exists</td>
+                <td>
+                                                                        <div>The path to the service executable.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">C:\Windows\system32\svchost.exe -k LocalServiceNoNetwork</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>start_mode</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success and service exists</td>
+                <td>
+                                                                        <div>The startup type of the service.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">manual</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success and service exists</td>
+                <td>
+                                                                        <div>The current running status of the service.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">stopped</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success and service exists</td>
+                <td>
+                                                                        <div>The username that runs the service.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">LocalSystem</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Chris Hoffman (@chrishoffman)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_service_info.rst
+++ b/docs/ansible.windows.win_service_info.rst
@@ -1,0 +1,886 @@
+:orphan:
+
+.. _ansible.windows.win_service_info_module:
+
+
+********************************
+ansible.windows.win_service_info
+********************************
+
+**Gather information about Windows services**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Gather information about all or a specific installed Windows service(s).
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>If specified, this is used to match the <code>name</code> or <code>display_name</code> of the Windows service to get the info for.</div>
+                                            <div>Can be a wildcard to match multiple services but the wildcard will only be matched on the <code>name</code> of the service and not <code>display_name</code>.</div>
+                                            <div>If omitted then all services will returned.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`ansible.windows.win_service_module`
+      The official documentation on the **ansible.windows.win_service** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Get info for all installed services
+      ansible.windows.win_service_info:
+      register: service_info
+
+    - name: Get info for a single service
+      ansible.windows.win_service_info:
+        name: WinRM
+      register: service_info
+
+    - name: Get info for a service using its display name
+      ansible.windows.win_service_info:
+        name: Windows Remote Management (WS-Management)
+
+    - name: Find all services that start with 'win'
+      ansible.windows.win_service_info:
+        name: win*
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="4">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>exists</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>Whether any services were found based on the criteria specified.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="4">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>services</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                       / <span style="color: purple">elements=dictionary</span>                    </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>A list of service(s) that were found based on the criteria.</div>
+                                                    <div>Will be an empty list if no services were found.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>checkpoint</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>A check-point value that the service increments periodically to report its progress.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>controls_accepted</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                       / <span style="color: purple">elements=string</span>                    </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>A list of controls that the service can accept.</div>
+                                                    <div>Common controls are <code>stop</code>, <code>pause_continue</code>, <code>shutdown</code>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;stop&#x27;, &#x27;shutdown&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>dependencies</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                       / <span style="color: purple">elements=string</span>                    </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>A list of services by their <code>name</code> that this service is dependent on.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;HTTP&#x27;, &#x27;RPCSS&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>dependency_of</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                       / <span style="color: purple">elements=string</span>                    </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>A list of services by their <code>name</code> that depend on this service.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;upnphost&#x27;, &#x27;WMPNetworkSvc&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>description</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The description of the service.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Example description of the Windows service.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>desktop_interact</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>Whether the service can interact with the desktop, only valid for services running as <code>SYSTEM</code>.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>display_name</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The display name to be used by SCM to identify the service.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Windows Remote Management (WS-Management)</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>error_control</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The action to take if a service fails to start.</div>
+                                                    <div>Common values are <code>critical</code>, <code>ignore</code>, <code>normal</code>, <code>severe</code>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">normal</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>failure_action_on_non_crash_failure</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>Controls when failure actions are fired based on how the service was stopped.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>failure_actions</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                       / <span style="color: purple">elements=dictionary</span>                    </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>A list of failure actions to run in the event of a failure.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>delay_ms</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The time to wait, in milliseconds, before performing the specified action.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">120000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>type</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The action that will be performed.</div>
+                                                    <div>Common values are <code>none</code>, <code>reboot</code>, <code>restart</code>, <code>run_command</code>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">run_command</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>failure_command</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The command line that will be run when a <code>run_command</code> failure action is fired.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">runme.exe</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>failure_reboot_msg</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The message to be broadcast to server users before rebooting when a <code>reboot</code> failure action is fired.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Service failed, rebooting host.</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>failure_reset_period_sec</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The time, in seconds, after which to reset the failure count to zero.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">86400</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>launch_protection</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The protection type of the service.</div>
+                                                    <div>Common values are <code>none</code>, <code>windows</code>, <code>windows_light</code>, or <code>antimalware_light</code>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">none</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>load_order_group</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The name of the load ordering group to which the service belongs.</div>
+                                                    <div>Will be an empty string if it does not belong to any group.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">My group</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The name of the service.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">WinRM</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The path to the service binary and any arguments used when starting the service.</div>
+                                                    <div>The binary part can be quoted to ensure any spaces in path are not treated as arguments.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">C:\Windows\System32\svchost.exe -k netsvcs -p</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>pre_shutdown_timeout_ms</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The preshutdown timeout out value in milliseconds.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">10000</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>preferred_node</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The node number for the preferred node.</div>
+                                                    <div>This will be <code>null</code> if the Windows host has no NUMA configuration.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>process_id</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The process identifier of the running service.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">5135</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>required_privileges</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                       / <span style="color: purple">elements=string</span>                    </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>A list of privileges that the service requires and will run with</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;SeBackupPrivilege&#x27;, &#x27;SeRestorePrivilege&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>service_exit_code</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>A service-specific error code that is set while the service is starting or stopping.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>service_flags</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                       / <span style="color: purple">elements=string</span>                    </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>Shows more information about the behaviour of a running service.</div>
+                                                    <div>Currently the only flag that can be set is <code>runs_in_system_process</code>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;runs_in_system_process&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>service_type</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The type of service.</div>
+                                                    <div>Common types are <code>win32_own_process</code>, <code>win32_share_process</code>, <code>user_own_process</code>, <code>user_share_process</code>, <code>kernel_driver</code>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">win32_own_process</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>sid_info</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The behavior of how the service&#x27;s access token is generated and how to add the service SID to the token.</div>
+                                                    <div>Common values are <code>none</code>, <code>restricted</code>, or <code>unrestricted</code>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">none</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>start_mode</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>When the service is set to start.</div>
+                                                    <div>Common values are <code>auto</code>, <code>manual</code>, <code>disabled</code>, <code>delayed</code>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">auto</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The current running state of the service.</div>
+                                                    <div>Common values are <code>stopped</code>, <code>start_pending</code>, <code>stop_pending</code>, <code>started</code>, <code>continue_pending</code>, <code>pause_pending</code>, <code>paused</code>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">started</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>triggers</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                       / <span style="color: purple">elements=dictionary</span>                    </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>A list of triggers defined for the service.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>action</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The action to perform once triggered, can be <code>start_service</code> or <code>stop_service</code>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">start_service</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>data_items</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                       / <span style="color: purple">elements=dictionary</span>                    </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>A list of trigger data items that contain trigger specific data.</div>
+                                                    <div>A trigger can contain 0 or multiple data items.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>data</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">complex</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The trigger data item value.</div>
+                                                    <div>Can be a string, list of string, int, or base64 string of binary data.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">named pipe</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>type</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The type of <code>data</code> for the trigger.</div>
+                                                    <div>Common values are <code>string</code>, <code>binary</code>, <code>level</code>, <code>keyword_any</code>, or <code>keyword_all</code>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">string</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>sub_type</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The trigger event sub type that is specific to each <code>type</code>.</div>
+                                                    <div>Common values are <code>named_pipe_event</code>, <code>domain_join</code>, <code>domain_leave</code>, <code>firewall_port_open</code>, and others.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>sub_type_guid</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The guid which represents the trigger sub type.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1ce20aba-9851-4421-9430-1ddeb766e809</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>type</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The trigger event type.</div>
+                                                    <div>Common values are <code>custom</code>, <code>rpc_interface_event</code>, <code>domain_join</code>, <code>group_policy</code>, and others.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">domain_join</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The username used to run the service.</div>
+                                                    <div>Can be null for user services and certain driver services.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">NT AUTHORITY\SYSTEM</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>wait_hint_ms</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The estimated time in milliseconds required for a pending start, stop, pause,or continue operations.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>win32_exitcode</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td></td>
+                <td>
+                                                                        <div>The error code returned from the service binary once it has stopped.</div>
+                                                    <div>When set to <code>1066</code> then a service specific error is returned on <code>service_exit_code</code>.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Jordan Borean (@jborean93)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_share.rst
+++ b/docs/ansible.windows.win_share.rst
@@ -1,0 +1,333 @@
+:orphan:
+
+.. _ansible.windows.win_share_module:
+
+
+*************************
+ansible.windows.win_share
+*************************
+
+**Manage Windows shares**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Add, modify or remove Windows share and set share permissions.
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- As this module used newer cmdlets like New-SmbShare this can only run on Windows 8 / Windows 2012 or newer.
+- This is due to the reliance on the WMI provider MSFT_SmbShare https://msdn.microsoft.com/en-us/library/hh830471 which was only added with these Windows releases.
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>caching_mode</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>BranchCache</li>
+                                                                                                                                                                                                <li>Documents</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>Manual</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>None</li>
+                                                                                                                                                                                                <li>Programs</li>
+                                                                                                                                                                                                <li>Unknown</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Set the CachingMode for this share.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>change</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Specify user list that should get read and write access on share, separated by comma.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>deny</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Specify user list that should get no access, regardless of implied access on share, separated by comma.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>description</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Share description.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>encrypt</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Sets whether to encrypt the traffic to the share or not.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>full</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Specify user list that should get full access on share, separated by comma.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>list</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Specify whether to allow or deny file listing, in case user has no permission on share. Also known as Access-Based Enumeration.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Share name.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Share directory.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>read</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Specify user list that should get read access on share, separated by comma.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>rule_action</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>set</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>add</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether to add or set (replace) access control entries.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Specify whether to add <code>present</code> or remove <code>absent</code> the specified share.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Add secret share
+      ansible.windows.win_share:
+        name: internal
+        description: top secret share
+        path: C:\shares\internal
+        list: no
+        full: Administrators,CEO
+        read: HR-Global
+        deny: HR-External
+
+    - name: Add public company share
+      ansible.windows.win_share:
+        name: company
+        description: top secret share
+        path: C:\shares\company
+        list: yes
+        full: Administrators,CEO
+        read: Global
+
+    - name: Remove previously added share
+      ansible.windows.win_share:
+        name: internal
+        state: absent
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>actions</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>A list of action cmdlets that were run by the module.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;New-SmbShare -Name share -Path C:\\temp&#x27;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Hans-Joachim Kliemeck (@h0nIg)
+- David Baumann (@daBONDi)
+- Shachaf Goldstein (@Shachaf92)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_shell.rst
+++ b/docs/ansible.windows.win_shell.rst
@@ -1,0 +1,418 @@
+:orphan:
+
+.. _ansible.windows.win_shell_module:
+
+
+*************************
+ansible.windows.win_shell
+*************************
+
+**Execute shell commands on target hosts**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- The :ref:`ansible.windows.win_shell <ansible.windows.win_shell_module>` module takes the command name followed by a list of space-delimited arguments. It is similar to the :ref:`ansible.windows.win_command <ansible.windows.win_command_module>` module, but runs the command via a shell (defaults to PowerShell) on the target host.
+- For non-Windows targets, use the :ref:`shell <shell_module>` module instead.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>chdir</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Set the specified path as the current working directory before executing a command</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>creates</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A path or path filter pattern; when the referenced path exists on the target host, the task will be skipped.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>executable</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Change the shell used to execute the command (eg, <code>cmd</code>).</div>
+                                            <div>The target shell must accept a <code>/c</code> parameter followed by the raw command line to be executed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>free_form</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The <span class='module'>ansible.windows.win_shell</span> module takes a free form command to run.</div>
+                                            <div>There is no parameter actually named &#x27;free form&#x27;. See the examples!</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>no_profile</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Do not load the user profile before running a command. This is only valid when using PowerShell as the executable.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>output_encoding_override</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>This option overrides the encoding of stdout/stderr output.</div>
+                                            <div>You can use this option when you need to run a command which ignore the console&#x27;s codepage.</div>
+                                            <div>You should only need to use this option in very rare circumstances.</div>
+                                            <div>This value can be any valid encoding <code>Name</code> based on the output of <code>[System.Text.Encoding]::GetEncodings(</code>). See <a href='https://docs.microsoft.com/dotnet/api/system.text.encoding.getencodings'>https://docs.microsoft.com/dotnet/api/system.text.encoding.getencodings</a>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>removes</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A path or path filter pattern; when the referenced path <b>does not</b> exist on the target host, the task will be skipped.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>stdin</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Set the stdin of the command directly to the specified value.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - If you want to run an executable securely and predictably, it may be better to use the :ref:`ansible.windows.win_command <ansible.windows.win_command_module>` module instead. Best practices when writing playbooks will follow the trend of using :ref:`ansible.windows.win_command <ansible.windows.win_command_module>` unless ``win_shell`` is explicitly required. When running ad-hoc commands, use your best judgement.
+   - WinRM will not return from a command execution until all child processes created have exited. Thus, it is not possible to use :ref:`ansible.windows.win_shell <ansible.windows.win_shell_module>` to spawn long-running child or background processes. Consider creating a Windows service for managing background processes.
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`community.windows.psexec_module`
+      The official documentation on the **community.windows.psexec** module.
+   :ref:`raw_module`
+      The official documentation on the **raw** module.
+   :ref:`script_module`
+      The official documentation on the **script** module.
+   :ref:`shell_module`
+      The official documentation on the **shell** module.
+   :ref:`ansible.windows.win_command_module`
+      The official documentation on the **ansible.windows.win_command** module.
+   :ref:`community.windows.win_psexec_module`
+      The official documentation on the **community.windows.win_psexec** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Execute a comand in the remote shell, stdout goes to the specified file on the remote
+      ansible.windows.win_shell: C:\somescript.ps1 >> C:\somelog.txt
+
+    - name: Change the working directory to somedir/ before executing the command
+      ansible.windows.win_shell: C:\somescript.ps1 >> C:\somelog.txt
+      args:
+        chdir: C:\somedir
+
+    - name: Run a command with an idempotent check on what it creates, will only run when somedir/somelog.txt does not exist
+      ansible.windows.win_shell: C:\somescript.ps1 >> C:\somelog.txt
+      args:
+        chdir: C:\somedir
+        creates: C:\somelog.txt
+
+    - name: Run a command under a non-Powershell interpreter (cmd in this case)
+      ansible.windows.win_shell: echo %HOMEDIR%
+      args:
+        executable: cmd
+      register: homedir_out
+
+    - name: Run multi-lined shell commands
+      ansible.windows.win_shell: |
+        $value = Test-Path -Path C:\temp
+        if ($value) {
+            Remove-Item -Path C:\temp -Force
+        }
+        New-Item -Path C:\temp -ItemType Directory
+
+    - name: Retrieve the input based on stdin
+      ansible.windows.win_shell: '$string = [Console]::In.ReadToEnd(); Write-Output $string.Trim()'
+      args:
+        stdin: Input message
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>cmd</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The command executed by the task.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">rabbitmqctl join_cluster rabbit@master</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>delta</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The command execution delta time.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">0:00:00.325771</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>end</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The command execution end time.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-02-25 09:18:26.755339</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>msg</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>Changed.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>rc</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The command return code (0 means success).</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>start</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The command execution start time.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2016-02-25 09:18:26.429568</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>stderr</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The command standard error.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">ls: cannot access foo: No such file or directory</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>stdout</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The command standard output.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Clustering node rabbit@slave1 with rabbit@master ...</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>stdout_lines</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The command standard output split in lines.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&quot;u&#x27;Clustering node rabbit@slave1 with rabbit@master ...&#x27;&quot;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Matt Davis (@nitzmahone)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_stat.rst
+++ b/docs/ansible.windows.win_stat.rst
@@ -1,0 +1,676 @@
+:orphan:
+
+.. _ansible.windows.win_stat_module:
+
+
+************************
+ansible.windows.win_stat
+************************
+
+**Get information about Windows files**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Returns information about a Windows file.
+- For non-Windows targets, use the :ref:`stat <stat_module>` module instead.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>checksum_algorithm</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>md5</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>sha1</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>sha256</li>
+                                                                                                                                                                                                <li>sha384</li>
+                                                                                                                                                                                                <li>sha512</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Algorithm to determine checksum of file.</div>
+                                            <div>Will throw an error if the host is unable to use specified algorithm.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>follow</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether to follow symlinks or junction points.</div>
+                                            <div>In the case of <code>path</code> pointing to another link, then that will be followed until no more links are found.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>get_checksum</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether to return a checksum of the file (default sha1)</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The full path of the file/object to get the facts of; both forward and back slashes are accepted.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: dest, name</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`stat_module`
+      The official documentation on the **stat** module.
+   :ref:`ansible.windows.win_acl_module`
+      The official documentation on the **ansible.windows.win_acl** module.
+   :ref:`ansible.windows.win_file_module`
+      The official documentation on the **ansible.windows.win_file** module.
+   :ref:`ansible.windows.win_owner_module`
+      The official documentation on the **ansible.windows.win_owner** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Obtain information about a file
+      ansible.windows.win_stat:
+        path: C:\foo.ini
+      register: file_info
+
+    - name: Obtain information about a folder
+      ansible.windows.win_stat:
+        path: C:\bar
+      register: folder_info
+
+    - name: Get MD5 checksum of a file
+      ansible.windows.win_stat:
+        path: C:\foo.ini
+        get_checksum: yes
+        checksum_algorithm: md5
+      register: md5_checksum
+
+    - debug:
+        var: md5_checksum.stat.checksum
+
+    - name: Get SHA1 checksum of file
+      ansible.windows.win_stat:
+        path: C:\foo.ini
+        get_checksum: yes
+      register: sha1_checksum
+
+    - debug:
+        var: sha1_checksum.stat.checksum
+
+    - name: Get SHA256 checksum of file
+      ansible.windows.win_stat:
+        path: C:\foo.ini
+        get_checksum: yes
+        checksum_algorithm: sha256
+      register: sha256_checksum
+
+    - debug:
+        var: sha256_checksum.stat.checksum
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>changed</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>Whether anything was changed</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>stat</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">complex</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>dictionary containing all the stat data</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>attributes</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>Attributes of the file at path in raw form.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Archive, Hidden</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>checksum</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exist, path is a file, get_checksum == True checksum_algorithm specified is supported</td>
+                <td>
+                                                                        <div>The checksum of a file based on checksum_algorithm specified.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">09cb79e8fc7453c84a07f644e441fd81623b7f98</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>creationtime</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">float</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>The create time of the file represented in seconds since epoch.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1477984205.15</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>exists</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>If the path exists or not.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>extension</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists, path is a file</td>
+                <td>
+                                                                        <div>The extension of the file at path.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">.ps1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>filename</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists, path is a file</td>
+                <td>
+                                                                        <div>The name of the file (without path).</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">foo.ini</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>hlnk_targets</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>List of other files pointing to the same file (hard links), excludes the current file.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;C:\\temp\\file.txt&#x27;, &#x27;C:\\Windows\\update.log&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>isarchive</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>If the path is ready for archiving or not.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>isdir</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>If the path is a directory or not.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>ishidden</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>If the path is hidden or not.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>isjunction</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>If the path is a junction point or not.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>islnk</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>If the path is a symbolic link or not.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>isreadonly</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>If the path is read only or not.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>isreg</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>If the path is a regular file.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>isshared</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>If the path is shared or not.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>lastaccesstime</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">float</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>The last access time of the file represented in seconds since epoch.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1477984205.15</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>lastwritetime</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">float</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>The last modification time of the file represented in seconds since epoch.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1477984205.15</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>lnk_source</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists and the path is a symbolic link or junction point</td>
+                <td>
+                                                                        <div>Target of the symlink normalized for the remote filesystem.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">C:\temp\link</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>lnk_target</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists and the path is a symbolic link or junction point</td>
+                <td>
+                                                                        <div>Target of the symlink. Note that relative paths remain relative.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">..\link</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>nlink</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>Number of links to the file (hard links).</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>owner</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists</td>
+                <td>
+                                                                        <div>The owner of the file.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BUILTIN\Administrators</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists, file exists</td>
+                <td>
+                                                                        <div>The full absolute path to the file.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">C:\foo.ini</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>sharename</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists, file is a directory and isshared == True</td>
+                <td>
+                                                                        <div>The name of share if folder is shared.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">file-share</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>size</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>success, path exists, file is not a link</td>
+                <td>
+                                                                        <div>The size in bytes of a file or folder.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1024</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Chris Church (@cchurch)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_tempfile.rst
+++ b/docs/ansible.windows.win_tempfile.rst
@@ -1,0 +1,184 @@
+:orphan:
+
+.. _ansible.windows.win_tempfile_module:
+
+
+****************************
+ansible.windows.win_tempfile
+****************************
+
+**Creates temporary files and directories**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Creates temporary files and directories.
+- For non-Windows targets, please use the :ref:`tempfile <tempfile_module>` module instead.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"%TEMP%"</div>
+                                    </td>
+                                                                <td>
+                                            <div>Location where temporary file or directory should be created.</div>
+                                            <div>If path is not specified default system temporary directory (%TEMP%) will be used.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: dest</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>prefix</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"ansible."</div>
+                                    </td>
+                                                                <td>
+                                            <div>Prefix of file/directory name created by module.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>directory</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>file</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether to create file or directory.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>suffix</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">""</div>
+                                    </td>
+                                                                <td>
+                                            <div>Suffix of file/directory name created by module.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`tempfile_module`
+      The official documentation on the **tempfile** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Create temporary build directory
+      ansible.windows.win_tempfile:
+        state: directory
+        suffix: build
+
+    - name: Create temporary file
+      ansible.windows.win_tempfile:
+        state: file
+        suffix: temp
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The absolute path to the created file or directory.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">C:\Users\Administrator\AppData\Local\Temp\ansible.bMlvdk</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Dag Wieers (@dagwieers)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_template.rst
+++ b/docs/ansible.windows.win_template.rst
@@ -1,0 +1,358 @@
+:orphan:
+
+.. _ansible.windows.win_template_module:
+
+
+****************************
+ansible.windows.win_template
+****************************
+
+**Template a file out to a remote server**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Templates are processed by the `Jinja2 templating language <http://jinja.pocoo.org/docs/>`_.
+- Documentation on the template formatting can be found in the `Template Designer Documentation <http://jinja.pocoo.org/docs/templates/>`_.
+- Additional variables listed below can be used in templates.
+- ``ansible_managed`` (configurable via the ``defaults`` section of ``ansible.cfg``) contains a string which can be used to describe the template name, host, modification time of the template file and the owner uid.
+- ``template_host`` contains the node name of the template's machine.
+- ``template_uid`` is the numeric user id of the owner.
+- ``template_path`` is the path of the template.
+- ``template_fullpath`` is the absolute path of the template.
+- ``template_destpath`` is the path of the template on the remote system (added in 2.8).
+- ``template_run_date`` is the date that the template was rendered.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>backup</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Determine whether a backup should be created.</div>
+                                            <div>When set to <code>yes</code>, create a backup file including the timestamp information so you can get the original file back if you somehow clobbered it incorrectly.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>block_end_string</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"%}"</div>
+                                    </td>
+                                                                <td>
+                                            <div>The string marking the end of a block.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>block_start_string</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"{%"</div>
+                                    </td>
+                                                                <td>
+                                            <div>The string marking the beginning of a block.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dest</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Location to render the template to on the remote machine.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>force</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Determine when the file is being transferred if the destination already exists.</div>
+                                            <div>When set to <code>yes</code>, replace the remote file when contents are different than the source.</div>
+                                            <div>When set to <code>no</code>, the file will only be transferred if the destination does not exist.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>lstrip_blocks</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Determine when leading spaces and tabs should be stripped.</div>
+                                            <div>When set to <code>yes</code> leading spaces and tabs are stripped from the start of a line to a block.</div>
+                                            <div>This functionality requires Jinja 2.7 or newer.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>newline_sequence</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>\n</li>
+                                                                                                                                                                                                <li>\r</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>\r\n</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Specify the newline sequence to use for templating files.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>output_encoding</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"utf-8"</div>
+                                    </td>
+                                                                <td>
+                                            <div>Overrides the encoding used to write the template file defined by <code>dest</code>.</div>
+                                            <div>It defaults to <code>utf-8</code>, but any encoding supported by python can be used.</div>
+                                            <div>The source template file must always be encoded using <code>utf-8</code>, for homogeneity.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>src</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Path of a Jinja2 formatted template on the Ansible controller.</div>
+                                            <div>This can be a relative or an absolute path.</div>
+                                            <div>The file must be encoded with <code>utf-8</code> but <em>output_encoding</em> can be used to control the encoding of the output template.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>trim_blocks</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Determine when newlines should be removed from blocks.</div>
+                                            <div>When set to <code>yes</code> the first newline after a block is removed (block, not variable tag!).</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>variable_end_string</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"}}"</div>
+                                    </td>
+                                                                <td>
+                                            <div>The string marking the end of a print statement.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>variable_start_string</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"{{"</div>
+                                    </td>
+                                                                <td>
+                                            <div>The string marking the beginning of a print statement.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - Including a string that uses a date in the template will result in the template being marked 'changed' each time.
+   - Also, you can override jinja2 settings by adding a special header to template file. i.e. ``#jinja2:variable_start_string:'[%', variable_end_string:'%]', trim_blocks: False`` which changes the variable interpolation markers to ``[% var %]`` instead of ``{{ var }}``. This is the best way to prevent evaluation of things that look like, but should not be Jinja2.
+
+   - Using raw/endraw in Jinja2 will not work as you expect because templates in Ansible are recursively evaluated.
+   - To find Byte Order Marks in files, use ``Format-Hex <file> -Count 16`` on Windows, and use ``od -a -t x1 -N 16 <file>`` on Linux.
+   - Beware fetching files from windows machines when creating templates because certain tools, such as Powershell ISE, and regedit's export facility add a Byte Order Mark as the first character of the file, which can cause tracebacks.
+   - You can use the :ref:`ansible.windows.win_copy <ansible.windows.win_copy_module>` module with the ``content:`` option if you prefer the template inline, as part of the playbook.
+   - For Linux you can use :ref:`template <template_module>` which uses '\\n' as ``newline_sequence`` by default.
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`ansible.windows.win_copy_module`
+      The official documentation on the **ansible.windows.win_copy** module.
+   :ref:`copy_module`
+      The official documentation on the **copy** module.
+   :ref:`template_module`
+      The official documentation on the **template** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Create a file from a Jinja2 template
+      ansible.windows.win_template:
+        src: /mytemplates/file.conf.j2
+        dest: C:\Temp\file.conf
+
+    - name: Create a Unix-style file from a Jinja2 template
+      ansible.windows.win_template:
+        src: unix/config.conf.j2
+        dest: C:\share\unix\config.conf
+        newline_sequence: '\n'
+        backup: yes
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>backup_file</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>if backup=yes</td>
+                <td>
+                                                                        <div>Name of the backup file that was created.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">C:\Path\To\File.txt.11540.20150212-220915.bak</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Jon Hawkesworth (@jhawkesworth)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_updates.rst
+++ b/docs/ansible.windows.win_updates.rst
@@ -1,0 +1,559 @@
+:orphan:
+
+.. _ansible.windows.win_updates_module:
+
+
+***************************
+ansible.windows.win_updates
+***************************
+
+**Download and install Windows updates**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Searches, downloads, and installs Windows updates synchronously by automating the Windows Update client.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>blacklist</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A list of update titles or KB numbers that can be used to specify which updates are to be excluded from installation.</div>
+                                            <div>If an available update does match one of the entries, then it is skipped and not installed.</div>
+                                            <div>Each entry can either be the KB article or Update title as a regex according to the PowerShell regex rules.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>category_names</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">["CriticalUpdates", "SecurityUpdates", "UpdateRollups"]</div>
+                                    </td>
+                                                                <td>
+                                            <div>A scalar or list of categories to install updates from. To get the list of categories, run the module with <code>state=searched</code>. The category must be the full category string, but is case insensitive.</div>
+                                            <div>Some possible categories are Application, Connectors, Critical Updates, Definition Updates, Developer Kits, Feature Packs, Guidance, Security Updates, Service Packs, Tools, Update Rollups and Updates.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>log_path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>If set, <code>win_updates</code> will append update progress to the specified file. The directory must already exist.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>reboot</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Ansible will automatically reboot the remote host if it is required and continue to install updates after the reboot.</div>
+                                            <div>This can be used instead of using a <span class='module'>ansible.windows.win_reboot</span> task after this one and ensures all updates for that category is installed in one go.</div>
+                                            <div>Async does not work when <code>reboot=yes</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>reboot_timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1200</div>
+                                    </td>
+                                                                <td>
+                                            <div>The time in seconds to wait until the host is back online from a reboot.</div>
+                                            <div>This is only used if <code>reboot=yes</code> and a reboot is required.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>server_selection</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>default</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>managed_server</li>
+                                                                                                                                                                                                <li>windows_update</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Defines the Windows Update source catalog.</div>
+                                            <div><code>default</code> Use the default search source. For many systems default is set to the Microsoft Windows Update catalog. Systems participating in Windows Server Update Services (WSUS), Systems Center Configuration Manager (SCCM), or similar corporate update server environments may default to those managed update sources instead of the Windows Update catalog.</div>
+                                            <div><code>managed_server</code> Use a managed server catalog. For environments utilizing Windows Server Update Services (WSUS), Systems Center Configuration Manager (SCCM), or similar corporate update servers, this option selects the defined corporate update source.</div>
+                                            <div><code>windows_update</code> Use the Microsoft Windows Update catalog.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>installed</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>searched</li>
+                                                                                                                                                                                                <li>downloaded</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Controls whether found updates are downloaded or installed or listed</div>
+                                            <div>This module also supports Ansible check mode, which has the same effect as setting state=searched</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>use_scheduled_task</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Will not auto elevate the remote process with <em>become</em> and use a scheduled task instead.</div>
+                                            <div>Set this to <code>yes</code> when using this module with async on Server 2008, 2008 R2, or Windows 7, or on Server 2008 that is not authenticated with basic or credssp.</div>
+                                            <div>Can also be set to <code>yes</code> on newer hosts where become does not work due to further privilege restrictions from the OS defaults.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>whitelist</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A list of update titles or KB numbers that can be used to specify which updates are to be searched or installed.</div>
+                                            <div>If an available update does not match one of the entries, then it is skipped and not installed.</div>
+                                            <div>Each entry can either be the KB article or Update title as a regex according to the PowerShell regex rules.</div>
+                                            <div>The whitelist is only validated on updates that were found based on <em>category_names</em>. It will not force the module to install an update if it was not in the category specified.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - :ref:`ansible.windows.win_updates <ansible.windows.win_updates_module>` must be run by a user with membership in the local Administrators group.
+   - :ref:`ansible.windows.win_updates <ansible.windows.win_updates_module>` will use the default update service configured for the machine (Windows Update, Microsoft Update, WSUS, etc).
+   - :ref:`ansible.windows.win_updates <ansible.windows.win_updates_module>` will *become* SYSTEM using *runas* unless ``use_scheduled_task`` is ``yes``
+   - By default :ref:`ansible.windows.win_updates <ansible.windows.win_updates_module>` does not manage reboots, but will signal when a reboot is required with the *reboot_required* return value. :ref:`reboot <reboot_module>` can be used to reboot the host if required in the one task.
+   - :ref:`ansible.windows.win_updates <ansible.windows.win_updates_module>` can take a significant amount of time to complete (hours, in some cases). Performance depends on many factors, including OS version, number of updates, system load, and update server load.
+   - Beware that just after :ref:`ansible.windows.win_updates <ansible.windows.win_updates_module>` reboots the system, the Windows system may not have settled yet and some base services could be in limbo. This can result in unexpected behavior. Check the examples for ways to mitigate this.
+   - More information about PowerShell and how it handles RegEx strings can be found at https://technet.microsoft.com/en-us/library/2007.11.powershell.aspx.
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`chocolatey.chocolatey.win_chocolatey_module`
+      The official documentation on the **chocolatey.chocolatey.win_chocolatey** module.
+   :ref:`ansible.windows.win_feature_module`
+      The official documentation on the **ansible.windows.win_feature** module.
+   :ref:`community.windows.win_hotfix_module`
+      The official documentation on the **community.windows.win_hotfix** module.
+   :ref:`ansible.windows.win_package_module`
+      The official documentation on the **ansible.windows.win_package** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Install all security, critical, and rollup updates without a scheduled task
+      ansible.windows.win_updates:
+        category_names:
+          - SecurityUpdates
+          - CriticalUpdates
+          - UpdateRollups
+
+    - name: Install only security updates as a scheduled task for Server 2008
+      ansible.windows.win_updates:
+        category_names: SecurityUpdates
+        use_scheduled_task: yes
+
+    - name: Search-only, return list of found updates (if any), log to C:\ansible_wu.txt
+      ansible.windows.win_updates:
+        category_names: SecurityUpdates
+        state: searched
+        log_path: C:\ansible_wu.txt
+
+    - name: Install all security updates with automatic reboots
+      ansible.windows.win_updates:
+        category_names:
+        - SecurityUpdates
+        reboot: yes
+
+    - name: Install only particular updates based on the KB numbers
+      ansible.windows.win_updates:
+        category_name:
+        - SecurityUpdates
+        whitelist:
+        - KB4056892
+        - KB4073117
+
+    - name: Exclude updates based on the update title
+      ansible.windows.win_updates:
+        category_name:
+        - SecurityUpdates
+        - CriticalUpdates
+        blacklist:
+        - Windows Malicious Software Removal Tool for Windows
+        - \d{4}-\d{2} Cumulative Update for Windows Server 2016
+
+    # One way to ensure the system is reliable just after a reboot, is to set WinRM to a delayed startup
+    - name: Ensure WinRM starts when the system has settled and is ready to work reliably
+      ansible.windows.win_service:
+        name: WinRM
+        start_mode: delayed
+
+    # Optionally, you can increase the reboot_timeout to survive long updates during reboot
+    - name: Ensure we wait long enough for the updates to be applied during reboot
+      ansible.windows.win_updates:
+        reboot: yes
+        reboot_timeout: 3600
+
+    # Search and download Windows updates
+    - name: Search and download Windows updates without installing them
+      ansible.windows.win_updates:
+        state: downloaded
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>failed_update_count</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The number of updates that failed to install.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>filtered_updates</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">complex</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>List of updates that were found but were filtered based on <em>blacklist</em>, <em>whitelist</em> or <em>category_names</em>. The return value is in the same form as <em>updates</em>, along with <em>filtered_reason</em>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">see the updates return value</div>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>filtered_reason</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The reason why this update was filtered.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">skip_hidden</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>found_update_count</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The number of updates found needing to be applied.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">3</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>installed_update_count</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The number of updates successfully installed or downloaded.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>reboot_required</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>True when the target server requires a reboot to complete updates (no further updates can be installed until after a reboot).</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>updates</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">complex</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>List of updates that were found/installed.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>categories</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                       / <span style="color: purple">elements=string</span>                    </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>A list of category strings for this update.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;Critical Updates&#x27;, &#x27;Windows Server 2012 R2&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>failure_hresult_code</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>on install failure</td>
+                <td>
+                                                                        <div>The HRESULT code from a failed update.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2147942402</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>id</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>Internal Windows Update GUID.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">fb95c1c8-de23-4089-ae29-fd3351d55421</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>installed</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>Was the update successfully installed.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>kb</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                       / <span style="color: purple">elements=string</span>                    </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>A list of KB article IDs that apply to the update.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;3004365&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>title</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>Display name.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Security Update for Windows Server 2012 R2 (KB3004365)</div>
+                                    </td>
+            </tr>
+                    
+                                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Matt Davis (@nitzmahone)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_uri.rst
+++ b/docs/ansible.windows.win_uri.rst
@@ -1,0 +1,687 @@
+:orphan:
+
+.. _ansible.windows.win_uri_module:
+
+
+***********************
+ansible.windows.win_uri
+***********************
+
+**Interacts with webservices**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Interacts with FTP, HTTP and HTTPS web services.
+- Supports Digest, Basic and WSSE HTTP authentication mechanisms.
+- For non-Windows targets, use the :ref:`uri <uri_module>` module instead.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>body</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">raw</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The body of the HTTP request/response to the web service.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>client_cert</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The path to the client certificate (.pfx) that is used for X509 authentication. This path can either be the path to the <code>pfx</code> on the filesystem or the PowerShell certificate path <code>Cert:\CurrentUser\My\&lt;thumbprint&gt;</code>.</div>
+                                            <div>The WinRM connection must be authenticated with <code>CredSSP</code> or <code>become</code> is used on the task if the certificate file is not password protected.</div>
+                                            <div>Other authentication types can set <em>client_cert_password</em> when the cert is password protected.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>client_cert_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The password for <em>client_cert</em> if the cert is password protected.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>content_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Sets the &quot;Content-Type&quot; header.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>creates</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A filename, when it already exists, this step will be skipped.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>dest</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Output the response body to a file.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>follow_redirects</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>all</li>
+                                                                                                                                                                                                <li>none</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>safe</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether or the module should follow redirects.</div>
+                                            <div><code>all</code> will follow all redirect.</div>
+                                            <div><code>none</code> will not follow any redirect.</div>
+                                            <div><code>safe</code> will follow only &quot;safe&quot; redirects, where &quot;safe&quot; means that the client is only doing a <code>GET</code> or <code>HEAD</code> on the URI to which it is being redirected.</div>
+                                            <div>When following a redirected URL, the <code>Authorization</code> header and any credentials set will be dropped and not redirected.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>force_basic_auth</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>By default the authentication header is only sent when a webservice responses to an initial request with a 401 status. Since some basic auth services do not properly send a 401, logins will fail.</div>
+                                            <div>This option forces the sending of the Basic authentication header upon the original request.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>headers</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Extra headers to set on the request.</div>
+                                            <div>This should be a dictionary where the key is the header name and the value is the value for that header.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>http_agent</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"ansible-httpget"</div>
+                                    </td>
+                                                                <td>
+                                            <div>Header to identify as, generally appears in web server logs.</div>
+                                            <div>This is set to the <code>User-Agent</code> header on a HTTP request.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>maximum_redirection</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">50</div>
+                                    </td>
+                                                                <td>
+                                            <div>Specify how many times the module will redirect a connection to an alternative URI before the connection fails.</div>
+                                            <div>If set to <code>0</code> or <em>follow_redirects</em> is set to <code>none</code>, or <code>safe</code> when not doing a <code>GET</code> or <code>HEAD</code> it prevents all redirection.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The password for <em>proxy_username</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_url</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>An explicit proxy to use for the request.</div>
+                                            <div>By default, the request will use the IE defined proxy unless <em>use_proxy</em> is set to <code>no</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_use_default_credential</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Uses the current user&#x27;s credentials when authenticating with a proxy host protected with <code>NTLM</code>, <code>Kerberos</code>, or <code>Negotiate</code> authentication.</div>
+                                            <div>Proxies that use <code>Basic</code> auth will still require explicit credentials through the <em>proxy_username</em> and <em>proxy_password</em> options.</div>
+                                            <div>The module will only have access to the user&#x27;s credentials if using <code>become</code> with a password, you are connecting with SSH using a password, or connecting with WinRM using <code>CredSSP</code> or <code>Kerberos with delegation</code>.</div>
+                                            <div>If not using <code>become</code> or a different auth method to the ones stated above, there will be no default credentials available and no proxy authentication will occur.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The username to use for proxy authentication.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>removes</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A filename, when it does not exist, this step will be skipped.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>return_content</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Whether or not to return the body of the response as a &quot;content&quot; key in the dictionary result. If the reported Content-type is &quot;application/json&quot;, then the JSON is additionally loaded into a key called <code>json</code> in the dictionary results.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>status_code</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=integer</span>                                            </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">[200]</div>
+                                    </td>
+                                                                <td>
+                                            <div>A valid, numeric, HTTP status code that signifies success of the request.</div>
+                                            <div>Can also be comma separated list of status codes.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>url</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Supports FTP, HTTP or HTTPS URLs in the form of (ftp|http|https)://host.domain:port/path.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>url_method</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"GET"</div>
+                                    </td>
+                                                                <td>
+                                            <div>The HTTP Method of the request.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: method</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>url_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The password for <em>url_username</em>.</div>
+                                            <div>The alias <em>password</em> is deprecated and will be removed on the major release after <code>2022-07-01</code>.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: password</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>url_timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">30</div>
+                                    </td>
+                                                                <td>
+                                            <div>Specifies how long the request can be pending before it times out (in seconds).</div>
+                                            <div>Set to <code>0</code> to specify an infinite timeout.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: timeout</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>url_username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The username to use for authentication.</div>
+                                            <div>The alias <em>user</em> and <em>username</em> is deprecated and will be removed on the major release after <code>2022-07-01</code>.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: user, username</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>use_default_credential</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>Uses the current user&#x27;s credentials when authenticating with a server protected with <code>NTLM</code>, <code>Kerberos</code>, or <code>Negotiate</code> authentication.</div>
+                                            <div>Sites that use <code>Basic</code> auth will still require explicit credentials through the <em>url_username</em> and <em>url_password</em> options.</div>
+                                            <div>The module will only have access to the user&#x27;s credentials if using <code>become</code> with a password, you are connecting with SSH using a password, or connecting with WinRM using <code>CredSSP</code> or <code>Kerberos with delegation</code>.</div>
+                                            <div>If not using <code>become</code> or a different auth method to the ones stated above, there will be no default credentials available and no authentication will occur.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>use_proxy</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>If <code>no</code>, it will not use the proxy defined in IE for the current user.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_certs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                                                                    <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>If <code>no</code>, SSL certificates will not be validated.</div>
+                                            <div>This should only be used on personally controlled sites using self-signed certificates.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`uri_module`
+      The official documentation on the **uri** module.
+   :ref:`ansible.windows.win_get_url_module`
+      The official documentation on the **ansible.windows.win_get_url** module.
+   :ref:`community.windows.win_inet_proxy_module`
+      The official documentation on the **community.windows.win_inet_proxy** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Perform a GET and Store Output
+      ansible.windows.win_uri:
+        url: http://example.com/endpoint
+      register: http_output
+
+    # Set a HOST header to hit an internal webserver:
+    - name: Hit a Specific Host on the Server
+      ansible.windows.win_uri:
+        url: http://example.com/
+        method: GET
+        headers:
+          host: www.somesite.com
+
+    - name: Perform a HEAD on an Endpoint
+      ansible.windows.win_uri:
+        url: http://www.example.com/
+        method: HEAD
+
+    - name: POST a Body to an Endpoint
+      ansible.windows.win_uri:
+        url: http://www.somesite.com/
+        method: POST
+        body: "{ 'some': 'json' }"
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>content</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success and return_content is True</td>
+                <td>
+                                                                        <div>The raw content of the HTTP response.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&quot;foo&quot;: &quot;bar&quot;}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>content_length</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The byte size of the response.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">54447</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>elapsed</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">float</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The number of seconds that elapsed while performing the download.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">23.2</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>json</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                                          </div>
+                                    </td>
+                <td>success and Content-Type is &quot;application/json&quot; or &quot;application/javascript&quot; and return_content is True</td>
+                <td>
+                                                                        <div>The json structure returned under content as a dictionary.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;this-is-dependent&#x27;: &#x27;on the actual return content&#x27;}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>status_code</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The HTTP Status Code of the response.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">200</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>status_description</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>A summary of the status.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">OK</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>url</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The Target URL.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">https://www.ansible.com</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Corwin Brown (@blakfeld)
+- Dag Wieers (@dagwieers)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_user.rst
+++ b/docs/ansible.windows.win_user.rst
@@ -1,0 +1,528 @@
+:orphan:
+
+.. _ansible.windows.win_user_module:
+
+
+************************
+ansible.windows.win_user
+************************
+
+**Manages local Windows user accounts**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Manages local Windows user accounts.
+- For non-Windows targets, use the :ref:`user <user_module>` module instead.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>account_disabled</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div><code>yes</code> will disable the user account.</div>
+                                            <div><code>no</code> will clear the disabled flag.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>account_locked</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div><code>no</code> will unlock the user account if locked.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>description</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Description of the user.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>fullname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Full name of the user.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>groups</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">-</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Adds or removes the user from this comma-separated list of groups, depending on the value of <em>groups_action</em>.</div>
+                                            <div>When <em>groups_action</em> is <code>replace</code> and <em>groups</em> is set to the empty string (&#x27;groups=&#x27;), the user is removed from all groups.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>groups_action</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>add</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>replace</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>remove</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>If <code>add</code>, the user is added to each group in <em>groups</em> where not already a member.</div>
+                                            <div>If <code>replace</code>, the user is added as a member of each group in <em>groups</em> and removed from any other groups.</div>
+                                            <div>If <code>remove</code>, the user is removed from each group in <em>groups</em>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Name of the user to create, remove or modify.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Optionally set the user&#x27;s password to this (plain text) value.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password_expired</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div><code>yes</code> will require the user to change their password at next login.</div>
+                                            <div><code>no</code> will clear the expired password flag.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password_never_expires</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div><code>yes</code> will set the password to never expire.</div>
+                                            <div><code>no</code> will allow the password to expire.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>query</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>When <code>absent</code>, removes the user account if it exists.</div>
+                                            <div>When <code>present</code>, creates or updates the user account.</div>
+                                            <div>When <code>query</code> (new in 1.9), retrieves the user account details without making any changes.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>update_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li><div style="color: blue"><b>always</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>on_create</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div><code>always</code> will update passwords if they differ.  <code>on_create</code> will only set the password for newly created users.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>user_cannot_change_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>no</li>
+                                                                                                                                                                                                <li>yes</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div><code>yes</code> will prevent the user from changing their password.</div>
+                                            <div><code>no</code> will allow the user to change their password.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`user_module`
+      The official documentation on the **user** module.
+   :ref:`ansible.windows.win_domain_membership_module`
+      The official documentation on the **ansible.windows.win_domain_membership** module.
+   :ref:`community.windows.win_domain_user_module`
+      The official documentation on the **community.windows.win_domain_user** module.
+   :ref:`ansible.windows.win_group_module`
+      The official documentation on the **ansible.windows.win_group** module.
+   :ref:`ansible.windows.win_group_membership_module`
+      The official documentation on the **ansible.windows.win_group_membership** module.
+   :ref:`community.windows.win_user_profile_module`
+      The official documentation on the **community.windows.win_user_profile** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Ensure user bob is present
+      ansible.windows.win_user:
+        name: bob
+        password: B0bP4ssw0rd
+        state: present
+        groups:
+          - Users
+
+    - name: Ensure user bob is absent
+      ansible.windows.win_user:
+        name: bob
+        state: absent
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>account_disabled</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>user exists</td>
+                <td>
+                                                                        <div>Whether the user is disabled.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>account_locked</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>user exists</td>
+                <td>
+                                                                        <div>Whether the user is locked.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>description</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>user exists</td>
+                <td>
+                                                                        <div>The description set for the user.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Username for test</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>fullname</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>user exists</td>
+                <td>
+                                                                        <div>The full name set for the user.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Test Username</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>groups</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>user exists</td>
+                <td>
+                                                                        <div>A list of groups and their ADSI path the user is a member of.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{&#x27;name&#x27;: &#x27;Administrators&#x27;, &#x27;path&#x27;: &#x27;WinNT://WORKGROUP/USER-PC/Administrators&#x27;}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The name of the user</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">username</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>password_expired</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>user exists</td>
+                <td>
+                                                                        <div>Whether the password is expired.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>password_never_expires</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>user exists</td>
+                <td>
+                                                                        <div>Whether the password is set to never expire.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">True</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>user exists</td>
+                <td>
+                                                                        <div>The ADSI path for the user.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">WinNT://WORKGROUP/USER-PC/username</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>sid</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>user exists</td>
+                <td>
+                                                                        <div>The SID for the user.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">S-1-5-21-3322259488-2828151810-3939402796-1001</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>user_cannot_change_password</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">boolean</span>
+                                          </div>
+                                    </td>
+                <td>user exists</td>
+                <td>
+                                                                        <div>Whether the user can change their own password.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Paul Durivage (@angstwad)
+- Chris Church (@cchurch)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_user_right.rst
+++ b/docs/ansible.windows.win_user_right.rst
@@ -1,0 +1,221 @@
+:orphan:
+
+.. _ansible.windows.win_user_right_module:
+
+
+******************************
+ansible.windows.win_user_right
+******************************
+
+**Manage Windows User Rights**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Add, remove or set User Rights for a group or users or groups.
+- You can set user rights for both local and domain accounts.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>action</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>add</li>
+                                                                                                                                                                                                <li>remove</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>set</b>&nbsp;&larr;</div></li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div><code>add</code> will add the users/groups to the existing right.</div>
+                                            <div><code>remove</code> will remove the users/groups from the existing right.</div>
+                                            <div><code>set</code> will replace the users/groups of the existing right.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The name of the User Right as shown by the <code>Constant Name</code> value from <a href='https://technet.microsoft.com/en-us/library/dd349804.aspx'>https://technet.microsoft.com/en-us/library/dd349804.aspx</a>.</div>
+                                            <div>The module will return an error if the right is invalid.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>users</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                                                 / <span style="color: red">required</span>                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>A list of users or groups to add/remove on the User Right.</div>
+                                            <div>These can be in the form DOMAIN\user-group, user-group@DOMAIN.COM for domain users/groups.</div>
+                                            <div>For local users/groups it can be in the form user-group, .\user-group, SERVERNAME\user-group where SERVERNAME is the name of the remote server.</div>
+                                            <div>You can also add special local accounts like SYSTEM and others.</div>
+                                            <div>Can be set to an empty list with <em>action=set</em> to remove all accounts from the right.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - If the server is domain joined this module can change a right but if a GPO governs this right then the changes won't last.
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`ansible.windows.win_group_module`
+      The official documentation on the **ansible.windows.win_group** module.
+   :ref:`ansible.windows.win_group_membership_module`
+      The official documentation on the **ansible.windows.win_group_membership** module.
+   :ref:`ansible.windows.win_user_module`
+      The official documentation on the **ansible.windows.win_user** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    ---
+    - name: Replace the entries of Deny log on locally
+      ansible.windows.win_user_right:
+        name: SeDenyInteractiveLogonRight
+        users:
+        - Guest
+        - Users
+        action: set
+
+    - name: Add account to Log on as a service
+      ansible.windows.win_user_right:
+        name: SeServiceLogonRight
+        users:
+        - .\Administrator
+        - '{{ansible_hostname}}\local-user'
+        action: add
+
+    - name: Remove accounts who can create Symbolic links
+      ansible.windows.win_user_right:
+        name: SeCreateSymbolicLinkPrivilege
+        users:
+        - SYSTEM
+        - Administrators
+        - DOMAIN\User
+        - group@DOMAIN.COM
+        action: remove
+
+    - name: Remove all accounts who cannot log on remote interactively
+      ansible.windows.win_user_right:
+        name: SeDenyRemoteInteractiveLogonRight
+        users: []
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>added</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>A list of accounts that were added to the right, this is empty if no accounts were added.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;NT AUTHORITY\\SYSTEM&#x27;, &#x27;DOMAIN\\User&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>removed</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>A list of accounts that were removed from the right, this is empty if no accounts were removed.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;SERVERNAME\\Administrator&#x27;, &#x27;BUILTIN\\Administrators&#x27;]</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Jordan Borean (@jborean93)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_wait_for.rst
+++ b/docs/ansible.windows.win_wait_for.rst
@@ -1,0 +1,335 @@
+:orphan:
+
+.. _ansible.windows.win_wait_for_module:
+
+
+****************************
+ansible.windows.win_wait_for
+****************************
+
+**Waits for a condition before continuing**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- You can wait for a set amount of time ``timeout``, this is the default if nothing is specified.
+- Waiting for a port to become available is useful for when services are not immediately available after their init scripts return which is true of certain Java application servers.
+- You can wait for a file to exist or not exist on the filesystem.
+- This module can also be used to wait for a regex match string to be present in a file.
+- You can wait for active connections to be closed before continuing on a local port.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+                        <th width="100%">Comments</th>
+        </tr>
+                    <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>connect_timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">5</div>
+                                    </td>
+                                                                <td>
+                                            <div>The maximum number of seconds to wait for a connection to happen before closing and retrying.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>delay</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The number of seconds to wait before starting to poll.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>exclude_hosts</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The list of hosts or IPs to ignore when looking for active TCP connections when <code>state=drained</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">"127.0.0.1"</div>
+                                    </td>
+                                                                <td>
+                                            <div>A resolvable hostname or IP address to wait for.</div>
+                                            <div>If <code>state=drained</code> then it will only check for connections on the IP specified, you can use &#x27;0.0.0.0&#x27; to use all host IPs.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>path</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">path</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The path to a file on the filesystem to check.</div>
+                                            <div>If <code>state</code> is present or started then it will wait until the file exists.</div>
+                                            <div>If <code>state</code> is absent then it will wait until the file does not exist.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>The port number to poll on <code>host</code>.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>regex</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                            </td>
+                                                                <td>
+                                            <div>Can be used to match a string in a file.</div>
+                                            <div>If <code>state</code> is present or started then it will wait until the regex matches.</div>
+                                            <div>If <code>state</code> is absent then it will wait until the regex does not match.</div>
+                                            <div>Defaults to a multiline regex.</div>
+                                                                <div style="font-size: small; color: darkgreen"><br/>aliases: search_regex, regexp</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>sleep</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">1</div>
+                                    </td>
+                                                                <td>
+                                            <div>Number of seconds to sleep between checks.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                            <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                                                                                                                                                <li>absent</li>
+                                                                                                                                                                                                <li>drained</li>
+                                                                                                                                                                                                <li>present</li>
+                                                                                                                                                                                                <li><div style="color: blue"><b>started</b>&nbsp;&larr;</div></li>
+                                                                                                                                                                                                <li>stopped</li>
+                                                                                    </ul>
+                                                                            </td>
+                                                                <td>
+                                            <div>When checking a port, <code>started</code> will ensure the port is open, <code>stopped</code> will check that is it closed and <code>drained</code> will check for active connections.</div>
+                                            <div>When checking for a file or a search string <code>present</code> or <code>started</code> will ensure that the file or string is present, <code>absent</code> will check that the file or search string is absent or removed.</div>
+                                                        </td>
+            </tr>
+                                <tr>
+                                                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                                                                    </div>
+                                    </td>
+                                <td>
+                                                                                                                                                                    <b>Default:</b><br/><div style="color: blue">300</div>
+                                    </td>
+                                                                <td>
+                                            <div>The maximum number of seconds to wait for.</div>
+                                                        </td>
+            </tr>
+                        </table>
+    <br/>
+
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`wait_for_module`
+      The official documentation on the **wait_for** module.
+   :ref:`community.windows.win_wait_for_process_module`
+      The official documentation on the **community.windows.win_wait_for_process** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Wait 300 seconds for port 8000 to become open on the host, don't start checking for 10 seconds
+      ansible.windows.win_wait_for:
+        port: 8000
+        delay: 10
+
+    - name: Wait 150 seconds for port 8000 of any IP to close active connections
+      ansible.windows.win_wait_for:
+        host: 0.0.0.0
+        port: 8000
+        state: drained
+        timeout: 150
+
+    - name: Wait for port 8000 of any IP to close active connection, ignoring certain hosts
+      ansible.windows.win_wait_for:
+        host: 0.0.0.0
+        port: 8000
+        state: drained
+        exclude_hosts: ['10.2.1.2', '10.2.1.3']
+
+    - name: Wait for file C:\temp\log.txt to exist before continuing
+      ansible.windows.win_wait_for:
+        path: C:\temp\log.txt
+
+    - name: Wait until process complete is in the file before continuing
+      ansible.windows.win_wait_for:
+        path: C:\temp\log.txt
+        regex: process complete
+
+    - name: Wait until file is removed
+      ansible.windows.win_wait_for:
+        path: C:\temp\log.txt
+        state: absent
+
+    - name: Wait until port 1234 is offline but try every 10 seconds
+      ansible.windows.win_wait_for:
+        port: 1234
+        state: absent
+        sleep: 10
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>elapsed</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">float</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The elapsed seconds between the start of poll and the end of the module. This includes the delay if the option is set.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2.1406487</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>wait_attempts</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>always</td>
+                <td>
+                                                                        <div>The number of attempts to poll the file or port before module finishes.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">1</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Jordan Borean (@jborean93)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/docs/ansible.windows.win_whoami.rst
+++ b/docs/ansible.windows.win_whoami.rst
@@ -1,0 +1,501 @@
+:orphan:
+
+.. _ansible.windows.win_whoami_module:
+
+
+**************************
+ansible.windows.win_whoami
+**************************
+
+**Get information about the current user and process**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Designed to return the same information as the ``whoami /all`` command.
+- Also includes information missing from ``whoami`` such as logon metadata like logon rights, id, type.
+
+
+
+
+
+Notes
+-----
+
+.. note::
+   - If running this module with a non admin user, the logon rights will be an empty list as Administrator rights are required to query LSA for the information.
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`community.windows.win_credential_module`
+      The official documentation on the **community.windows.win_credential** module.
+   :ref:`ansible.windows.win_group_membership_module`
+      The official documentation on the **ansible.windows.win_group_membership** module.
+   :ref:`ansible.windows.win_user_right_module`
+      The official documentation on the **ansible.windows.win_user_right** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    
+    - name: Get whoami information
+      ansible.windows.win_whoami:
+
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+                    <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>account</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">complex</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The running account SID details.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>account_name</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The account name of the account SID.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Administrator</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>domain_name</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The domain name of the account SID.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">DOMAIN</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>sid</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The SID in string form.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">S-1-5-21-1654078763-769949647-2968445802-500</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>type</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The type of SID.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">User</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>authentication_package</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The name of the authentication package used to authenticate the user in the session.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Negotiate</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>dns_domain_name</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The DNS name of the logon session, this is an empty string if this is not set.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">DOMAIN.COM</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>groups</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>A list of groups and attributes that the user is a member of.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{&#x27;account_name&#x27;: &#x27;Domain Users&#x27;, &#x27;domain_name&#x27;: &#x27;DOMAIN&#x27;, &#x27;attributes&#x27;: [&#x27;Mandatory&#x27;, &#x27;Enabled by default&#x27;, &#x27;Enabled&#x27;], &#x27;sid&#x27;: &#x27;S-1-5-21-1654078763-769949647-2968445802-513&#x27;, &#x27;type&#x27;: &#x27;Group&#x27;}, {&#x27;account_name&#x27;: &#x27;Administrators&#x27;, &#x27;domain_name&#x27;: &#x27;BUILTIN&#x27;, &#x27;attributes&#x27;: [&#x27;Mandatory&#x27;, &#x27;Enabled by default&#x27;, &#x27;Enabled&#x27;, &#x27;Owner&#x27;], &#x27;sid&#x27;: &#x27;S-1-5-32-544&#x27;, &#x27;type&#x27;: &#x27;Alias&#x27;}]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>impersonation_level</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The impersonation level of the token, only valid if <code>token_type</code> is <code>TokenImpersonation</code>, see <a href='https://msdn.microsoft.com/en-us/library/windows/desktop/aa379572.aspx'>https://msdn.microsoft.com/en-us/library/windows/desktop/aa379572.aspx</a>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">SecurityAnonymous</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>label</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">complex</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The mandatory label set to the logon session.</div>
+                                                                <br/>
+                                    </td>
+            </tr>
+                                                            <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>account_name</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The account name of the label SID.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">High Mandatory Level</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>domain_name</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The domain name of the label SID.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Mandatory Label</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>sid</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The SID in string form.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">S-1-16-12288</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                    <td class="elbow-placeholder">&nbsp;</td>
+                                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>type</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The type of SID.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Label</div>
+                                    </td>
+            </tr>
+                    
+                                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>login_domain</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The name of the domain used to authenticate the owner of the session.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">DOMAIN</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>login_time</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The logon time in ISO 8601 format</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">2017-11-27T06:24:14.3321665+10:00</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>logon_id</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">integer</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The unique identifier of the logon session.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">20470143</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>logon_server</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The name of the server used to authenticate the owner of the logon session.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">DC01</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>logon_type</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The logon type that identifies the logon method, see <a href='https://msdn.microsoft.com/en-us/library/windows/desktop/aa380129.aspx'>https://msdn.microsoft.com/en-us/library/windows/desktop/aa380129.aspx</a>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Network</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>privileges</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>A dictionary of privileges and their state on the logon token.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;SeChangeNotifyPrivileges&#x27;: &#x27;enabled-by-default&#x27;, &#x27;SeRemoteShutdownPrivilege&#x27;: &#x27;disabled&#x27;, &#x27;SeDebugPrivilege&#x27;: &#x27;enabled&#x27;}</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>rights</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                                          </div>
+                                    </td>
+                <td>success and running user is a member of the local Administrators group</td>
+                <td>
+                                                                        <div>A list of logon rights assigned to the logon.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[&#x27;SeNetworkLogonRight&#x27;, &#x27;SeInteractiveLogonRight&#x27;, &#x27;SeBatchLogonRight&#x27;, &#x27;SeRemoteInteractiveLogonRight&#x27;]</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>token_type</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The token type to indicate whether it is a primary or impersonation token.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">TokenPrimary</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>upn</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The user principal name of the current user.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Administrator@DOMAIN.COM</div>
+                                    </td>
+            </tr>
+                                <tr>
+                                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>user_flags</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                                          </div>
+                                    </td>
+                <td>success</td>
+                <td>
+                                                                        <div>The user flags for the logon session, see UserFlags in <a href='https://msdn.microsoft.com/en-us/library/windows/desktop/aa380128'>https://msdn.microsoft.com/en-us/library/windows/desktop/aa380128</a>.</div>
+                                                                <br/>
+                                            <div style="font-size: smaller"><b>Sample:</b></div>
+                                                <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Winlogon</div>
+                                    </td>
+            </tr>
+                        </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Jordan Borean (@jborean93)
+
+
+.. hint::
+    Configuration entries for each entry type have a low to high priority order. For example, a variable that is lower in the list will override a variable that is higher up.

--- a/plugins/filter/quote.py
+++ b/plugins/filter/quote.py
@@ -71,11 +71,12 @@ def _quote_pwsh(s):
 
 
 def quote(value, shell=None):
-    """
-    Quotes argument(s) for the various shells in Windows command processing. Will default to escaping arguments based
-    on the Win32 C argv parsing rules that 'win_command' uses but shell='cmd' or shell='powershell' can be set to
-    escape arguments for those respective shells. Each value is escaped in a way to ensure the process gets the literal
-    argument passed in and meta chars escaped.
+    """Quotes argument(s) for the various shells in Windows command processing.
+
+    Quotes argument(s) for the various Windows command line shells. Default to escaping arguments based on the Win32 C
+    argv parsing rules that 'win_command' uses but shell='cmd' or shell='powershell' can be set to escape arguments for
+    those respective shells. Each value is escaped in a way to ensure the process gets the literal argument passed in
+    and meta chars escaped.
 
     When passing in a dict, the arguments will be in the form 'key={{ value | ansible.windows.quote }}' to match the
     MSI parameter format.


### PR DESCRIPTION
##### SUMMARY
Until docs are officially hosts at docs.ansible.com we are using the [add_docs.py script](https://github.com/ansible-network/collection_prep) to generate a temp rst doc for each module under `docs`.

Hopefully this is only a temporary solution for collection docs in the public and we use a better hosting method on docs.ansible.com.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
many