### PR TITLE
Add support for setting ACL rules on windows certificate store keys

### DIFF
--- a/plugins/module_utils/CertACLHelper.cs
+++ b/plugins/module_utils/CertACLHelper.cs
@@ -13,7 +13,7 @@ using System.Security.Principal;
 //TypeAccelerator -Name Ansible.Windows.CertAclHelper.CertAccessRightsHelper -TypeName CertAccessRightsHelper
 //TypeAccelerator -Name Ansible.Windows.CertAclHelper.CertAclHelper -TypeName CertAclHelper
 
-namespace ansible_collections.ansible.windows.plugins.module_utils.CertAclHelper
+namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
 {
 
     public class CryptHandle : SafeHandleZeroOrMinusOneIsInvalid

--- a/plugins/module_utils/CertACLHelper.cs
+++ b/plugins/module_utils/CertACLHelper.cs
@@ -6,6 +6,13 @@ using System.Security.Cryptography.X509Certificates;
 using Microsoft.Win32.SafeHandles;
 using System.Security.Principal;
 
+
+//TypeAccelerator -Name Ansible.Windows.CertAclHelper.CryptHandle -TypeName CryptHandle
+//TypeAccelerator -Name Ansible.Windows.CertAclHelper.SafeSecurityDescriptorPtr -TypeName SafeSecurityDescriptorPtr
+//TypeAccelerator -Name Ansible.Windows.CertAclHelper.CertAccessRights -TypeName CertAccessRights
+//TypeAccelerator -Name Ansible.Windows.CertAclHelper.CertAccessRightsHelper -TypeName CertAccessRightsHelper
+//TypeAccelerator -Name Ansible.Windows.CertAclHelper.CertAclHelper -TypeName CertAclHelper
+
 namespace ansible_collections.ansible.windows.plugins.module_utils.CertAclHelper
 {
 

--- a/plugins/module_utils/CertACLHelper.cs
+++ b/plugins/module_utils/CertACLHelper.cs
@@ -1,0 +1,275 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Win32.SafeHandles;
+using System.Security.Principal;
+
+namespace ansible_collections.ansible.windows.plugins.module_utils.CertAclHelper
+{
+
+    public class CryptHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+
+        public CryptHandle()
+            : base(true)
+        {
+        }
+
+        public CryptHandle(IntPtr handle)
+            : base(true)
+        {
+            this.SetHandle(handle);
+        }
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CryptReleaseContext(IntPtr safeProvHandle, uint dwFlags);
+
+        protected override bool ReleaseHandle()
+        {
+            return CryptReleaseContext(this.handle, 0);
+        }
+    }
+    public class SafeSecurityDescriptorPtr : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        private int size = -1;
+
+        public SafeSecurityDescriptorPtr()
+            : base(true)
+        {
+        }
+
+        public SafeSecurityDescriptorPtr(uint size)
+            : base(true)
+        {
+            this.size = (int)size;
+            this.SetHandle(Marshal.AllocHGlobal(this.size));
+        }
+
+        public SafeSecurityDescriptorPtr(IntPtr handle)
+            : base(true)
+        {
+            this.SetHandle(handle);
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            try
+            {
+                Marshal.FreeHGlobal(this.handle);
+                return true;
+            }
+            catch
+            {
+                // semantics of this function are to never throw an exception so we must eat the underlying error and 
+                // return false. 
+                return false;
+            }
+        }
+    }
+    [Flags]
+    public enum CertAccessRights : uint
+    {
+        Read = 0x80000000,
+        FullControl = 0x10000000
+    }
+
+    public static class CertAccessRightsHelper
+    {
+        public static int ToAccessMask(this CertAccessRights accessRights)
+        {
+            return (int)accessRights;
+        }
+    }
+
+    public class CertAccessRule : AccessRule
+    {
+        public CertAccessRule(IdentityReference identity, CertAccessRights accessRights, AccessControlType type) : 
+            base(identity, (int)accessRights, false, InheritanceFlags.None, PropagationFlags.None, type)
+        {
+        }
+
+        CertAccessRights AccessRights {
+            get { return (CertAccessRights) this.AccessMask; }
+        }
+    }
+
+    public class CertAclHelper
+    {
+
+        [Flags]
+        public enum SecurityInformationFlags : uint
+        {
+            DACL_SECURITY_INFORMATION = 0x00000004,
+        }
+        [Flags]
+        public enum CryptAcquireKeyFlags : uint
+        {
+            CRYPT_ACQUIRE_SILENT_FLAG = 0x00000040,
+        }
+        [Flags]
+        private enum CryptAcquireKeyFlagControl : uint
+        {
+            CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG = 0x00010000,
+            CRYPT_ACQUIRE_PREFER_NCRYPT_KEY_FLAG = 0x00020000,
+            CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG = 0x00040000,
+        }
+        public enum KeySpec : uint
+        {
+            NONE = 0x0,
+            AT_KEYEXCHANGE = 0x1,
+            AT_SIGNATURE = 2,
+            CERT_NCRYPT_KEY_SPEC = 0xFFFFFFFF
+        }
+
+        [DllImport("crypt32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern bool CryptAcquireCertificatePrivateKey(IntPtr pCert, uint dwFlags, IntPtr pvParameters, out CryptHandle phCryptProvOrNCryptKey, out KeySpec pdwKeySpec, out bool pfCallerFreeProvOrNCryptKey);
+
+        [DllImport("ncrypt.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern int NCryptGetProperty(CryptHandle hObject, [MarshalAs(UnmanagedType.LPWStr)] string pszProperty, SafeSecurityDescriptorPtr pbOutput, uint cbOutput, ref uint pcbResult, SecurityInformationFlags dwFlags);
+
+        [DllImport("ncrypt.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern int NCryptSetProperty(CryptHandle hObject, [MarshalAs(UnmanagedType.LPWStr)] string pszProperty, [MarshalAs(UnmanagedType.LPArray)] byte[] pbInput, uint cbInput, SecurityInformationFlags dwFlags);
+
+        public enum CryptProvParam : uint
+        {
+            PP_KEYSET_SEC_DESCR = 8
+        }
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CryptGetProvParam(CryptHandle safeProvHandle, CryptProvParam dwParam, SafeSecurityDescriptorPtr pbData, ref uint dwDataLen, SecurityInformationFlags dwFlags);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CryptSetProvParam(CryptHandle safeProvHandle, CryptProvParam dwParam, [MarshalAs(UnmanagedType.LPArray)] byte[] pbData, SecurityInformationFlags dwFlags);
+
+
+        CryptHandle handle;
+        bool ncrypt = false;
+        public CertAclHelper(X509Certificate2 certificate)
+        {
+            CryptHandle certPkeyHandle;
+            KeySpec keySpec;
+
+            bool ownHandle;
+            if (CryptAcquireCertificatePrivateKey(
+                    certificate.Handle,
+                    (uint)CryptAcquireKeyFlags.CRYPT_ACQUIRE_SILENT_FLAG | (uint)CryptAcquireKeyFlagControl.CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG,
+                    IntPtr.Zero,
+                    out certPkeyHandle,
+                    out keySpec,
+                    out ownHandle))
+            {
+                if (!ownHandle)
+                {
+                    throw new NotSupportedException("Could not take ownership of certificate private key handle");
+                }
+
+                if (keySpec == KeySpec.CERT_NCRYPT_KEY_SPEC)
+                    ncrypt = true;
+                handle = certPkeyHandle;
+            }
+            else
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+
+            }
+        }
+
+
+        public FileSecurity Acl
+        {
+            get
+            {
+
+                SafeSecurityDescriptorPtr securityDescriptorBuffer;
+                uint securityDescriptorSize = 0;
+                if (ncrypt)
+                {
+                    if (NCryptGetProperty(
+                        handle,
+                        "Security Descr",
+                        new SafeSecurityDescriptorPtr(),
+                        0,
+                        ref securityDescriptorSize,
+                        SecurityInformationFlags.DACL_SECURITY_INFORMATION) != 0)
+                    {
+                        throw new Exception("Could not get security descriptor");
+                    }
+                    securityDescriptorBuffer = new SafeSecurityDescriptorPtr(securityDescriptorSize);
+
+                    if (NCryptGetProperty(
+                        handle,
+                        "Security Descr",
+                        securityDescriptorBuffer,
+                        securityDescriptorSize,
+                        ref securityDescriptorSize,
+                        SecurityInformationFlags.DACL_SECURITY_INFORMATION) != 0)
+                    {
+                        throw new Exception("Could not get security descriptor");
+                    }
+
+                }
+                else
+                {
+                    if (!CryptGetProvParam(
+                            handle,
+                            CryptProvParam.PP_KEYSET_SEC_DESCR,
+                            new SafeSecurityDescriptorPtr(),
+                            ref securityDescriptorSize,
+                            SecurityInformationFlags.DACL_SECURITY_INFORMATION))
+                    {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+
+
+                    securityDescriptorBuffer = new SafeSecurityDescriptorPtr(securityDescriptorSize);
+                    if (!CryptGetProvParam(
+                            handle,
+                            CryptProvParam.PP_KEYSET_SEC_DESCR,
+                            securityDescriptorBuffer,
+                            ref securityDescriptorSize,
+                            SecurityInformationFlags.DACL_SECURITY_INFORMATION))
+                    {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+
+                }
+                byte[] buffer = new byte[securityDescriptorSize];
+                Marshal.Copy(securityDescriptorBuffer.DangerousGetHandle(), buffer, 0, buffer.Length);
+                FileSecurity acl = new FileSecurity();
+                acl.SetSecurityDescriptorBinaryForm(buffer);
+
+                return acl;
+
+            }
+            set
+            {
+                if (ncrypt)
+                {
+                    byte[] sd = value.GetSecurityDescriptorBinaryForm();
+                    if (NCryptSetProperty(
+                        handle,
+                        "Security Descr",
+                        sd,
+                        (uint)sd.Length,
+                        SecurityInformationFlags.DACL_SECURITY_INFORMATION) != 0)
+                    {
+                        throw new Exception("Could not set security descriptor");
+                    }
+                }
+                else
+                {
+                    if (!CryptSetProvParam(handle, CryptProvParam.PP_KEYSET_SEC_DESCR,value.GetSecurityDescriptorBinaryForm(), SecurityInformationFlags.DACL_SECURITY_INFORMATION))
+                    {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+                }
+            }
+        }
+
+    }
+}

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -9,7 +9,7 @@
 #Requires -Module Ansible.ModuleUtils.Legacy
 #Requires -Module Ansible.ModuleUtils.PrivilegeUtil
 #Requires -Module Ansible.ModuleUtils.SID
-#AnsibleRequires -CSharpUtil Ansible.CertAclHelpers
+#AnsibleRequires -CSharpUtil ansible_collections.ansible.windows.plugins.module_utils.CertAclHelper
 
 $ErrorActionPreference = "Stop"
 
@@ -138,7 +138,7 @@ Try {
         $colRights = [System.Security.AccessControl.RegistryRights]$rights
     }
     ElseIf ($path_item.PSProvider.Name -eq "Certificate") {
-        $colRights = [Ansible.CertAclHelpers.CertAccessRights]$rights
+        $colRights = [Ansible.Windows.CertAclHelper.CertAccessRights]$rights
     }
     Else {
         $colRights = [System.Security.AccessControl.FileSystemRights]$rights
@@ -158,9 +158,9 @@ Try {
 
     If ($path_item.PSProvider.Name -eq "Certificate") {
         $cert = Get-Item -LiteralPath $path
-        $certSecurityHandle = [Ansible.CertAclHelpers.CertAclHelper]::new($cert)
+        $certSecurityHandle = [Ansible.Windows.CertAclHelper.CertAclHelper]::new($cert)
         $objACL = $certSecurityHandle.Acl
-        $objACE = $objACL.AccessRuleFactory($objUser, [Ansible.CertAclHelpers.CertAccessRightsHelper]::ToAccessMask($colRights), $False, $InheritanceFlag, $PropagationFlag, $objType)
+        $objACE = $objACL.AccessRuleFactory($objUser, [Ansible.Windows.CertAclHelper.CertAccessRightsHelper]::ToAccessMask($colRights), $False, $InheritanceFlag, $PropagationFlag, $objType)
     } Else {
         If ($path_item.PSProvider.Name -eq "Registry") {
             $objACE = New-Object System.Security.AccessControl.RegistryAccessRule ($objUser, $colRights, $InheritanceFlag, $PropagationFlag, $objType)

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -9,7 +9,7 @@
 #Requires -Module Ansible.ModuleUtils.Legacy
 #Requires -Module Ansible.ModuleUtils.PrivilegeUtil
 #Requires -Module Ansible.ModuleUtils.SID
-#AnsibleRequires -CSharpUtil ansible_collections.ansible.windows.plugins.module_utils.CertAclHelper
+#AnsibleRequires -CSharpUtil ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
 
 $ErrorActionPreference = "Stop"
 

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -126,7 +126,8 @@ ElseIf ($null -eq $inherit) {
 }
 
 # Bug in Set-Acl, Get-Acl where -LiteralPath only works for the Registry provider if the location is in that root
-# qualifier. We also don't have a qualifier for a network path so only change if not null
+# qualifier. We also don't have a qualifier for a network path so only change if not null. The Cert provider does
+# not use Set-Acl or Get-Acl and does not have this bug.
 if (($null -ne $path_qualifier) -and ($path_qualifier -ne "Cert:")) {
     Push-Location -LiteralPath $path_qualifier
 }

--- a/plugins/modules/win_acl.py
+++ b/plugins/modules/win_acl.py
@@ -45,7 +45,7 @@ options:
       FileSystemRights U(https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.filesystemrights.aspx).
     - If C(path) is a registry key, rights can be any right under MSDN
       RegistryRights U(https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.registryrights.aspx).
-    - If C(path) is a certificate key, rights can be Read and/or FullControl
+    - If I(path) is a certificate key, rights can be C(Read) and/or C(FullControl).
     type: str
     required: yes
   inherit:

--- a/plugins/modules/win_acl.py
+++ b/plugins/modules/win_acl.py
@@ -45,7 +45,7 @@ options:
       FileSystemRights U(https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.filesystemrights.aspx).
     - If C(path) is a registry key, rights can be any right under MSDN
       RegistryRights U(https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.registryrights.aspx).
-    - If I(path) is a certificate key, rights can be C(Read) and/or C(FullControl).
+    - If I(path) is a certificate key, rights can be C(Read) and/or C(FullControl). (Added in 1.8.0)
     type: str
     required: yes
   inherit:

--- a/plugins/modules/win_acl.py
+++ b/plugins/modules/win_acl.py
@@ -9,7 +9,7 @@
 DOCUMENTATION = r'''
 ---
 module: win_acl
-short_description: Set file/directory/registry permissions for a system user or group
+short_description: Set file/directory/registry/certificate permissions for a system user or group
 description:
 - Add or remove rights/permissions for a given user or group for the specified
   file, folder, registry key or AppPool identifies.
@@ -45,6 +45,7 @@ options:
       FileSystemRights U(https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.filesystemrights.aspx).
     - If C(path) is a registry key, rights can be any right under MSDN
       RegistryRights U(https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.registryrights.aspx).
+    - If C(path) is a certificate key, rights can be Read and/or FullControl
     type: str
     required: yes
   inherit:
@@ -123,4 +124,12 @@ EXAMPLES = r'''
     rights: Read,Write,Modify,FullControl,Delete
     type: deny
     state: present
+
+- name: Set certificate private key FullControl to Fed-Phil
+  ansible.windows.win_acl:
+    path: Cert:\LocalMachine\My\168ba8c488463f88c6648466a22484b6189e165f
+    user: Fed-Phil
+    type: allow
+    state: present
+    rights: FullControl
 '''


### PR DESCRIPTION
##### SUMMARY

Added support via the win_acl module which now supports the Cert:\<store location>\<storename>\<thumbprint> paths.
The code for this is only available through the C api for CAPI (crypto api) and CNG (Crypto API: Next Generation).
The interface to CAPI and CNG is implemented as a module util called CertACLHelper.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_acl

