### PR TITLE
Migrate version deprecations to dates, added runtime

### DIFF
--- a/changelogs/fragments/win_domain_computer.yml
+++ b/changelogs/fragments/win_domain_computer.yml
@@ -1,0 +1,7 @@
+minor_changes:
+- win_domain_computer - Use new Ansible.Basic wrapper for better invocation reporting
+
+deprecated_features:
+- >-
+    win_domain_computer - Deprecated the undocumented ``log_path`` option. This option will be removed in a major
+    release after ``2022-07-01``.

--- a/changelogs/fragments/win_regedit-basic-dep.yml
+++ b/changelogs/fragments/win_regedit-basic-dep.yml
@@ -1,0 +1,8 @@
+minor_changes:
+- win_regedit - Use new Ansible.Basic wrapper for better invocation reporting
+
+deprecated_features:
+- >-
+    win_regedit - Deprecated using forward slashes as a path separator, use backslashes to avoid ambiguity between a
+    forward slash in the key name or a forward slash as a path separator. This feature will be removed in a major
+    release after ``2021-07-01``.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: '>=2.10'

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -159,8 +159,8 @@ if ($osversion.Version -lt [version]"6.2") {
     # Server 2008, 2008 R2, and Windows 7 are not tested in CI and we want to let customers know about it before
     # removing support altogether.
     $version_string = "{0}.{1}" -f ($osversion.Version.Major, $osversion.Version.Minor)
-    $msg = "Windows version '$version_string' will no longer be supported or tested in the next Ansible release"
-    Add-DeprecationWarning -obj $result -message $msg -version "2.11"
+    $msg = "The Windows version '$version_string' will no longer be supported or tested in future releases"
+    Add-Warning -obj $result -message $msg
 }
 
 if($gather_subset.Contains('all_ipv4_addresses') -or $gather_subset.Contains('all_ipv6_addresses')) {

--- a/plugins/modules/win_domain_controller.py
+++ b/plugins/modules/win_domain_controller.py
@@ -49,6 +49,7 @@ options:
       - Whether the target host should be a domain controller or a member server.
     type: str
     choices: [ domain_controller, member_server ]
+    required: yes
   database_path:
     description:
     - The path to a directory on a fixed disk of the Windows host where the
@@ -80,7 +81,7 @@ options:
   log_path:
     description:
     - The path to log any debug information when running the module.
-    - This option is deprecated and should not be used, it will be removed in Ansible 2.14.
+    - This option is deprecated and should not be used, it will be removed on the major release after C(2022-07-01).
     - This does not relate to the C(-LogPath) paramter of the install controller cmdlet.
     type: str
 seealso:

--- a/plugins/modules/win_regedit.py
+++ b/plugins/modules/win_regedit.py
@@ -49,7 +49,7 @@ options:
     description:
     - The registry value data type.
     type: str
-    choices: [ binary, dword, expandstring, multistring, string, qword ]
+    choices: [ none, binary, dword, expandstring, multistring, string, qword ]
     default: string
     aliases: [ datatype ]
   state:

--- a/plugins/modules/win_regedit.py
+++ b/plugins/modules/win_regedit.py
@@ -44,7 +44,7 @@ options:
       or a hex value.
     - Multistring values should be passed in as a list.
     - See the examples for more details on how to format this data.
-    type: str
+    type: raw
   type:
     description:
     - The registry value data type.

--- a/tests/integration/targets/win_regedit/tasks/tests.yml
+++ b/tests/integration/targets/win_regedit/tasks/tests.yml
@@ -10,7 +10,7 @@
     that:
     - forward_separator_warn.deprecations|length == 1
     - forward_separator_warn.deprecations[0].msg == "path is not using '\\' as a separator, support for '/' as a separator will be removed in a future Ansible version"
-    - forward_separator_warn.deprecations[0].version == 2.12
+    - forward_separator_warn.deprecations[0].date == '2021-07-01'
 
 - name: fail run win_regedit with larger dword
   win_regedit:


### PR DESCRIPTION
##### SUMMARY
After migrating the code from ansible/ansible to the collection we need to change any Ansible version deprecations to date deprecations. To easily support this the module should also be using the Ansible.Basic wrapper. Also adds the `runtime.yml` that specifies the versions of Ansible the collection supports.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_domain_controller
win_regedit

##### OTHER NOTES

Have manually test `win_domain_controller` outside of CI with the following Vagrantfile and playbook

```ruby
# -*- mode: ruby -*-
# vi: set ft=ruby :

Vagrant.configure("2") do |config|
  config.vm.define "dc01" do |dc|
    dc.vm.box = "jborean93/WindowsServer2019"
    dc.vm.network :private_network, ip: "192.168.56.40"
    dc.vm.hostname = "dc01"

    dc.vm.provider :libvirt do |lv|
      lv.cpus = 4
      lv.memory = 8192
    end
  end

  config.vm.define "dc02" do |cd|
    cd.vm.box = "jborean93/WindowsServer2019"
    cd.vm.network :private_network, ip: "192.168.56.41"
    cd.vm.hostname = "dc02"

    cd.vm.provider :libvirt do |lv|
      lv.cpus = 4
      lv.memory = 8192
    end
  end
end
```

```yaml
- hosts: test-dc01
  gather_facts: no
  tasks:
  - win_dns_client:
      adapter_name: Ethernet 2
      ipv4_addresses:
      - 127.0.0.1

  - win_domain:
      dns_domain_name: ansible.test
      safe_mode_password: password123!
    register: domain_res

  - win_reboot:
    when: domain_res.reboot_required

  - win_domain_user:
      name: vagrant-domain
      upn: vagrant-domain@ansible.test
      description: test domain user
      password: password123!
      password_never_expired: yes
      groups:
      - Domain Admins
      state: present
    register: domain_user
    retries: 30
    delay: 15
    until: domain_user is successful

- hosts: test-dc02
  gather_facts: no
  tasks:
  - win_dns_client:
      adapter_name: Ethernet 2
      ipv4_addresses:
      - 192.168.56.40

  - win_domain_controller:
      domain_admin_user: vagrant-domain@ansible.test
      domain_admin_password: password123!
      safe_mode_password: password123!
      dns_domain_name: ansible.test
      state: domain_controller
    register: domain_res

  - win_reboot:
    when: domain_res.reboot_required
```