### PR TITLE
Fix up invalid sanity check not supported by our PSSA version

### DIFF
--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -6,27 +6,24 @@
 #Requires -Module Ansible.ModuleUtils.Legacy
 
 Function Get-CustomFacts {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSCustomUseLiteralPath", "",
-        Justification="Wildcards can be specified for the fact path to run mutliple fact scripts")]
     [CmdletBinding()]
-  [cmdletBinding()]
-  param (
-    [Parameter(mandatory=$false)]
-    $factpath = $null
-  )
+    param (
+        [Parameter(mandatory=$false)]
+        $factpath = $null
+    )
 
-  if (Test-Path -Path $factpath) {
-    $FactsFiles = Get-ChildItem -Path $factpath | Where-Object -FilterScript {($PSItem.PSIsContainer -eq $false) -and ($PSItem.Extension -eq '.ps1')}
+    if (Test-Path -Path $factpath) {
+        $FactsFiles = Get-ChildItem -Path $factpath | Where-Object -FilterScript {($PSItem.PSIsContainer -eq $false) -and ($PSItem.Extension -eq '.ps1')}
 
-    foreach ($FactsFile in $FactsFiles) {
-        $out = & $($FactsFile.FullName)
-        $result.ansible_facts.Add("ansible_$(($FactsFile.Name).Split('.')[0])", $out)
+        foreach ($FactsFile in $FactsFiles) {
+            $out = & $($FactsFile.FullName)
+            $result.ansible_facts.Add("ansible_$(($FactsFile.Name).Split('.')[0])", $out)
+        }
     }
-  }
-  else
-  {
+    else
+    {
         Add-Warning $result "Non existing path was set for local facts - $factpath"
-  }
+    }
 }
 
 Function Get-MachineSid {
@@ -66,8 +63,6 @@ Function Get-WinRMCertificate {
     .SYNOPSIS
     Gets all the certificates that are bound to a WinRM HTTPS listener.
     #>
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSCustomUseLiteralPath", "",
-        Justification="Need to use wildcard in gci to get all the child listeners")]
     [CmdletBinding()]
     param ()
 

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,2 +1,3 @@
+plugins/modules/setup.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
 tests/utils/shippable/check_matrix.py replace-urlopen
 tests/utils/shippable/timing.py shebang

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,2 +1,3 @@
+plugins/modules/setup.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
 tests/utils/shippable/check_matrix.py replace-urlopen
 tests/utils/shippable/timing.py shebang


### PR DESCRIPTION
##### SUMMARY
We run PSScriptAnalyzer at 1.18.0 in the default test container and it was only recently that PSSA added support for suppressing custom rules in the code. For now we just need to continue ignoring it globally for the file until we update the PSSA version used.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sanity