### PR TITLE
win_copy - fix copying single file in a dir copy

### DIFF
--- a/changelogs/fragments/win_copy-single-fix.yml
+++ b/changelogs/fragments/win_copy-single-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_copy - fix bug when copying a single file during a folder copy operation

--- a/plugins/action/win_copy.py
+++ b/plugins/action/win_copy.py
@@ -418,6 +418,7 @@ class ActionModule(ActionBase):
         source_files = {'files': [], 'directories': [], 'symlinks': []}
 
         # If source is a directory populate our list else source is a file and translate it to a tuple.
+        original_basename = None
         if os.path.isdir(to_bytes(source, errors='surrogate_or_strict')):
             result['operation'] = 'folder_copy'
 
@@ -500,7 +501,8 @@ class ActionModule(ActionBase):
             # we only need to copy 1 file, don't mess around with zips
             file_src = query_return['files'][0]['src']
             file_dest = query_return['files'][0]['dest']
-            result.update(self._copy_single_file(file_src, dest, original_basename, file_dest,
+            basename = original_basename or file_dest
+            result.update(self._copy_single_file(file_src, dest, basename, file_dest,
                                                  task_vars, self._connection._shell.tmpdir, backup))
             if result.get('failed') is True:
                 result['msg'] = "failed to copy file %s: %s" % (file_src, result['msg'])

--- a/tests/integration/targets/win_copy/tasks/tests.yml
+++ b/tests/integration/targets/win_copy/tasks/tests.yml
@@ -420,6 +420,29 @@
     - copy_folder_contents_actual.files[3].filename == 'subdir3'
     - copy_folder_contents_actual.files[4].filename == 'subdir4'
 
+- name: remove single file in folder before next test
+  win_file:
+    path: '{{ test_win_copy_path }}\recursive-contents\subdir\bar.txt'
+    state: absent
+
+- name: copy folder contents with single file changed to folder
+  win_copy:
+    src: files/
+    dest: '{{ test_win_copy_path }}\recursive-contents\'
+  register: copy_folder_single_change
+
+- name: get result of copy folder contents with single file changed to folder
+  win_stat:
+    path: '{{ test_win_copy_path }}\recursive-contents\subdir\bar.txt'
+  register: copy_folder_single_change_actual
+
+- name: assert copy folder contents with single file changed to folder
+  assert:
+    that:
+    - copy_folder_single_change is changed
+    - copy_folder_single_change.operation == 'folder_copy'
+    - copy_folder_single_change_actual.stat.exists
+
 - name: remove foo.txt before next test
   win_file:
     path: '{{test_win_copy_path}}\recursive-contents\foo.txt'


### PR DESCRIPTION
##### SUMMARY
When copying a folder from the Ansible controller to the remote host and only a single file needs to be copied across, the plugin will fail with:

```
The full traceback is:Traceback (most recent call last):
  File "/home/jborean/dev/ansible/lib/ansible/executor/task_executor.py", line 159, in run
    res = self._execute()
  File "/home/jborean/dev/ansible/lib/ansible/executor/task_executor.py", line 574, in _execute
    result = self._handler.run(task_vars=variables)
  File "/home/jborean/dev/ansible_collections/ansible/windows/plugins/action/win_copy.py", line 503, in run
    result.update(self._copy_single_file(file_src, dest, original_basename, file_dest,
UnboundLocalError: local variable 'original_basename' referenced before assignment
fatal: [2019]: FAILED! => 
  msg: Unexpected failure during module execution.
  stdout: ''
```

This PR fixes that problem and adds a test to ensure it doesn't regress in the future.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_copy