### PR TITLE
win_domain and win_domain_controller necessary features

### DIFF
--- a/plugins/modules/win_domain.ps1
+++ b/plugins/modules/win_domain.ps1
@@ -12,8 +12,6 @@ $ErrorActionPreference = "Stop"
 $required_features = @("AD-Domain-Services","RSAT-ADDS", "RSAT-AD-AdminCenter")
 
 Function Get-MissingFeatures {
-    Write-DebugLog "Checking for missing Windows features..."
-
     $features = @(Get-WindowsFeature $required_features)
 
     If($features.Count -ne $required_features.Count) {

--- a/plugins/modules/win_domain.ps1
+++ b/plugins/modules/win_domain.ps1
@@ -18,7 +18,7 @@ Function Get-MissingFeatures {
     )
     $features = @(Get-WindowsFeature $required_features)
     # Check for $required_features that are not in $features
-    $unavailable_features = @(Compare-Object -ReferenceObject $required_features -DifferenceObject ($features | select -ExpandProperty Name) -PassThru)
+    $unavailable_features = @(Compare-Object -ReferenceObject $required_features -DifferenceObject ($features | Select-Object -ExpandProperty Name) -PassThru)
 
     if ($unavailable_features) {
         Throw "The following features required for a domain controller are unavailable: $($unavailable_features -join ',')"

--- a/plugins/modules/win_domain_controller.ps1
+++ b/plugins/modules/win_domain_controller.ps1
@@ -39,7 +39,7 @@ Function Get-MissingFeatures {
 
     $features = @(Get-WindowsFeature $required_features)
     # Check for $required_features that are not in $features
-    $unavailable_features = @(Compare-Object -ReferenceObject $required_features -DifferenceObject ($features | select -ExpandProperty Name) -PassThru)
+    $unavailable_features = @(Compare-Object -ReferenceObject $required_features -DifferenceObject ($features | Select-Object -ExpandProperty Name) -PassThru)
 
     if ($unavailable_features) {
         Throw "The following features required for a domain controller are unavailable: $($unavailable_features -join ',')"
@@ -47,7 +47,7 @@ Function Get-MissingFeatures {
 
     $missing_features = @($features | Where-Object InstallState -ne Installed)
 
-    return @($missing_features)
+    return ,$missing_features # comma needed to force array type output
 }
 
 Function Install-FeatureInstallation {

--- a/plugins/modules/win_domain_controller.ps1
+++ b/plugins/modules/win_domain_controller.ps1
@@ -12,6 +12,9 @@ $ConfirmPreference = "None"
 
 $log_path = $null
 
+# Set of features required for a domain controller
+$dc_required_features = @("AD-Domain-Services","RSAT-ADDS")
+
 Function Write-DebugLog {
     Param(
         [string]$msg
@@ -28,23 +31,29 @@ Function Write-DebugLog {
     }
 }
 
-$required_features = @("AD-Domain-Services","RSAT-ADDS", "RSAT-AD-AdminCenter")
-
 Function Get-MissingFeatures {
+    Param(
+        [string[]]$required_features
+    )
     Write-DebugLog "Checking for missing Windows features..."
 
     $features = @(Get-WindowsFeature $required_features)
+    # Check for $required_features that are not in $features
+    $unavailable_features = @(Compare-Object -ReferenceObject $required_features -DifferenceObject ($features | select -ExpandProperty Name) -PassThru)
 
-    If($features.Count -ne $required_features.Count) {
-        Throw "One or more Windows features required for a domain controller are unavailable"
+    if ($unavailable_features) {
+        Throw "The following features required for a domain controller are unavailable: $($unavailable_features -join ',')"
     }
 
     $missing_features = @($features | Where-Object InstallState -ne Installed)
 
-    return ,$missing_features # no, the comma's not a typo- allows us to return an empty array
+    return @($missing_features)
 }
 
 Function Install-FeatureInstallation {
+    Param(
+        [string[]]$required_features
+    )
     # Ensure required features are installed
 
     Write-DebugLog "Ensuring required Windows features are installed..."
@@ -156,7 +165,7 @@ Try {
 
     # all other operations will require the AD-DS and RSAT-ADDS features...
 
-    $missing_features = Get-MissingFeatures
+    $missing_features = Get-MissingFeatures $dc_required_features
 
     If($missing_features.Count -gt 0) {
         Write-DebugLog ("Missing Windows features ({0}), need to install" -f ($missing_features -join ", "))
@@ -167,7 +176,7 @@ Try {
             Exit-Json $result
         }
 
-        Install-FeatureInstallation | Out-Null
+        Install-FeatureInstallation $dc_required_features | Out-Null
     }
 
     $domain_admin_cred = New-Credential -cred_user $domain_admin_user -cred_password $domain_admin_password

--- a/plugins/modules/win_domain_controller.ps1
+++ b/plugins/modules/win_domain_controller.ps1
@@ -28,7 +28,7 @@ Function Write-DebugLog {
     }
 }
 
-$required_features = @("AD-Domain-Services","RSAT-ADDS")
+$required_features = @("AD-Domain-Services","RSAT-ADDS", "RSAT-AD-AdminCenter")
 
 Function Get-MissingFeatures {
     Write-DebugLog "Checking for missing Windows features..."
@@ -45,14 +45,14 @@ Function Get-MissingFeatures {
 }
 
 Function Install-FeatureInstallation {
-    # ensure RSAT-ADDS and AD-Domain-Services features are installed
+    # Ensure required features are installed
 
     Write-DebugLog "Ensuring required Windows features are installed..."
     $feature_result = Install-WindowsFeature $required_features
     $result.reboot_required = $feature_result.RestartNeeded
 
     If(-not $feature_result.Success) {
-        Exit-Json -message ("Error installing AD-Domain-Services and RSAT-ADDS features: {0}" -f ($feature_result | Out-String))
+        Exit-Json -message ("Error installing AD-Domain-Services, RSAT-ADDS, and RSAT-AD-AdminCenter features: {0}" -f ($feature_result | Out-String))
     }
 }
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A mismatch in the required features between win_domain and win_domain_controller will lead to unnecessary reboots/feature installations when both modules are used (which is the typical case). The comments show win_domain incorrectly assumed that AD-Domain-Services includes RSAT-AD-Tools and RSAT-AD-AdminCenter (not the case, at least for Win 2019). Now both will check for the same necessary features in a domain controller.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_domain and win_domain_controller
