### PR TITLE
win_dsc - load module first for their defined assemblies

### DIFF
--- a/changelogs/fragments/66-win_dsc-load-assemblies.yml
+++ b/changelogs/fragments/66-win_dsc-load-assemblies.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_dsc - Always import module that contains DSC resource to ensure the required assemblies are loaded before parsing it - https://github.com/ansible-collections/ansible.windows/issues/66

--- a/plugins/modules/win_dsc.ps1
+++ b/plugins/modules/win_dsc.ps1
@@ -362,11 +362,19 @@ if (-not $params.ContainsKey("resource_name")) {
 }
 $resource_name = $params.resource_name
 
+$module_params = @{ Name = $resource_name }
 if ($params.ContainsKey("module_version")) {
     $module_version = $params.module_version
+    $module_params.RequiredVersion = $params.module_version
 } else {
     $module_version = "latest"
 }
+
+# For DSC class based resources we may need to ensure the module was loaded normally so the 'RequiredAssemblies' part
+# of the manifest is run. This is important as classes have their types validated during parse time before the
+# assemblies are loaded and this will fail if the assembly isn't already there.
+# https://github.com/ansible-collections/ansible.windows/issues/66
+Import-Module @module_params -ErrorAction SilentlyContinue
 
 $module_versions = (Get-DscResource -Name $resource_name -ErrorAction SilentlyContinue | Sort-Object -Property Version)
 $resource = $null

--- a/tests/integration/targets/win_dsc/files/xTestClassDsc/1.0.0/xTestClassDsc.psd1
+++ b/tests/integration/targets/win_dsc/files/xTestClassDsc/1.0.0/xTestClassDsc.psd1
@@ -1,0 +1,20 @@
+@{
+    RootModule = 'xTestClassDsc.psm1'
+    ModuleVersion = '1.0.0'
+    GUID = '883aa273-27b8-4b9f-a96d-6e4056f987b2'
+    Author = ''
+    CompanyName = ''
+    Copyright = ''
+    Description = 'Example DSC Resource'
+    PowerShellVersion = '5.1'
+    RequiredAssemblies = @("System.ServiceProcess")
+    FunctionsToExport = '*'
+    CmdletsToExport = '*'
+    VariablesToExport = '*'
+    AliasesToExport = '*'
+    DscResourcesToExport = 'xTestClassDsc'
+    PrivateData = @{
+        PSData = @{
+        }
+    }
+}

--- a/tests/integration/targets/win_dsc/files/xTestClassDsc/1.0.0/xTestClassDsc.psm1
+++ b/tests/integration/targets/win_dsc/files/xTestClassDsc/1.0.0/xTestClassDsc.psm1
@@ -1,0 +1,34 @@
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCDscExamplesPresent", "")]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCDscTestsPresent", "")]
+param()
+
+enum Ensure
+{
+    Absent
+    Present
+}
+
+[DscResource()]
+class xTestClassDsc
+{
+    [DscProperty(Key)]
+    [Ensure]$Ensure
+
+    [xTestClassDsc] Get()
+    {
+        return $this
+    }
+
+    [bool] Test()
+    {
+        return $true
+    }
+
+    [void] Set()
+    {
+        [System.ServiceProcess.ServiceControllerStatus] $stopped = [System.ServiceProcess.ServiceControllerStatus]::Stopped
+        if (-not $stopped) {
+            throw "test"
+        }
+    }
+}

--- a/tests/integration/targets/win_dsc/tasks/main.yml
+++ b/tests/integration/targets/win_dsc/tasks/main.yml
@@ -23,7 +23,7 @@
 
   - name: copy custom DSC resources to remote temp dir
     win_copy:
-      src: xTestDsc
+      src: files/
       dest: '{{ remote_tmp_dir }}'
 
   - name: run tests

--- a/tests/integration/targets/win_dsc/tasks/tests.yml
+++ b/tests/integration/targets/win_dsc/tasks/tests.yml
@@ -207,9 +207,7 @@
     - not create_file.reboot_required
 
 - name: get SID of the current Ansible user
-  win_shell: |
-    Add-Type -AssemblyName System.DirectoryServices.AccountManagement
-    [System.DirectoryServices.AccountManagement.UserPrincipal]::Current.Sid.Value
+  win_shell: '[System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value'
   register: actual_sid
 
 - name: run DSC process as another user
@@ -217,8 +215,7 @@
     resource_name: Script
     GetScript: '@{ Result= "" }'
     SetScript: |
-      Add-Type -AssemblyName System.DirectoryServices.AccountManagement
-      $sid = [System.DirectoryServices.AccountManagement.UserPrincipal]::Current.Sid.Value
+      $sid = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
       Set-Content -Path "{{ remote_tmp_dir }}\runas.txt" -Value $sid
     TestScript: $false
     PsDscRunAsCredential_username: '{{ ansible_user }}'
@@ -560,3 +557,15 @@
     - dsc_types_old_actual.CimInstanceArrayParam.Value[0].StringArrayValue == ['zyx', 'wvu']
     - dsc_types_old_actual.CimInstanceArrayParam.Value[0].StringValue == 'string old 1'
     - dsc_types_old_actual.CimInstanceArrayParam.Value[0]._cim_instance == 'ANSIBLE_xTestClass'
+
+- name: invoke class based DSC resource with loaded assembly
+  win_dsc:
+    resource_name: xTestClassDsc
+    Ensure: Present
+  register: class_resource
+
+- name: assert invoke class based DSC resource with loaded assembly
+  assert:
+    that:
+    - not class_resource is changed
+    - class_resource.module_version == '1.0.0'


### PR DESCRIPTION
##### SUMMARY
Make sure we always load the module so it loads its required assemblies before importing the DSC resource.

Fixes https://github.com/ansible-collections/ansible.windows/issues/66

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_dsc