### PR TITLE
win_user refactor

### DIFF
--- a/changelogs/fragments/win_user-refactor.yml
+++ b/changelogs/fragments/win_user-refactor.yml
@@ -1,0 +1,11 @@
+minor_changes:
+- win_user - Added check mode support
+- win_user - Added diff mode support
+- win_user - Use new ``Ansible.Basic.AnsibleModule`` wrapper for better invocation reporting
+- win_user - Added the ``home_directory`` option
+- win_user - Added the ``login_script`` option
+- win_user - Added the ``profile`` option
+
+breaking_changes:
+- win_user - Change idempotency checks for ``fullname`` to be case sensitive
+- win_user - Change idempotency checks for ``description`` to be case sensitive

--- a/plugins/modules/win_user.ps1
+++ b/plugins/modules/win_user.ps1
@@ -338,7 +338,11 @@ if ($state -eq 'present') {
                     if ($groupAdsi) {
                         if (-not $module.CheckMode) {
                             try {
-                                $groupAdsi."$($action.Key)"($user.Path)
+                                if ($action.Key -eq 'Add') {
+                                     $groupAdsi.Add($user.Path)
+                                 } else {
+                                     $groupAdsi.Remove($user.Path)
+                                 }
                             } catch {
                                 $module.FailJson(
                                     "Failed to $($action.Key.ToLower()) $($group): $($_.Exception.Message)", $_
@@ -346,6 +350,7 @@ if ($state -eq 'present') {
                             }
                         }
                         $module.Result.changed = $true
+
                         if ($action.Key -eq 'Add') {
                             $module.Diff.after.groups.Add($group)
                         } else {

--- a/plugins/modules/win_user.py
+++ b/plugins/modules/win_user.py
@@ -9,82 +9,95 @@ DOCUMENTATION = r'''
 module: win_user
 short_description: Manages local Windows user accounts
 description:
-     - Manages local Windows user accounts.
-     - For non-Windows targets, use the M(ansible.builtin.user) module instead.
+- Manages local Windows user accounts.
+- For non-Windows targets, use the M(ansible.builtin.user) module instead.
 options:
-  name:
-    description:
-      - Name of the user to create, remove or modify.
-    type: str
-    required: yes
-  fullname:
-    description:
-      - Full name of the user.
-    type: str
-  description:
-    description:
-      - Description of the user.
-    type: str
-  password:
-    description:
-      - Optionally set the user's password to this (plain text) value.
-    type: str
-  update_password:
-    description:
-      - C(always) will update passwords if they differ.  C(on_create) will
-        only set the password for newly created users.
-    type: str
-    choices: [ always, on_create ]
-    default: always
-  password_expired:
-    description:
-      - C(yes) will require the user to change their password at next login.
-      - C(no) will clear the expired password flag.
-    type: bool
-  password_never_expires:
-    description:
-      - C(yes) will set the password to never expire.
-      - C(no) will allow the password to expire.
-    type: bool
-  user_cannot_change_password:
-    description:
-      - C(yes) will prevent the user from changing their password.
-      - C(no) will allow the user to change their password.
-    type: bool
   account_disabled:
     description:
-      - C(yes) will disable the user account.
-      - C(no) will clear the disabled flag.
+    - C(yes) will disable the user account.
+    - C(no) will clear the disabled flag.
     type: bool
   account_locked:
     description:
-      - C(no) will unlock the user account if locked.
+    - C(no) will unlock the user account if locked.
     choices: [ 'no' ]
+  description:
+    description:
+    - Description of the user.
+    type: str
+  fullname:
+    description:
+    - Full name of the user.
+    type: str
   groups:
     description:
-      - Adds or removes the user from this comma-separated list of groups,
-        depending on the value of I(groups_action).
-      - When I(groups_action) is C(replace) and I(groups) is set to the empty
-        string ('groups='), the user is removed from all groups.
+    - Adds or removes the user from this comma-separated list of groups, depending on the value of I(groups_action).
+    - When I(groups_action) is C(replace) and I(groups) is set to the empty string ('groups='), the user is removed
+      from all groups.
+    type: list
+    elements: str
   groups_action:
     description:
-      - If C(add), the user is added to each group in I(groups) where not
-        already a member.
-      - If C(replace), the user is added as a member of each group in
-        I(groups) and removed from any other groups.
-      - If C(remove), the user is removed from each group in I(groups).
+    - If C(add), the user is added to each group in I(groups) where not already a member.
+    - If C(replace), the user is added as a member of each group in I(groups) and removed from any other groups.
+    - If C(remove), the user is removed from each group in I(groups).
     type: str
     choices: [ add, replace, remove ]
     default: replace
+  home_directory:
+    description:
+    - The designated home directory of the user.
+    type: str
+    version_added: 1.0.0
+  login_script:
+    description:
+    - The login script of the user.
+    type: str
+    version_added: 1.0.0
+  name:
+    description:
+    - Name of the user to create, remove or modify.
+    type: str
+    required: yes
+  password:
+    description:
+    - Optionally set the user's password to this (plain text) value.
+    type: str
+  password_expired:
+    description:
+    - C(yes) will require the user to change their password at next login.
+    - C(no) will clear the expired password flag.
+    type: bool
+  password_never_expires:
+    description:
+    - C(yes) will set the password to never expire.
+    - C(no) will allow the password to expire.
+    type: bool
+  profile:
+    description:
+    - The profile path of the user.
+    type: str
+    version_added: 1.0.0
   state:
     description:
-      - When C(absent), removes the user account if it exists.
-      - When C(present), creates or updates the user account.
-      - When C(query) (new in 1.9), retrieves the user account details
-        without making any changes.
+    - When C(absent), removes the user account if it exists.
+    - When C(present), creates or updates the user account.
+    - When C(query), retrieves the user account details without making any changes.
     type: str
     choices: [ absent, present, query ]
     default: present
+  update_password:
+    description:
+    - C(always) will update passwords if they differ.
+    - C(on_create) will only set the password for newly created users.
+    type: str
+    choices: [ always, on_create ]
+    default: always
+  user_cannot_change_password:
+    description:
+    - C(yes) will prevent the user from changing their password.
+    - C(no) will allow the user to change their password.
+    type: bool
 seealso:
 - module: ansible.builtin.user
 - module: ansible.windows.win_domain_membership
@@ -93,8 +106,8 @@ seealso:
 - module: ansible.windows.win_group_membership
 - module: community.windows.win_user_profile
 author:
-    - Paul Durivage (@angstwad)
-    - Chris Church (@cchurch)
+- Paul Durivage (@angstwad)
+- Chris Church (@cchurch)
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/win_user.py
+++ b/plugins/modules/win_user.py
@@ -19,8 +19,8 @@ options:
     type: bool
   account_locked:
     description:
-    - C(no) will unlock the user account if locked.
-    choices: [ 'no' ]
+    - Only C(no) can be set and it will unlock the user account if locked.
+    type: bool
   description:
     description:
     - Description of the user.
@@ -98,6 +98,9 @@ options:
     - C(yes) will prevent the user from changing their password.
     - C(no) will allow the user to change their password.
     type: bool
+notes:
+- The return values are based on the user object after the module options have been set. When running in check mode
+  the values will still reflect the existing user settings and not what they would have been changed to.
 seealso:
 - module: ansible.builtin.user
 - module: ansible.windows.win_domain_membership

--- a/tests/integration/targets/win_user/files/lockout_user.ps1
+++ b/tests/integration/targets/win_user/files/lockout_user.ps1
@@ -9,7 +9,7 @@ $username = $args[0]
 $pc = New-Object -TypeName System.DirectoryServices.AccountManagement.PrincipalContext 'Machine', $env:COMPUTERNAME
 For ($i = 1; $i -le 10; $i++) {
     try {
-        $pc.ValidateCredentials($username, 'b@DP@ssw0rd')
+        $null = $pc.ValidateCredentials($username, 'b@DP@ssw0rd')
     }
     catch {
         break

--- a/tests/integration/targets/win_user/tasks/tests.yml
+++ b/tests/integration/targets/win_user/tasks/tests.yml
@@ -1,54 +1,20 @@
-# test code for the win_user module
 # (c) 2014, Chris Church <chris@ninemoreminutes.com>
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+- name: test create user (check mode)
+  win_user:
+    name: '{{ test_win_user_name }}'
+    password: '{{ test_win_user_password }}'
+    fullname: Test User
+    description: Test user account
+    groups: Guests
+  check_mode: yes
+  register: win_user_create_result_check
 
-- name: remove existing test user if present
-  win_user: name="{{ test_win_user_name }}" state="absent"
-  register: win_user_remove_result
-
-- name: check user removal result
+- name: assert test create user (check mode)
   assert:
     that:
-      - "win_user_remove_result.name"
-      - "win_user_remove_result.state == 'absent'"
-
-- name: try to remove test user again
-  win_user: name="{{ test_win_user_name }}" state="absent"
-  register: win_user_remove_result_again
-
-- name: check user removal result again
-  assert:
-    that:
-      - "win_user_remove_result_again is not changed"
-      - "win_user_remove_result_again.name"
-      - "win_user_remove_result_again.msg"
-      - "win_user_remove_result.state == 'absent'"
-
-- name: test missing user with query state
-  win_user: name="{{ test_win_user_name }}" state="query"
-  register: win_user_missing_query_result
-
-- name: check missing query result
-  assert:
-    that:
-      - "win_user_missing_query_result is not changed"
-      - "win_user_missing_query_result.name"
-      - "win_user_missing_query_result.msg"
-      - "win_user_missing_query_result.state == 'absent'"
+    - win_user_create_result_check is changed
+    - win_user_create_result_check.state == 'present'
 
 - name: test create user
   win_user: name="{{ test_win_user_name }}" password="{{ test_win_user_password }}" fullname="Test User" description="Test user account" groups="Guests"
@@ -64,27 +30,52 @@
       - "win_user_create_result.path"
       - "win_user_create_result.state == 'present'"
 
+- name: test create user (idempotent)
+  win_user:
+    name: '{{ test_win_user_name }}'
+    password: '{{ test_win_user_password }}'
+    fullname: Test User
+    description: Test user account
+    groups: Guests
+  register: win_user_create_result_again
+
+- name: assert test create user (idempotent)
+  assert:
+    that:
+    - not win_user_create_result_again is changed
+
+- name: update user full name and description (check mode)
+  win_user:
+    name: '{{ test_win_user_name }}'
+    fullname: Test user
+    description: Test User Account
+    groups: []
+  check_mode: yes
+  register: win_user_update_result_check
+
+- name: assert update user full name and description (check mode)
+  assert:
+    that:
+    - win_user_update_result_check is changed
+    - win_user_update_result_check.fullname == 'Test User'
+    - win_user_update_result_check.description == 'Test user account'
+    - win_user_update_result_check.groups | length == 1
+
 - name: update user full name and description
-  win_user: name="{{ test_win_user_name }}" fullname="Test Ansible User" description="Test user account created by Ansible" groups=""
+  win_user:
+    name: '{{ test_win_user_name }}'
+    fullname: Test user
+    description: Test User Account
+    groups: []
   register: win_user_update_result
 
 - name: check full name and description update result
   assert:
     that:
-      - "win_user_update_result is changed"
-      - "win_user_update_result.fullname == 'Test Ansible User'"
-      - "win_user_update_result.description == 'Test user account created by Ansible'"
-
-- name: update user full name and description again with same values
-  win_user: name="{{ test_win_user_name }}" fullname="Test Ansible User" description="Test user account created by Ansible"
-  register: win_user_update_result_again
-
-- name: check full name and description result again
-  assert:
-    that:
-      - "win_user_update_result_again is not changed"
-      - "win_user_update_result_again.fullname == 'Test Ansible User'"
-      - "win_user_update_result_again.description == 'Test user account created by Ansible'"
+    - win_user_update_result is changed
+    - win_user_update_result.fullname == 'Test user'
+    - win_user_update_result.description == 'Test User Account'
+    - win_user_update_result.groups == []
 
 - name: test again with no options or changes
   win_user: name="{{ test_win_user_name }}"
@@ -105,11 +96,23 @@
       - "win_user_query_result is not changed"
       - "win_user_query_result.state == 'present'"
       - "win_user_query_result.name == '{{ test_win_user_name }}'"
-      - "win_user_query_result.fullname == 'Test Ansible User'"
-      - "win_user_query_result.description == 'Test user account created by Ansible'"
+      - "win_user_query_result.fullname == 'Test user'"
+      - "win_user_query_result.description == 'Test User Account'"
       - "win_user_query_result.path"
       - "win_user_query_result.sid"
       - "win_user_query_result.groups == []"
+
+- name: change user password (check mode)
+  win_user:
+    name: '{{ test_win_user_name }}'
+    password: '{{ test_win_user_password2 }}'
+  check_mode: yes
+  register: win_user_password_result_check
+
+- name: assert change user password (check mode)
+  assert:
+    that:
+    - win_user_password_result_check is changed
 
 - name: change user password
   win_user: name="{{ test_win_user_name }}" password="{{ test_win_user_password2 }}"
@@ -277,6 +280,20 @@
       - "not win_user_clear_account_locked_result.account_locked"
   when: "win_user_account_locked_result.account_locked"
 
+- name: assign test user to a group (check mode)
+  win_user:
+    name: '{{ test_win_user_name }}'
+    groups:
+    - Users
+  check_mode: yes
+  register: win_user_replace_group_result_check
+
+- name: assert assign test user to a group (check mode)
+  assert:
+    that:
+    - win_user_replace_group_result_check is changed
+    - win_user_replace_group_result_check.groups == []
+
 - name: assign test user to a group
   win_user: name="{{ test_win_user_name }}" groups="Users"
   register: win_user_replace_groups_result
@@ -406,17 +423,53 @@
       - "win_user_invalid_group_result.msg"
       - win_user_invalid_group_result.msg is match("group 'Userz' not found")
 
-- name: remove test user when finished
-  win_user: name="{{ test_win_user_name }}" state="absent"
-  register: win_user_final_remove_result
+- name: remove existing test user if present (check mode)
+  win_user:
+    name: '{{ test_win_user_name }}'
+    state: absent
+  check_mode: yes
+  register: win_user_remove_result_check
 
-- name: check final user removal result
+- name: assert remove existing test user if present (check mode)
   assert:
     that:
-      - "win_user_final_remove_result is changed"
-      - "win_user_final_remove_result.name"
-      - "win_user_final_remove_result.msg"
-      - "win_user_final_remove_result.state == 'absent'"
+    - win_user_remove_result_check is changed
+    - win_user_remove_result_check.state == 'absent'
+
+- name: remove existing test user if present
+  win_user: name="{{ test_win_user_name }}" state="absent"
+  register: win_user_remove_result
+
+- name: check user removal result
+  assert:
+    that:
+      - win_user_remove_result is changed
+      - "win_user_remove_result.name"
+      - "win_user_remove_result.state == 'absent'"
+
+- name: try to remove test user again
+  win_user: name="{{ test_win_user_name }}" state="absent"
+  register: win_user_remove_result_again
+
+- name: check user removal result again
+  assert:
+    that:
+      - "win_user_remove_result_again is not changed"
+      - "win_user_remove_result_again.name"
+      - "win_user_remove_result_again.msg"
+      - "win_user_remove_result.state == 'absent'"
+
+- name: test missing user with query state
+  win_user: name="{{ test_win_user_name }}" state="query"
+  register: win_user_missing_query_result
+
+- name: check missing query result
+  assert:
+    that:
+      - "win_user_missing_query_result is not changed"
+      - "win_user_missing_query_result.name"
+      - "win_user_missing_query_result.msg"
+      - "win_user_missing_query_result.state == 'absent'"
 
 - name: test removed user with query state
   win_user: name="{{ test_win_user_name }}" state="query"


### PR DESCRIPTION
##### SUMMARY
A refactor of the win_user module that adds the following features

* Adds check mode support
* Adds diff mode support
* Uses `Ansible.Basic.AnsibleModule`
* Adds the `home_directory` option
* Adds the `login_script` option
* Adds the `profile` option

It also makes a change to how the imdepotency checks work for `fullname` and `description`. Because the checks were case insensitive now they are case sensitive. While this is a breaking change in behaviour I believe the new behaviour is correct and wouldn't break existing playbooks.

I still need to expand the integration tests to cover the new options and things like the check mode behaviour.

Fixes https://github.com/ansible-collections/ansible.windows/issues/24

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_user