### PR TITLE
Add porting guide entries from Ansible-base porting guide

### DIFF
--- a/changelogs/fragments/porting-guide.yml
+++ b/changelogs/fragments/porting-guide.yml
@@ -1,0 +1,13 @@
+breaking_changes:
+  - |
+    win_find - module has been refactored to better match the behaviour of the ``find`` module. Here is what has changed:
+      * When the directory specified by ``paths`` does not exist or is a file, it will no longer fail and will just warn the user
+      * Junction points are no longer reported as ``islnk``, use ``isjunction`` to properly report these files. This behaviour matches the win_stat module
+      * Directories no longer return a ``size``, this matches the ``stat`` and ``find`` behaviour and has been removed due to the difficulties in correctly reporting the size of a directory
+deprecated_features:
+  - win_domain_controller - the ``log_path`` option has been deprecated and will be removed in a later release. This was undocumented and only related to debugging information for module development.
+  - "win_package - the ``username`` and ``password`` options has been deprecated and will be removed in a later release. The same functionality can be done by using ``become: yes`` and ``become_flags: logon_type=new_credentials logon_flags=netcredentials_only`` on the task."
+  - win_package - the ``ensure`` alias for the ``state`` option has been deprecated and will be removed in a later release. Please use ``state`` instead of ``ensure``.
+  - win_package - the ``productid`` alias for the ``product_id`` option has been deprecated and will be removed in a later release. Please use ``product_id`` instead of ``productid``.
+removed_features:
+  - win_stat - removed the deprecated ``get_md55`` option and ``md5`` return value.


### PR DESCRIPTION
##### SUMMARY
This adds entries from the Ansible-base porting guide that do not belong there (because they belong to this collection). This data has already been moved to the ansible changelog (https://github.com/ansible-community/ansible-build-data/blob/main/2.10/changelog.yaml), but it would be better if it appears in the changelog of the collection it applies to.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelog
