### PR TITLE
Fix up builtin module references

### DIFF
--- a/plugins/modules/win_command.py
+++ b/plugins/modules/win_command.py
@@ -14,7 +14,7 @@ description:
        processed through the shell, so variables like C($env:HOME) and operations
        like C("<"), C(">"), C("|"), and C(";") will not work (use the M(ansible.windows.win_shell)
        module if you need these features).
-     - For non-Windows targets, use the M(command) module instead.
+     - For non-Windows targets, use the M(ansible.builtin.command) module instead.
 options:
   free_form:
     description:
@@ -54,9 +54,9 @@ notes:
     - C(creates), C(removes), and C(chdir) can be specified after the command. For instance, if you only want to run a command if a certain file does not
       exist, use this.
 seealso:
-- module: command
+- module: ansible.builtin.command
 - module: community.windows.psexec
-- module: raw
+- module: ansible.builtin.raw
 - module: community.windows.win_psexec
 - module: ansible.windows.win_shell
 author:

--- a/plugins/modules/win_copy.py
+++ b/plugins/modules/win_copy.py
@@ -11,14 +11,14 @@ module: win_copy
 short_description: Copies files to remote locations on windows hosts
 description:
 - The C(win_copy) module copies a file on the local box to remote windows locations.
-- For non-Windows targets, use the M(copy) module instead.
+- For non-Windows targets, use the M(ansible.builtin.copy) module instead.
 options:
   content:
     description:
     - When used instead of C(src), sets the contents of a file directly to the
       specified value.
     - This is for simple values, for anything complex or with formatting please
-      switch to the M(template) module.
+      switch to the M(ansible.windows.win_template) module.
     type: str
   decrypt:
     description:
@@ -92,7 +92,7 @@ notes:
   using M(ansible.windows.win_get_url) instead.
 seealso:
 - module: community.general.assemble
-- module: copy
+- module: ansible.builtin.copy
 - module: ansible.windows.win_get_url
 - module: community.windows.win_robocopy
 author:

--- a/plugins/modules/win_file.py
+++ b/plugins/modules/win_file.py
@@ -11,8 +11,8 @@ short_description: Creates, touches or removes files or directories
 description:
      - Creates (empty) files, updates file modification stamps of existing files,
        and can create or remove directories.
-     - Unlike M(file), does not modify ownership, permissions or manipulate links.
-     - For non-Windows targets, use the M(file) module instead.
+     - Unlike M(ansible.builtin.file), does not modify ownership, permissions or manipulate links.
+     - For non-Windows targets, use the M(ansible.builtin.file) module instead.
 options:
   path:
     description:
@@ -24,8 +24,8 @@ options:
     description:
       - If C(directory), all immediate subdirectories will be created if they
         do not exist.
-      - If C(file), the file will NOT be created if it does not exist, see the M(copy)
-        or M(template) module if you want that behavior.
+      - If C(file), the file will NOT be created if it does not exist, see the M(ansible.windows.win_copy)
+        or M(ansible.windows.win_template) module if you want that behavior.
       - If C(absent), directories will be recursively deleted, and files will be removed.
       - If C(touch), an empty file will be created if the C(path) does not
         exist, while an existing file or directory will receive updated file access and
@@ -33,7 +33,7 @@ options:
     type: str
     choices: [ absent, directory, file, touch ]
 seealso:
-- module: file
+- module: ansible.builtin.file
 - module: ansible.windows.win_acl
 - module: ansible.windows.win_acl_inheritance
 - module: ansible.windows.win_owner

--- a/plugins/modules/win_find.py
+++ b/plugins/modules/win_find.py
@@ -11,7 +11,7 @@ short_description: Return a list of files based on specific criteria
 description:
     - Return a list of files based on specified criteria.
     - Multiple criteria are AND'd together.
-    - For non-Windows targets, use the M(find) module instead.
+    - For non-Windows targets, use the M(ansible.builtin.find) module instead.
 options:
     age:
         description:

--- a/plugins/modules/win_get_url.py
+++ b/plugins/modules/win_get_url.py
@@ -11,7 +11,7 @@ short_description: Downloads file from HTTP, HTTPS, or FTP to node
 description:
 - Downloads files from HTTP, HTTPS, or FTP to the remote server.
 - The remote server I(must) have direct access to the remote resource.
-- For non-Windows targets, use the M(get_url) module instead.
+- For non-Windows targets, use the M(ansible.builtin.get_url) module instead.
 options:
   url:
     description:
@@ -92,8 +92,8 @@ extends_documentation_fragment:
 - ansible.windows.web_request
 
 seealso:
-- module: get_url
-- module: uri
+- module: ansible.builtin.get_url
+- module: ansible.builtin.uri
 - module: ansible.windows.win_uri
 author:
 - Paul Durivage (@angstwad)

--- a/plugins/modules/win_group.py
+++ b/plugins/modules/win_group.py
@@ -10,7 +10,7 @@ module: win_group
 short_description: Add and remove local groups
 description:
     - Add and remove local groups.
-    - For non-Windows targets, please use the M(group) module instead.
+    - For non-Windows targets, please use the M(ansible.builtin.group) module instead.
 options:
   name:
     description:
@@ -28,7 +28,7 @@ options:
     choices: [ absent, present ]
     default: present
 seealso:
-- module: group
+- module: ansible.builtin.group
 - module: community.windows.win_domain_group
 - module: ansible.windows.win_group_membership
 author:

--- a/plugins/modules/win_ping.py
+++ b/plugins/modules/win_ping.py
@@ -11,8 +11,7 @@ short_description: A windows version of the classic ping module
 description:
   - Checks management connectivity of a windows host.
   - This is NOT ICMP ping, this is just a trivial test module.
-  - For non-Windows targets, use the M(ping) module instead.
-  - For Network targets, use the M(net_ping) module instead.
+  - For non-Windows targets, use the M(ansible.builtin.ping) module instead.
 options:
   data:
     description:
@@ -21,7 +20,7 @@ options:
     type: str
     default: pong
 seealso:
-- module: ping
+- module: ansible.builtin.ping
 author:
 - Chris Church (@cchurch)
 '''

--- a/plugins/modules/win_reboot.py
+++ b/plugins/modules/win_reboot.py
@@ -9,7 +9,7 @@ module: win_reboot
 short_description: Reboot a windows machine
 description:
 - Reboot a Windows machine, wait for it to go down, come back up, and respond to commands.
-- For non-Windows targets, use the M(reboot) module instead.
+- For non-Windows targets, use the M(ansible.builtin.reboot) module instead.
 options:
   pre_reboot_delay:
     description:
@@ -61,7 +61,7 @@ notes:
   U(https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/force-shutdown-from-a-remote-system)
   for more information.
 seealso:
-- module: reboot
+- module: ansible.builtin.reboot
 author:
 - Matt Davis (@nitzmahone)
 '''

--- a/plugins/modules/win_service.py
+++ b/plugins/modules/win_service.py
@@ -10,7 +10,7 @@ module: win_service
 short_description: Manage and query Windows services
 description:
 - Manage and query Windows services.
-- For non-Windows targets, use the M(service) module instead.
+- For non-Windows targets, use the M(ansible.builtin.service) module instead.
 options:
   dependencies:
     description:
@@ -255,7 +255,7 @@ notes:
 - This module historically returning information about the service in its return values. These should be avoided in
   favour of the M(ansible.windows.win_service_info) module.
 seealso:
-- module: service
+- module: ansible.builtin.service
 - module: community.windows.win_nssm
 - module: ansible.windows.win_service_info
 - module: ansible.windows.win_user_right

--- a/plugins/modules/win_shell.py
+++ b/plugins/modules/win_shell.py
@@ -12,7 +12,7 @@ description:
      - The M(ansible.windows.win_shell) module takes the command name followed by a list of space-delimited arguments.
        It is similar to the M(ansible.windows.win_command) module, but runs
        the command via a shell (defaults to PowerShell) on the target host.
-     - For non-Windows targets, use the M(shell) module instead.
+     - For non-Windows targets, use the M(ansible.builtin.shell) module instead.
 options:
   free_form:
     description:
@@ -65,9 +65,9 @@ notes:
       Consider creating a Windows service for managing background processes.
 seealso:
 - module: community.windows.psexec
-- module: raw
-- module: script
-- module: shell
+- module: ansible.builtin.raw
+- module: ansible.builtin.script
+- module: ansible.builtin.shell
 - module: ansible.windows.win_command
 - module: community.windows.win_psexec
 author:

--- a/plugins/modules/win_stat.py
+++ b/plugins/modules/win_stat.py
@@ -10,7 +10,7 @@ module: win_stat
 short_description: Get information about Windows files
 description:
      - Returns information about a Windows file.
-     - For non-Windows targets, use the M(stat) module instead.
+     - For non-Windows targets, use the M(ansible.builtin.stat) module instead.
 options:
     path:
         description:
@@ -39,7 +39,7 @@ options:
         type: bool
         default: no
 seealso:
-- module: stat
+- module: ansible.builtin.stat
 - module: ansible.windows.win_acl
 - module: ansible.windows.win_file
 - module: ansible.windows.win_owner

--- a/plugins/modules/win_tempfile.py
+++ b/plugins/modules/win_tempfile.py
@@ -10,7 +10,7 @@ module: win_tempfile
 short_description: Creates temporary files and directories
 description:
   - Creates temporary files and directories.
-  - For non-Windows targets, please use the M(tempfile) module instead.
+  - For non-Windows targets, please use the M(ansible.builtin.tempfile) module instead.
 options:
   state:
     description:
@@ -36,7 +36,7 @@ options:
     type: str
     default: ''
 seealso:
-- module: tempfile
+- module: ansible.builtin.tempfile
 author:
 - Dag Wieers (@dagwieers)
 '''

--- a/plugins/modules/win_template.py
+++ b/plugins/modules/win_template.py
@@ -109,11 +109,11 @@ notes:
   and regedit's export facility add a Byte Order Mark as the first character of the file, which can cause tracebacks.
 - You can use the M(ansible.windows.win_copy) module with the C(content:) option if you prefer the template inline, as part of the
   playbook.
-- For Linux you can use M(template) which uses '\\n' as C(newline_sequence) by default.
+- For Linux you can use M(ansible.builtin.template) which uses '\\n' as C(newline_sequence) by default.
 seealso:
 - module: ansible.windows.win_copy
-- module: copy
-- module: template
+- module: ansible.builtin.copy
+- module: ansible.builtin.template
 author:
 - Jon Hawkesworth (@jhawkesworth)
 '''

--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -103,7 +103,7 @@ notes:
 - M(ansible.windows.win_updates) will I(become) SYSTEM using I(runas) unless C(use_scheduled_task) is C(yes)
 - By default M(ansible.windows.win_updates) does not manage reboots, but will signal when a
   reboot is required with the I(reboot_required) return value.
-  M(reboot) can be used to reboot the host if required in the one task.
+  I(reboot) can be used to reboot the host if required in the one task.
 - M(ansible.windows.win_updates) can take a significant amount of time to complete (hours, in some cases).
   Performance depends on many factors, including OS version, number of updates, system load, and update server load.
 - Beware that just after M(ansible.windows.win_updates) reboots the system, the Windows system may not have settled yet

--- a/plugins/modules/win_uri.py
+++ b/plugins/modules/win_uri.py
@@ -12,7 +12,7 @@ short_description: Interacts with webservices
 description:
 - Interacts with FTP, HTTP and HTTPS web services.
 - Supports Digest, Basic and WSSE HTTP authentication mechanisms.
-- For non-Windows targets, use the M(uri) module instead.
+- For non-Windows targets, use the M(ansible.builtin.uri) module instead.
 options:
   url:
     description:
@@ -83,7 +83,7 @@ extends_documentation_fragment:
 - ansible.windows.web_request
 
 seealso:
-- module: uri
+- module: ansible.builtin.uri
 - module: ansible.windows.win_get_url
 author:
 - Corwin Brown (@blakfeld)

--- a/plugins/modules/win_user.py
+++ b/plugins/modules/win_user.py
@@ -10,7 +10,7 @@ module: win_user
 short_description: Manages local Windows user accounts
 description:
      - Manages local Windows user accounts.
-     - For non-Windows targets, use the M(user) module instead.
+     - For non-Windows targets, use the M(ansible.builtin.user) module instead.
 options:
   name:
     description:
@@ -86,7 +86,7 @@ options:
     choices: [ absent, present, query ]
     default: present
 seealso:
-- module: user
+- module: ansible.builtin.user
 - module: ansible.windows.win_domain_membership
 - module: community.windows.win_domain_user
 - module: ansible.windows.win_group

--- a/plugins/modules/win_wait_for.py
+++ b/plugins/modules/win_wait_for.py
@@ -84,7 +84,7 @@ options:
     type: int
     default: 300
 seealso:
-- module: wait_for
+- module: ansible.builtin.wait_for
 - module: community.windows.win_wait_for_process
 author:
 - Jordan Borean (@jborean93)


### PR DESCRIPTION
##### SUMMARY
Any references to builtin modules should contain the `ansible.builtin` prefix.

https://github.com/ansible-collections/overview/issues/45#issuecomment-648405709

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
many