### PR TITLE
win_acl - use path type for path option

### DIFF
--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -80,7 +80,7 @@ $result = @{
     changed = $false
 }
 
-$path = Get-AnsibleParam -obj $params -name "path" -type "str" -failifempty $true
+$path = Get-AnsibleParam -obj $params -name "path" -type "path" -failifempty $true
 $user = Get-AnsibleParam -obj $params -name "user" -type "str" -failifempty $true
 $rights = Get-AnsibleParam -obj $params -name "rights" -type "str" -failifempty $true
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
it would be nice to be able to use environment variables directly in the path for `win_acl` rather than having to gather facts and use the env vars via templating.

The `win_acl_inheritance` module already does this.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_acl

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
