### PR TITLE
win_environment - add a dictionary option to set multiple values at once

### DIFF
--- a/changelogs/fragments/113-win_environment-multi-var.yaml
+++ b/changelogs/fragments/113-win_environment-multi-var.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - win_environment - add ``variables`` dictionary option for setting many env vars at once (https://github.com/ansible-collections/ansible.windows/pull/113).

--- a/plugins/modules/win_environment.ps1
+++ b/plugins/modules/win_environment.ps1
@@ -1,5 +1,6 @@
 #!powershell
 
+# Copyright: (c) 2020, Brian Scholer (@briantist)
 # Copyright: (c) 2015, Jon Hawkesworth (@jhawkesworth) <figs@unity.demon.co.uk>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -7,55 +8,117 @@
 
 $spec = @{
     options = @{
-        name = @{ type = "str"; required = $true }
+        name = @{ type = "str" }
         level = @{ type = "str"; choices = "machine", "process", "user"; required = $true }
         state = @{ type = "str"; choices = "absent", "present"; default = "present" }
         value = @{ type = "str" }
+        variables = @{ type = "dict" }
     }
-    required_if = @(,@("state", "present", @("value")))
+    required_if = @(
+        ,@("state", "present", @("value", "variables"), $true)
+        ,@("state", "absent", @("name"))
+    )
+    mutually_exclusive = @(
+        ,@("variables", "name")
+        ,@("variables", "value")
+    )
+    required_one_of = @(,@("name", "variables"))
     supports_check_mode = $true
 }
 
 $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 
-$name = $module.Params.name
+function Set-EnvironmentVariableState {
+    [CmdletBinding(SupportsShouldProcess=$true)]
+    [OutputType([hashtable])]
+    param(
+        [Parameter(Mandatory=$true)]
+        [System.EnvironmentVariableTarget]
+        $Level ,
+
+        [Parameter(Mandatory=$true, ValueFromPipelineByPropertyName=$true)]
+        [Alias('Key')]
+        [String]
+        $Name ,
+
+        [Parameter(ValueFromPipelineByPropertyName=$true)]
+        [String]
+        $Value,
+
+        [Parameter()]
+        [ValidateSet('present', 'absent')]
+        [String]
+        $State
+    )
+
+    Process {
+        $before_value = [Environment]::GetEnvironmentVariable($name, $Level)
+
+        $ret = @{
+            changed = $false
+            after = $Value
+            before = $before_value
+        }
+
+        if ($State -eq "present" -and $before_value -ne $Value) {
+            if ($PSCmdlet.ShouldProcess($Name, 'Set environment variable')) {
+                [Environment]::SetEnvironmentVariable($Name, $Value, $Level)
+            }
+            $ret.changed = $true
+        } elseif ($State -eq "absent" -and $null -ne $before_value) {
+            if ($PSCmdlet.ShouldProcess($Name, 'Remove environment variable')) {
+                [Environment]::SetEnvironmentVariable($Name, $null, $Level)
+            }
+            $ret.changed = $true
+        }
+
+        $ret
+    }
+}
+
+$module.Result.values = @{}
+
 $level = $module.Params.level
 $state = $module.Params.state
-$value = $module.Params.value
 
-$before_value = [Environment]::GetEnvironmentVariable($name, $level)
-$module.Result.before_value = $before_value
-$module.Result.value = $value
-
-# When removing environment, set value to $null if set
-if ($state -eq "absent" -and $value) {
-    $module.Warn("When removing environment variable '$name' it should not have a value '$value' set")
-    $value = $null
-} elseif ($state -eq "present" -and (-not $value)) {
-    $module.FailJson("When state=present, value must be defined and not an empty string, if you wish to remove the envvar, set state=absent")
+$envvars = if ($module.Params.variables) {
+    $module.Params.variables
+}
+else {
+    @{
+        $module.Params.name = $module.Params.value
+    }
 }
 
 $module.Diff.before = @{ $level = @{} }
-if ($before_value) {
-    $module.Diff.before.$level.$name = $before_value
-}
 $module.Diff.after = @{ $level = @{} }
-if ($value) {
-    $module.Diff.after.$level.$name = $value
-}
 
-if ($state -eq "present" -and $before_value -ne $value) {
-    if (-not $module.CheckMode) {
-        [Environment]::SetEnvironmentVariable($name, $value, $level)
-    }
-    $module.Result.changed = $true
+foreach ($kv in $envvars.GetEnumerator()) {
+    $name = $kv.Key
+    $value = $kv.Value
 
-} elseif ($state -eq "absent" -and $null -ne $before_value) {
-    if (-not $module.CheckMode) {
-        [Environment]::SetEnvironmentVariable($name, $null, $level)
+    # When removing environment, set value to $null if set
+    if ($state -eq "absent" -and $value) {
+        $module.Warn("When removing environment variable '$name' it should not have a value '$value' set")
+        $value = $null
+    } elseif ($state -eq "present" -and (-not $value)) {
+        $module.FailJson("When state=present, value must be defined and not an empty string, if you wish to remove the envvar, set state=absent")
     }
-    $module.Result.changed = $true
+
+    $status = $kv | Set-EnvironmentVariableState -Level $level -State $state -WhatIf:$($module.CheckMode)
+
+    if ($status.before) {
+        $module.Diff.before.$level.$name = $status.before
+    }
+    if ($status.after) {
+        $module.Diff.after.$level.$name = $status.after
+    }
+
+    $module.Result.values.$name = $status
+    $module.Result.changed = $module.Result.changed -or $status.changed
+
+    $module.Result.before_value = $status.before
+    $module.Result.value = $status.after
 }
 
 $module.ExitJson()
-

--- a/plugins/modules/win_environment.py
+++ b/plugins/modules/win_environment.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# Copyright: (c) 2020, Brian Scholer (@briantist)
 # Copyright: (c) 2015, Jon Hawkesworth (@jhawkesworth) <figs@unity.demon.co.uk>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -21,15 +22,21 @@ options:
     default: present
   name:
     description:
-    - The name of the environment variable.
+    - The name of the environment variable. Required when I(state=absent).
     type: str
-    required: yes
   value:
     description:
     - The value to store in the environment variable.
     - Must be set when C(state=present) and cannot be an empty string.
     - Can be omitted for C(state=absent).
     type: str
+    version_added: '1.1.0'
+  variables:
+    description:
+    - A dictionary where multiple environment variables can be defined at once.
+    - Only valid when I(state=present).
+    - I(level) applies to all vars defined this way.
+    type: dict
   level:
     description:
     - The level at which to set the environment variable.
@@ -49,10 +56,14 @@ notes:
   therefore will need restarting to pick up new environment settings.
   User level environment variables will require the user to log out
   and in again before they become available.
+- In the return, C(before_value) and C(value) will be set to the last values
+  when using I(variables). It's best to use C(values) in that case if you need
+  to find a specific variable's before and after values.
 seealso:
 - module: ansible.windows.win_path
 author:
 - Jon Hawkesworth (@jhawkesworth)
+- Brian Scholer (@briantist)
 '''
 
 EXAMPLES = r'''
@@ -68,6 +79,15 @@ EXAMPLES = r'''
     state: absent
     name: TestVariable
     level: user
+
+- name: Set several variables at once
+  ansible.windows.win_environment:
+    state: present
+    level: machine
+    variables:
+      TestVariable: Test value
+      CUSTOM_APP_VAR: 'Very important value'
+      ANOTHER_VAR: '{{ my_ansible_var }}'
 '''
 
 RETURN = r'''
@@ -81,4 +101,10 @@ value:
   returned: always
   type: str
   sample: C:\Program Files\jdk1.8
+values:
+  description: "dictionary of before and after values; each key is a variable name, each value is
+  another dict with C(before), C(after), and C(changed) keys"
+  returned: always
+  type: dict
+  version_added: '1.1.0'
 '''

--- a/plugins/modules/win_environment.py
+++ b/plugins/modules/win_environment.py
@@ -30,13 +30,13 @@ options:
     - Must be set when I(state=present) and cannot be an empty string.
     - Should be omitted for I(state=absent) and I(variables).
     type: str
-    version_added: '1.1.0'
   variables:
     description:
     - A dictionary where multiple environment variables can be defined at once.
     - Not valid when I(state) is set. Variables with a value will be set (C(present)) and variables with an empty value will be unset (C(absent)).
     - I(level) applies to all vars defined this way.
     type: dict
+    version_added: '1.3.0'
   level:
     description:
     - The level at which to set the environment variable.
@@ -114,5 +114,5 @@ values:
   another dict with C(before), C(after), and C(changed) keys"
   returned: always
   type: dict
-  version_added: '1.1.0'
+  version_added: '1.3.0'
 '''

--- a/plugins/modules/win_environment.py
+++ b/plugins/modules/win_environment.py
@@ -17,9 +17,9 @@ options:
     description:
     - Set to C(present) to ensure environment variable is set.
     - Set to C(absent) to ensure it is removed.
+    - When using I(variables), do not set this option.
     type: str
     choices: [ absent, present ]
-    default: present
   name:
     description:
     - The name of the environment variable. Required when I(state=absent).
@@ -27,14 +27,14 @@ options:
   value:
     description:
     - The value to store in the environment variable.
-    - Must be set when C(state=present) and cannot be an empty string.
-    - Can be omitted for C(state=absent).
+    - Must be set when I(state=present) and cannot be an empty string.
+    - Should be omitted for I(state=absent) and I(variables).
     type: str
     version_added: '1.1.0'
   variables:
     description:
     - A dictionary where multiple environment variables can be defined at once.
-    - Only valid when I(state=present).
+    - Not valid when I(state) is set. Variables with a value will be set (C(present)) and variables with an empty value will be unset (C(absent)).
     - I(level) applies to all vars defined this way.
     type: dict
   level:
@@ -82,12 +82,20 @@ EXAMPLES = r'''
 
 - name: Set several variables at once
   ansible.windows.win_environment:
-    state: present
     level: machine
     variables:
       TestVariable: Test value
       CUSTOM_APP_VAR: 'Very important value'
       ANOTHER_VAR: '{{ my_ansible_var }}'
+
+- name: Set and remove multiple variables at once
+  ansible.windows.win_environment:
+    level: user
+    variables:
+      TestVariable: Test value
+      CUSTOM_APP_VAR: 'Very important value'
+      ANOTHER_VAR: '{{ my_ansible_var }}'
+      UNWANTED_VAR: ''  # < this will be removed
 '''
 
 RETURN = r'''

--- a/tests/integration/targets/win_environment/defaults/main.yml
+++ b/tests/integration/targets/win_environment/defaults/main.yml
@@ -7,3 +7,13 @@ test_new_user_environment_value: C:\Program Files (x86)
 test_multi_value_environment_values:
   TEST_VAR_A: value A
   TEST_VAR_B: value B
+
+test_removal_var_name: TEST_VAR_C
+test_removal_var_dict: "{{
+  { test_removal_var_name: '' }
+}}"
+
+test_multi_value_with_removal_environment_values: "{{
+  test_multi_value_environment_values
+  | combine(test_removal_var_dict)
+}}"

--- a/tests/integration/targets/win_environment/defaults/main.yml
+++ b/tests/integration/targets/win_environment/defaults/main.yml
@@ -3,3 +3,7 @@ test_machine_environment_value: "%SystemRoot%\\System32"
 test_new_machine_environment_value: C:\Windows\System32
 test_user_environment_value: C:\Program Files
 test_new_user_environment_value: C:\Program Files (x86)
+
+test_multi_value_environment_values:
+  TEST_VAR_A: value A
+  TEST_VAR_B: value B

--- a/tests/integration/targets/win_environment/tasks/cleanup.yml
+++ b/tests/integration/targets/win_environment/tasks/cleanup.yml
@@ -15,5 +15,5 @@
     state: absent
     level: "{{ item.1 }}"
   with_nested:
-  - "{{ test_multi_value_environment_values | dict2items }}"
+  - "{{ test_multi_value_with_removal_environment_values | dict2items }}"
   - [ 'machine', 'process', 'user' ]

--- a/tests/integration/targets/win_environment/tasks/cleanup.yml
+++ b/tests/integration/targets/win_environment/tasks/cleanup.yml
@@ -1,0 +1,19 @@
+---
+- name: ensure test environment value is not set in all scope
+  win_environment:
+    name: "{{test_environment_name}}"
+    state: absent
+    level: "{{item}}"
+  with_items:
+  - machine
+  - process
+  - user
+
+- name: ensure test multi environment vars are not set in all scope
+  win_environment:
+    name: "{{ item.0.key }}"
+    state: absent
+    level: "{{ item.1 }}"
+  with_nested:
+  - "{{ test_multi_value_environment_values | dict2items }}"
+  - [ 'machine', 'process', 'user' ]

--- a/tests/integration/targets/win_environment/tasks/main.yml
+++ b/tests/integration/targets/win_environment/tasks/main.yml
@@ -1,13 +1,6 @@
 ---
-- name: ensure test environment value is not set in all scope
-  win_environment:
-    name: "{{test_environment_name}}"
-    state: absent
-    level: "{{item}}"
-  with_items:
-  - machine
-  - process
-  - user
+- name: Pre-clean test vars
+  import_tasks: cleanup.yml
 
 - name: fail to create environment value with null value
   win_environment:
@@ -15,7 +8,7 @@
     state: present
     level: machine
   register: create_fail_null
-  failed_when: 'create_fail_null.msg != "state is present but all of the following are missing: value"'
+  failed_when: 'create_fail_null.msg != "state is present but any of the following are missing: value, variables"'
 
 - name: fail to create environment value with empty value
   win_environment:
@@ -256,12 +249,85 @@
     - change_user_again.before_value == test_new_user_environment_value
     - change_user_actual_again.stdout == "{{test_new_user_environment_value}}\r\n"
 
-- name: cleanup test changes
+# multi-value checks:
+#
+# single name/value option set and multi-value share implementation, so most tests above cover the bases
+# including user/machine/level setting. These tests primarily check that option restrictions work and that
+# the multi setting still sets all values, works in check mode, etc.
+
+- name: set multi value check mode
   win_environment:
-    name: "{{test_environment_name}}"
-    state: absent
-    level: "{{item}}"
-  with_items:
-  - machine
-  - process
-  - user
+    state: present
+    level: machine
+    variables: "{{ test_multi_value_environment_values }}"
+  register: multi_set
+  check_mode: True
+
+- name: check multi values after check mode
+  win_shell: |
+    [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey(
+      'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', $true
+    ).GetValue(
+      '{{ item.key }}', $null, 'DoNotExpandEnvironmentNames'
+    ) -eq '{{ item.value }}'
+  register: multi_val
+  with_dict: "{{ test_multi_value_environment_values }}"
+
+- name: assert multi value check
+  assert:
+    that:
+    - multi_set is changed
+    - item.stdout | trim | bool == False
+  with_items: "{{ multi_val.results }}"
+
+- name: set multi value
+  win_environment:
+    state: present
+    level: machine
+    variables: "{{ test_multi_value_environment_values }}"
+  register: multi_set
+
+- name: check multi values after setting
+  win_shell: |
+    [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey(
+      'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', $true
+    ).GetValue(
+      '{{ item.key }}', $null, 'DoNotExpandEnvironmentNames'
+    ) -eq '{{ item.value }}'
+  register: multi_val
+  with_dict: "{{ test_multi_value_environment_values }}"
+
+- name: assert multi value
+  assert:
+    that:
+    - multi_set is changed
+    - item.stdout | trim | bool == True
+  with_items: "{{ multi_val.results }}"
+
+- name: set multi value again
+  win_environment:
+    state: present
+    level: machine
+    variables: "{{ test_multi_value_environment_values }}"
+  register: multi_set
+
+- name: check multi values after setting again
+  win_shell: |
+    [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey(
+      'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', $true
+    ).GetValue(
+      '{{ item.key }}', $null, 'DoNotExpandEnvironmentNames'
+    ) -eq '{{ item.value }}'
+  register: multi_val
+  with_dict: "{{ test_multi_value_environment_values }}"
+
+- name: assert multi value after setting again
+  assert:
+    that:
+    - multi_set is not changed
+    - item.stdout | trim | bool == True
+  with_items: "{{ multi_val.results }}"
+
+# cleanup
+- name: Post-clean test vars
+  import_tasks: cleanup.yml

--- a/tests/integration/targets/win_environment/tasks/main.yml
+++ b/tests/integration/targets/win_environment/tasks/main.yml
@@ -2,13 +2,29 @@
 - name: Pre-clean test vars
   import_tasks: cleanup.yml
 
+- name: removal of non-existant value is ok check
+  win_environment:
+    level: machine
+    state: absent
+    name: "{{ test_removal_var_name }}"
+  register: remove_nonexistant
+  failed_when: remove_nonexistant is changed
+
+- name: removal of non-existant value is ok
+  win_environment:
+    level: machine
+    state: absent
+    name: "{{ test_removal_var_name }}"
+  register: remove_nonexistant
+  failed_when: remove_nonexistant is changed
+
 - name: fail to create environment value with null value
   win_environment:
     name: "{{test_environment_name}}"
     state: present
     level: machine
   register: create_fail_null
-  failed_when: 'create_fail_null.msg != "state is present but any of the following are missing: value, variables"'
+  failed_when: 'create_fail_null.msg != "When state=present, value must be defined and not an empty string, if you wish to remove the envvar, set state=absent"'
 
 - name: fail to create environment value with empty value
   win_environment:
@@ -253,11 +269,20 @@
 #
 # single name/value option set and multi-value share implementation, so most tests above cover the bases
 # including user/machine/level setting. These tests primarily check that option restrictions work and that
-# the multi setting still sets all values, works in check mode, etc.
+# the multi setting still sets all values, works in check mode, etc. Only other main difference is some
+# checks for the mixed-mode of set/remove by setting variables with empty string.
+
+- name: fail when state is specified with multi-value
+  win_environment:
+    state: present
+    level: machine
+    variables: "{{ test_multi_value_environment_values }}"
+  register: multi_set
+  check_mode: True
+  failed_when: 'multi_set.msg != "parameters are mutually exclusive: variables, state"'
 
 - name: set multi value check mode
   win_environment:
-    state: present
     level: machine
     variables: "{{ test_multi_value_environment_values }}"
   register: multi_set
@@ -282,7 +307,6 @@
 
 - name: set multi value
   win_environment:
-    state: present
     level: machine
     variables: "{{ test_multi_value_environment_values }}"
   register: multi_set
@@ -306,7 +330,6 @@
 
 - name: set multi value again
   win_environment:
-    state: present
     level: machine
     variables: "{{ test_multi_value_environment_values }}"
   register: multi_set
@@ -326,6 +349,60 @@
     that:
     - multi_set is not changed
     - item.stdout | trim | bool == True
+  with_items: "{{ multi_val.results }}"
+
+- name: set removal test value
+  win_environment:
+    level: machine
+    state: present
+    name: "{{ test_removal_var_name }}"
+    value: value C
+
+- name: test removal in multi-val check
+  win_environment:
+    level: machine
+    variables: "{{ test_multi_value_with_removal_environment_values }}"
+  register: multi_mixed
+  failed_when: multi_mixed is not changed
+  check_mode: True
+
+- name: test removal in multi-val
+  win_environment:
+    level: machine
+    variables: "{{ test_multi_value_with_removal_environment_values }}"
+  register: multi_mixed
+  failed_when: multi_mixed is not changed
+
+- name: check set multi values after mixed-mode
+  win_shell: |
+    [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey(
+      'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', $true
+    ).GetValue(
+      '{{ item.key }}', $null, 'DoNotExpandEnvironmentNames'
+    ) -eq '{{ item.value }}'
+  register: multi_val
+  with_dict: "{{ test_multi_value_environment_values }}"
+
+- name: assert set multi value after mixed-mode
+  assert:
+    that:
+    - item.stdout | trim | bool == True
+  with_items: "{{ multi_val.results }}"
+
+- name: check removed multi values after mixed-mode
+  win_shell: |
+    [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey(
+      'SYSTEM\CurrentControlSet\Control\Session Manager\Environment', $true
+    ).GetValue(
+      '{{ item.key }}', $null, 'DoNotExpandEnvironmentNames'
+    ) -eq '{{ item.value }}'
+  register: multi_val
+  with_dict: "{{ test_removal_var_dict }}"
+
+- name: assert removal multi value after mixed-mode
+  assert:
+    that:
+    - item.stdout | trim | bool == False
   with_items: "{{ multi_val.results }}"
 
 # cleanup


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Adds dict option `variables` so you can set multiple key/value pairs without looping over the module
- Previous `name` and `value` options still work
- Added tests for the new option
- Added a new return value for seeing the changes on all vars affected
- Existing return values still work correctly on single vars
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_environment

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Usage:
```yaml
- win_environment:
    state: present
    level: machine
    variables:
      VAR_ONE: value 1
      COOL_VAR_NAME: uncool value tho
      VAULT_ADDR: https://127.0.0.1
```

Internals:
- A function handles the setting and before/after/changed status of individual env vars
- Single name/value option set is implemented the same as passing in a single key/value dict to `variables` internally, which keeps testing relatively simple
- Fully backward compatible
<!--- Paste verbatim command output below, e.g. before and after your change -->
