### PR TITLE
Added Process util and add option to wait for child processes to be done for win_package

### DIFF
--- a/plugins/module_utils/Process.cs
+++ b/plugins/module_utils/Process.cs
@@ -250,7 +250,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
         public Win32Exception(string message) : this(Marshal.GetLastWin32Error(), message) { }
         public Win32Exception(int errorCode, string message) : base(errorCode)
         {
-            _msg = String.Format("{0} ({1}, Win32ErrorCode {2})", message, base.Message, errorCode);
+            _msg = String.Format("{0} ({1}, Win32ErrorCode {2} - 0x{2:X8})", message, base.Message, errorCode);
         }
 
         public override string Message { get { return _msg; } }
@@ -271,7 +271,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
         /// </summary>
         /// <param name="lpCommandLine">The command line to parse</param>
         /// <returns>An array of arguments interpreted by Windows</returns>
-        public static string[] ParseCommandLine(string lpCommandLine)
+        public static string[] CommandLineToArgv(string lpCommandLine)
         {
             int numArgs;
             using (SafeMemoryBuffer buf = NativeMethods.CommandLineToArgvW(lpCommandLine, out numArgs))

--- a/plugins/module_utils/Process.cs
+++ b/plugins/module_utils/Process.cs
@@ -1,0 +1,530 @@
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Collections;
+using System.IO;
+using System.Linq;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+
+//TypeAccelerator -Name Ansible.Windows.Process.ProcessUtil -TypeName ProcessUtil
+//TypeAccelerator -Name Ansible.Windows.Process.Result -TypeName Result
+
+namespace ansible_collections.ansible.windows.plugins.module_utils.Process
+{
+    internal class NativeHelpers
+    {
+        [StructLayout(LayoutKind.Sequential)]
+        public struct JOBOBJECT_ASSOCIATE_COMPLETION_PORT
+        {
+            public IntPtr CompletionKey;
+            public IntPtr CompletionPort;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public class SECURITY_ATTRIBUTES
+        {
+            public UInt32 nLength;
+            public IntPtr lpSecurityDescriptor;
+            public bool bInheritHandle = false;
+            public SECURITY_ATTRIBUTES()
+            {
+                nLength = (UInt32)Marshal.SizeOf(this);
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public class STARTUPINFO
+        {
+            public UInt32 cb;
+            public IntPtr lpReserved;
+            [MarshalAs(UnmanagedType.LPWStr)] public string lpDesktop;
+            [MarshalAs(UnmanagedType.LPWStr)] public string lpTitle;
+            public UInt32 dwX;
+            public UInt32 dwY;
+            public UInt32 dwXSize;
+            public UInt32 dwYSize;
+            public UInt32 dwXCountChars;
+            public UInt32 dwYCountChars;
+            public UInt32 dwFillAttribute;
+            public StartupInfoFlags dwFlags;
+            public UInt16 wShowWindow;
+            public UInt16 cbReserved2;
+            public IntPtr lpReserved2;
+            public SafeFileHandle hStdInput;
+            public SafeFileHandle hStdOutput;
+            public SafeFileHandle hStdError;
+            public STARTUPINFO()
+            {
+                cb = (UInt32)Marshal.SizeOf(this);
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public class STARTUPINFOEX
+        {
+            public STARTUPINFO startupInfo;
+            public IntPtr lpAttributeList;
+            public STARTUPINFOEX()
+            {
+                startupInfo = new STARTUPINFO();
+                startupInfo.cb = (UInt32)Marshal.SizeOf(this);
+            }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct PROCESS_INFORMATION
+        {
+            public IntPtr hProcess;
+            public IntPtr hThread;
+            public int dwProcessId;
+            public int dwThreadId;
+        }
+
+        public enum JobObjectInformationClass : uint
+        {
+            JobObjectAssociateCompletionPortInformation = 7,
+        }
+
+        [Flags]
+        public enum ProcessCreationFlags : uint
+        {
+            CREATE_SUSPENDED = 0x00000004,
+            CREATE_NEW_CONSOLE = 0x00000010,
+            CREATE_UNICODE_ENVIRONMENT = 0x00000400,
+            EXTENDED_STARTUPINFO_PRESENT = 0x00080000
+        }
+
+        [Flags]
+        public enum StartupInfoFlags : uint
+        {
+            USESTDHANDLES = 0x00000100
+        }
+
+        [Flags]
+        public enum HandleFlags : uint
+        {
+            None = 0,
+            INHERIT = 1
+        }
+    }
+
+    internal class NativeMethods
+    {
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool AllocConsole();
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool AssignProcessToJobObject(
+            SafeHandle hJob,
+            IntPtr hProcess);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool CloseHandle(
+            IntPtr hObject);
+
+        [DllImport("shell32.dll", SetLastError = true)]
+        public static extern SafeMemoryBuffer CommandLineToArgvW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpCmdLine,
+            out int pNumArgs);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern SafeNativeHandle CreateIoCompletionPort(
+            IntPtr FileHandle,
+            IntPtr ExistingCompletionPort,
+            UIntPtr CompletionKey,
+            UInt32 NumberOfConcurrentThreads);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern SafeNativeHandle CreateJobObjectW(
+            IntPtr lpJobAttributes,
+            string lpName);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool CreatePipe(
+            out SafeFileHandle hReadPipe,
+            out SafeFileHandle hWritePipe,
+            NativeHelpers.SECURITY_ATTRIBUTES lpPipeAttributes,
+            UInt32 nSize);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern bool CreateProcessW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpApplicationName,
+            StringBuilder lpCommandLine,
+            IntPtr lpProcessAttributes,
+            IntPtr lpThreadAttributes,
+            bool bInheritHandles,
+            NativeHelpers.ProcessCreationFlags dwCreationFlags,
+            SafeMemoryBuffer lpEnvironment,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpCurrentDirectory,
+            NativeHelpers.STARTUPINFOEX lpStartupInfo,
+            out NativeHelpers.PROCESS_INFORMATION lpProcessInformation);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool FreeConsole();
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern IntPtr GetConsoleWindow();
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool GetExitCodeProcess(
+            SafeWaitHandle hProcess,
+            out UInt32 lpExitCode);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool GetQueuedCompletionStatus(
+            IntPtr CompletionPort,
+            out UInt32 lpNumberOfBytesTransferred,
+            out UIntPtr lpCompletionKey,
+            out IntPtr lpOverlapped,
+            UInt32 dwMilliseconds);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern UInt32 ResumeThread(
+            IntPtr hThread);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool SetConsoleCP(
+            UInt32 wCodePageID);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool SetConsoleOutputCP(
+            UInt32 wCodePageID);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool SetHandleInformation(
+            SafeFileHandle hObject,
+            NativeHelpers.HandleFlags dwMask,
+            NativeHelpers.HandleFlags dwFlags);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        public static extern bool SetInformationJobObject(
+            SafeHandle hJob,
+            NativeHelpers.JobObjectInformationClass JobObjectInformationClass,
+            IntPtr lpJobObjectInformation,
+            Int32 cbJobObjectInformationLength);
+
+        [DllImport("kernel32.dll")]
+        public static extern UInt32 WaitForSingleObject(
+            SafeWaitHandle hHandle,
+            UInt32 dwMilliseconds);
+    }
+
+    internal class SafeMemoryBuffer : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        public SafeMemoryBuffer() : base(true) { }
+        public SafeMemoryBuffer(int cb) : base(true)
+        {
+            base.SetHandle(Marshal.AllocHGlobal(cb));
+        }
+        public SafeMemoryBuffer(IntPtr handle) : base(true)
+        {
+            base.SetHandle(handle);
+        }
+
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+        protected override bool ReleaseHandle()
+        {
+            Marshal.FreeHGlobal(handle);
+            return true;
+        }
+    }
+
+    internal class SafeNativeHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        public SafeNativeHandle() : base(true) { }
+        public SafeNativeHandle(IntPtr handle) : base(true) { this.handle = handle; }
+
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.MayFail)]
+        protected override bool ReleaseHandle()
+        {
+            return NativeMethods.CloseHandle(handle);
+        }
+    }
+
+    public class Win32Exception : System.ComponentModel.Win32Exception
+    {
+        private string _msg;
+
+        public Win32Exception(string message) : this(Marshal.GetLastWin32Error(), message) { }
+        public Win32Exception(int errorCode, string message) : base(errorCode)
+        {
+            _msg = String.Format("{0} ({1}, Win32ErrorCode {2})", message, base.Message, errorCode);
+        }
+
+        public override string Message { get { return _msg; } }
+        public static explicit operator Win32Exception(string message) { return new Win32Exception(message); }
+    }
+
+    public class Result
+    {
+        public string StandardOut { get; internal set; }
+        public string StandardError { get; internal set; }
+        public uint ExitCode { get; internal set; }
+    }
+
+    public class ProcessUtil
+    {
+        /// <summary>
+        /// Parses a command line string into an argv array according to the Windows rules
+        /// </summary>
+        /// <param name="lpCommandLine">The command line to parse</param>
+        /// <returns>An array of arguments interpreted by Windows</returns>
+        public static string[] ParseCommandLine(string lpCommandLine)
+        {
+            int numArgs;
+            using (SafeMemoryBuffer buf = NativeMethods.CommandLineToArgvW(lpCommandLine, out numArgs))
+            {
+                if (buf.IsInvalid)
+                    throw new Win32Exception("Error parsing command line");
+                IntPtr[] strptrs = new IntPtr[numArgs];
+                Marshal.Copy(buf.DangerousGetHandle(), strptrs, 0, numArgs);
+                return strptrs.Select(s => Marshal.PtrToStringUni(s)).ToArray();
+            }
+        }
+
+        /// <summary>
+        /// Creates a process based on the CreateProcess API call.
+        /// </summary>
+        /// <param name="lpApplicationName">The name of the executable or batch file to execute</param>
+        /// <param name="lpCommandLine">The command line to execute, typically this includes lpApplication as the first argument</param>
+        /// <param name="lpCurrentDirectory">The full path to the current directory for the process, null will have the same cwd as the calling process</param>
+        /// <param name="environment">A dictionary of key/value pairs to define the new process environment</param>
+        /// <param name="stdin">A byte array to send over the stdin pipe</param>
+        /// <param name="outputEncoding">The character encoding for decoding stdout/stderr output of the process.</param>
+        /// <param name="waitChildren">Whether to wait for any children spawned by the process to finished (Server2012 +).</param>
+        /// <returns>Result object that contains the command output and return code</returns>
+        public static Result CreateProcess(string lpApplicationName, string lpCommandLine, string lpCurrentDirectory,
+            IDictionary environment, byte[] stdin, string outputEncoding, bool waitChildren)
+        {
+            NativeHelpers.ProcessCreationFlags creationFlags = NativeHelpers.ProcessCreationFlags.CREATE_SUSPENDED |
+                NativeHelpers.ProcessCreationFlags.CREATE_UNICODE_ENVIRONMENT | 
+                NativeHelpers.ProcessCreationFlags.EXTENDED_STARTUPINFO_PRESENT;
+            NativeHelpers.PROCESS_INFORMATION pi = new NativeHelpers.PROCESS_INFORMATION();
+            NativeHelpers.STARTUPINFOEX si = new NativeHelpers.STARTUPINFOEX();
+            si.startupInfo.dwFlags = NativeHelpers.StartupInfoFlags.USESTDHANDLES;
+
+            SafeFileHandle stdoutRead, stdoutWrite, stderrRead, stderrWrite, stdinRead, stdinWrite;
+            CreateStdioPipes(si, out stdoutRead, out stdoutWrite, out stderrRead, out stderrWrite, out stdinRead,
+                out stdinWrite);
+            FileStream stdinStream = new FileStream(stdinWrite, FileAccess.Write);
+
+            // $null from PowerShell ends up as an empty string, we need to convert back as an empty string doesn't
+            // make sense for these parameters
+            if (lpApplicationName == "")
+                lpApplicationName = null;
+
+            if (lpCurrentDirectory == "")
+                lpCurrentDirectory = null;
+
+            using (SafeMemoryBuffer lpEnvironment = CreateEnvironmentPointer(environment))
+            {
+                // Create console with utf-8 CP if no existing console is present
+                bool isConsole = false;
+                if (NativeMethods.GetConsoleWindow() == IntPtr.Zero)
+                {
+                    isConsole = NativeMethods.AllocConsole();
+
+                    // Set console input/output codepage to UTF-8
+                    NativeMethods.SetConsoleCP(65001);
+                    NativeMethods.SetConsoleOutputCP(65001);
+                }
+
+                try
+                {
+                    StringBuilder commandLine = new StringBuilder(lpCommandLine);
+                    if (!NativeMethods.CreateProcessW(lpApplicationName, commandLine, IntPtr.Zero, IntPtr.Zero,
+                        true, creationFlags, lpEnvironment, lpCurrentDirectory, si, out pi))
+                    {
+                        throw new Win32Exception("CreateProcessW() failed");
+                    }
+                }
+                finally
+                {
+                    if (isConsole)
+                        NativeMethods.FreeConsole();
+                }
+            }
+
+            return WaitProcess(stdoutRead, stdoutWrite, stderrRead, stderrWrite, stdinStream, stdin, pi,
+                outputEncoding, waitChildren);
+        }
+
+        internal static void CreateStdioPipes(NativeHelpers.STARTUPINFOEX si, out SafeFileHandle stdoutRead,
+            out SafeFileHandle stdoutWrite, out SafeFileHandle stderrRead, out SafeFileHandle stderrWrite,
+            out SafeFileHandle stdinRead, out SafeFileHandle stdinWrite)
+        {
+            NativeHelpers.SECURITY_ATTRIBUTES pipesec = new NativeHelpers.SECURITY_ATTRIBUTES();
+            pipesec.bInheritHandle = true;
+
+            if (!NativeMethods.CreatePipe(out stdoutRead, out stdoutWrite, pipesec, 0))
+                throw new Win32Exception("STDOUT pipe setup failed");
+            if (!NativeMethods.SetHandleInformation(stdoutRead, NativeHelpers.HandleFlags.INHERIT, 0))
+                throw new Win32Exception("STDOUT pipe handle setup failed");
+
+            if (!NativeMethods.CreatePipe(out stderrRead, out stderrWrite, pipesec, 0))
+                throw new Win32Exception("STDERR pipe setup failed");
+            if (!NativeMethods.SetHandleInformation(stderrRead, NativeHelpers.HandleFlags.INHERIT, 0))
+                throw new Win32Exception("STDERR pipe handle setup failed");
+
+            if (!NativeMethods.CreatePipe(out stdinRead, out stdinWrite, pipesec, 0))
+                throw new Win32Exception("STDIN pipe setup failed");
+            if (!NativeMethods.SetHandleInformation(stdinWrite, NativeHelpers.HandleFlags.INHERIT, 0))
+                throw new Win32Exception("STDIN pipe handle setup failed");
+
+            si.startupInfo.hStdOutput = stdoutWrite;
+            si.startupInfo.hStdError = stderrWrite;
+            si.startupInfo.hStdInput = stdinRead;
+        }
+
+        internal static SafeMemoryBuffer CreateEnvironmentPointer(IDictionary environment)
+        {
+            IntPtr lpEnvironment = IntPtr.Zero;
+            if (environment != null && environment.Count > 0)
+            {
+                StringBuilder environmentString = new StringBuilder();
+                foreach (DictionaryEntry kv in environment)
+                    environmentString.AppendFormat("{0}={1}\0", kv.Key, kv.Value);
+                environmentString.Append('\0');
+
+                lpEnvironment = Marshal.StringToHGlobalUni(environmentString.ToString());
+            }
+            return new SafeMemoryBuffer(lpEnvironment);
+        }
+
+        internal static Result WaitProcess(SafeFileHandle stdoutRead, SafeFileHandle stdoutWrite, SafeFileHandle stderrRead,
+            SafeFileHandle stderrWrite, FileStream stdinStream, byte[] stdin, NativeHelpers.PROCESS_INFORMATION pi,
+            string outputEncoding, bool waitChildren)
+        {
+            // Default to using UTF-8 as the output encoding, this should be a sane default for most scenarios.
+            outputEncoding = String.IsNullOrEmpty(outputEncoding) ? "utf-8" : outputEncoding;
+            Encoding encodingInstance = Encoding.GetEncoding(outputEncoding);
+
+            // If we aren't waiting for child processes we don't care if the below fails
+            // Logic to wait for children is from Raymond Chen
+            // https://devblogs.microsoft.com/oldnewthing/20130405-00/?p=4743
+            using (SafeHandle job = CreateJob(!waitChildren))
+            using (SafeHandle ioPort = CreateCompletionPort(!waitChildren))
+            {
+                // Need to assign the completion port to the job and then assigned the new process to that job.
+                if (waitChildren)
+                {
+                    NativeHelpers.JOBOBJECT_ASSOCIATE_COMPLETION_PORT compPort = new NativeHelpers.JOBOBJECT_ASSOCIATE_COMPLETION_PORT()
+                    {
+                        CompletionKey = job.DangerousGetHandle(),
+                        CompletionPort = ioPort.DangerousGetHandle(),
+                    };
+                    int compPortSize = Marshal.SizeOf(compPort);
+
+                    using (SafeMemoryBuffer compPortPtr = new SafeMemoryBuffer(compPortSize))
+                    {
+                        Marshal.StructureToPtr(compPort, compPortPtr.DangerousGetHandle(), false);
+
+                        if (!NativeMethods.SetInformationJobObject(job,
+                            NativeHelpers.JobObjectInformationClass.JobObjectAssociateCompletionPortInformation,
+                            compPortPtr.DangerousGetHandle(), compPortSize))
+                        {
+                            throw new Win32Exception("Failed to set job completion port information");
+                        }
+                    }
+
+                    // Server 2012/Win 8 introduced the ability to nest jobs. Older versions will fail with
+                    // ERROR_ACCESS_DENIED but we can't do anything about that except not wait for children.
+                    if (!NativeMethods.AssignProcessToJobObject(job, pi.hProcess))
+                        throw new Win32Exception("Failed to assign new process to completion watcher job");
+                }
+
+                // Start the process and get the output.
+                NativeMethods.ResumeThread(pi.hThread);
+
+                FileStream stdoutFS = new FileStream(stdoutRead, FileAccess.Read, 4096);
+                StreamReader stdout = new StreamReader(stdoutFS, encodingInstance, true, 4096);
+                stdoutWrite.Close();
+
+                FileStream stderrFS = new FileStream(stderrRead, FileAccess.Read, 4096);
+                StreamReader stderr = new StreamReader(stderrFS, encodingInstance, true, 4096);
+                stderrWrite.Close();
+
+                if (stdin != null)
+                    stdinStream.Write(stdin, 0, stdin.Length);
+                stdinStream.Close();
+
+                string stdoutStr, stderrStr = null;
+                GetProcessOutput(stdout, stderr, out stdoutStr, out stderrStr);
+                UInt32 rc = GetProcessExitCode(pi.hProcess);
+
+                if (waitChildren)
+                {
+                    // If the caller wants to wait for all child processes to finish, we continue to poll the job
+                    // until it receives JOB_OBJECT_MSG_ACTIVE_PROCESS_ZERO (4).
+                    UInt32 completionCode = 0xFFFFFFFF;
+                    UIntPtr completionKey;
+                    IntPtr overlapped;
+
+                    while (NativeMethods.GetQueuedCompletionStatus(ioPort.DangerousGetHandle(), out completionCode,
+                        out completionKey, out overlapped, 0xFFFFFFFF) && completionCode != 4) { }
+                }
+
+                return new Result
+                {
+                    StandardOut = stdoutStr,
+                    StandardError = stderrStr,
+                    ExitCode = rc
+                };
+            }
+        }
+
+        internal static void GetProcessOutput(StreamReader stdoutStream, StreamReader stderrStream, out string stdout, out string stderr)
+        {
+            var sowait = new EventWaitHandle(false, EventResetMode.ManualReset);
+            var sewait = new EventWaitHandle(false, EventResetMode.ManualReset);
+            string so = null, se = null;
+            ThreadPool.QueueUserWorkItem((s) =>
+            {
+                so = stdoutStream.ReadToEnd();
+                sowait.Set();
+            });
+            ThreadPool.QueueUserWorkItem((s) =>
+            {
+                se = stderrStream.ReadToEnd();
+                sewait.Set();
+            });
+            foreach (var wh in new WaitHandle[] { sowait, sewait })
+                wh.WaitOne();
+            stdout = so;
+            stderr = se;
+        }
+
+        internal static UInt32 GetProcessExitCode(IntPtr processHandle)
+        {
+            SafeWaitHandle hProcess = new SafeWaitHandle(processHandle, true);
+            NativeMethods.WaitForSingleObject(hProcess, 0xFFFFFFFF);
+
+            UInt32 exitCode;
+            if (!NativeMethods.GetExitCodeProcess(hProcess, out exitCode))
+                throw new Win32Exception("GetExitCodeProcess() failed");
+            return exitCode;
+        }
+
+        private static SafeHandle CreateJob(bool ignoreErrors)
+        {
+            SafeNativeHandle job = NativeMethods.CreateJobObjectW(IntPtr.Zero, null);
+            if (job.IsInvalid && !ignoreErrors)
+                throw new Win32Exception("Failed to create job object");
+
+            return job;
+        }
+
+        private static SafeHandle CreateCompletionPort(bool ignoreErrors)
+        {
+            SafeNativeHandle ioPort = NativeMethods.CreateIoCompletionPort((IntPtr)(-1), IntPtr.Zero,
+                UIntPtr.Zero, 1);
+
+            if (ioPort.IsInvalid && !ignoreErrors)
+                throw new Win32Exception("Failed to create IoCompletionPort");
+
+            return ioPort;
+        }
+    }
+}

--- a/plugins/module_utils/Process.psm1
+++ b/plugins/module_utils/Process.psm1
@@ -26,7 +26,7 @@ Function Resolve-ExecutablePath {
     # they exist.
     $command = Get-Command -Name $FilePath -CommandType Application -ErrorAction SilentlyContinue
     if ($command) {
-        $command.Source
+        $command.Path
         return
     }
 
@@ -166,7 +166,7 @@ Function Start-AnsibleWindowsProcess {
         [String[]]
         $ArgumentList,
 
-        [Parameter(ParameterSetName='CommandLine')]
+        [Parameter(Mandatory=$true, ParameterSetName='CommandLine')]
         [String]
         $CommandLine,
 
@@ -196,11 +196,13 @@ Function Start-AnsibleWindowsProcess {
     }
 
     if ($FilePath) {
-        $applicationName = Resolve-ExecutablePath -FilePath $FilePath -WorkingDirectory $WorkingDirectory
+        $applicationName = $FilePath
     }
     else {
-        $applicationName = [NullString]::Value
+        # If -FilePath is not set then -CommandLine must have been used. Select the path based on the first entry.
+        $applicationName = [Ansible.Windows.Process.ProcessUtil]::CommandLineToArgv($CommandLine)[0]
     }
+    $applicationName = Resolve-ExecutablePath -FilePath $applicationName -WorkingDirectory $WorkingDirectory
 
     # When -ArgumentList is used, we need to escape each argument, including the FilePath to build our CommandLine.
     if ($PSCmdlet.ParameterSetName -eq 'ArgumentList') {

--- a/plugins/module_utils/Process.psm1
+++ b/plugins/module_utils/Process.psm1
@@ -1,0 +1,228 @@
+# Copyright (c) 2020 Ansible Project
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+#AnsibleRequires -CSharpUtil .Process
+
+Function Resolve-ExecutablePath {
+    <#
+    .SYNOPSIS
+    Tries to resolve the file path to a valid executable.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        $FilePath,
+
+        [String]
+        $WorkingDirectory
+    )
+
+    # Ensure the path has an extension set, default to .exe
+    if (-not [IO.Path]::HasExtension($FilePath)) {
+        $FilePath = "$FilePath.exe"
+    }
+
+    # See the if path is resolvable using the normal PATH logic. Also resolves absolute paths and relative paths if
+    # they exist.
+    $command = Get-Command -Name $FilePath -CommandType Application -ErrorAction SilentlyContinue
+    if ($command) {
+        $command.Source
+        return
+    }
+
+    # If -WorkingDirectory is specified, check if the path is relative to that
+    if ($WorkingDirectory) {
+        $file = $PSCmdlet.GetUnresolvedProviderPathFromPSPath((Join-Path -Path $WorkingDirectory -ChildPath $FilePath))
+        if (Test-Path -LiteralPath $file) {
+            $file
+            return
+        }
+    }
+
+    # Just hope for the best and use whatever was provided.
+    $FilePath
+}
+
+Function ConvertFrom-EscapedArgument {
+    <#
+    .SYNOPSIS
+    Extract individual arguments from a command line string.
+
+    .PARAMETER InputObject
+    The command line string to extract the arguments from.
+    #>
+    [CmdletBinding()]
+    [OutputType([String])]
+    param (
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [String[]]
+        $InputObject
+    )
+
+    process {
+        foreach ($command in $InputObject) {
+            [Ansible.Windows.Process.ProcessUtil]::ParseCommandLine($command)
+        }
+    }
+}
+
+Function ConvertTo-EscapedArgument {
+    <#
+    .SYNOPSIS
+    Escapes an argument value so it can be used in a call to CreateProcess.
+
+    .PARAMETER InputObject
+    The argument(s) to escape.
+    #>
+    [CmdletBinding()]
+    [OutputType([String])]
+    param (
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [String[]]
+        $InputObject
+    )
+
+    process {
+        foreach ($argument in $InputObject) {
+            if (-not $argument) {
+                return '""'
+            }
+            elseif ($argument -notmatch '[\s"]') {
+                return $argument
+            }
+
+            # Replace any double quotes in an argument with '\"'
+            $argument = $argument -replace '"', '\"'
+
+            # Double up on any '\' chars that preceded a double quote
+            $argument = $argument -replace '(\\+)\"', '$1$1\"'
+
+            # Double up '\' at the end of the argument so it doesn't escape end quote.
+            $argument = $argument -replace '(\\+)$', '$1$1'
+
+            # Finally wrap the entire argument in double quotes now we've escaped the double quotes within
+            '"{0}"' -f $argument
+        }
+    }
+}
+
+Function Start-AnsibleWindowsProcess {
+    <#
+    .SYNOPSIS
+    Start a process and wait for it to finish.
+
+    .PARAMETER FilePath
+    The file to execute.
+
+    .PARAMETER ArgumentList
+    Arguments to execute, these will be escaped so the literal value is used.
+
+    .PARAMETER CommandLine
+    The raw command line to call with CreateProcess. These values are not escaped for you so use at your own risk.
+
+    .PARAMETER WorkingDirectory
+    The working directory to set on the new process, defaults to the current working dir.
+
+    .PARAMETER Environment
+    Override the environment to set for the new process, if not set then the current environment will be used.
+
+    .PARAMETER InputObject
+    A string or byte[] array to send to the process' stdin when it has started.
+
+    .PARAMETER OutputEncodingOverride
+    The encoding name to use when reading the stdout/stderr of the process. Defaults to utf-8 if not set.
+
+    .PARAMETER WaitChildren
+    Whether to wait for any child process spawned to finish before returning. This only works on Windows hosts on
+    Server 2012/Windows 8 or newer.
+
+    .OUTPUTS
+    [PSCustomObject]@{
+        Command = The final command used to start the process
+        Stdout = The stdout of the process
+        Stderr = The stderr of the process
+        ExitCode = The return code from the process
+    }
+    #>
+    [CmdletBinding(DefaultParameterSetName='ArgumentList')]
+    [OutputType('Ansible.Windows.Process.Info')]
+    param (
+        [Parameter(Mandatory=$true, ParameterSetName='ArgumentList')]
+        [Parameter(ParameterSetName='CommandLine')]
+        [String]
+        $FilePath,
+
+        [Parameter(ParameterSetName='ArgumentList')]
+        [String[]]
+        $ArgumentList,
+
+        [Parameter(ParameterSetName='CommandLine')]
+        [String]
+        $CommandLine,
+
+        [String]
+        $WorkingDirectory,
+
+        [Collections.IDictionary]
+        $Environment,
+
+        [Object]
+        $InputObject,
+
+        [String]
+        [Alias('OutputEncoding')]
+        $OutputEncodingOverride,
+
+        [Switch]
+        $WaitChildren
+    )
+
+    if ($WorkingDirectory) {
+        if (-not (Test-Path -LiteralPath $WorkingDirectory)) {
+            Write-Error -Message "Could not find specified -WorkingDirectory '$WorkingDirectory'"
+            return
+        }
+    }
+
+    if ($FilePath) {
+        $applicationName = Resolve-ExecutablePath -FilePath $FilePath -WorkingDirectory $WorkingDirectory
+    }
+    else {
+        $applicationName = [NullString]::Value
+    }
+
+    # When -ArgumentList is used, we need to escape each argument, including the FilePath to build our CommandLine.
+    if ($PSCmdlet.ParameterSetName -eq 'SplitArgs') {
+        $CommandLine = ConvertTo-EscapedArgument -Argument $applicationName
+        if ($ArgumentList) {
+            $escapedArguments = @($ArgumentList | ConvertTo-EscapedArgument)
+            $CommandLine += " $($escapedArguments -join ' '))"
+        }
+    }
+
+    $stdin = switch ($InputObject) {
+        { $null -eq $_ } { $null }
+        { $_ -is [byte[]] } { ,$_ }
+        { $_ -is [String] } { ,[Text.Encoding]::UTF8.GetBytes($InputObject) }
+        default {
+            Write-Error -Message "InputObject must be a string or byte[]"
+            return
+        }
+    }
+
+    $res = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($applicationName, $CommandLine, $WorkingDirectory,
+        $Environment, $stdin, $OutputEncodingOverride, $WaitChildren)
+
+    [PSCustomObject]@{
+        PSTypeName = 'Ansible.Windows.Process.Info'
+        Command = $CommandLine
+        Stdout = $res.Stdout
+        Stderr = $res.Stderr
+        ExitCode = $res.ExitCode
+    }
+}
+
+$export_members = @{
+    Function = 'ConvertFrom-EscapedArgument', 'ConvertTo-EscapedArgument', 'Start-AnsibleWindowsProcess'
+}
+Export-ModuleMember @export_members

--- a/plugins/modules/win_package.ps1
+++ b/plugins/modules/win_package.ps1
@@ -1206,7 +1206,7 @@ $providerInfo = [Ordered]@{
             }
 
             if ($Path) {
-                $invokeParams.CommandLine = ConvertTo-EscapedArgument -Argument $Path
+                $invokeParams.CommandLine = ConvertTo-EscapedArgument -InputObject $Path
             } else {
                 $registryProperties = Get-ItemProperty -LiteralPath $RegistryPath
 
@@ -1244,9 +1244,9 @@ $providerInfo = [Ordered]@{
                     }
 
                     # If we still couldn't find a file just use the command literally and hope WIndows can handle it,
-                    # otherwise recombind the args which will also quote whatever is needed.
+                    # otherwise recombine the args which will also quote whatever is needed.
                     if ($rawArguments.Count -gt 0) {
-                        $command = $rawArguments | ConvertTo-EscapedArgument
+                        $command = @($rawArguments | ConvertTo-EscapedArgument) -join ' '
                     }
                 }
 
@@ -1336,7 +1336,7 @@ $module.Result.reboot_required = $false
 if ($null -ne $arguments) {
     # convert a list to a string and escape the values
     if ($arguments -is [array]) {
-        $arguments = $arguments | ConvertTo-EscapedArgument
+        $arguments = @($arguments | ConvertTo-EscapedArgument) -join ' '
     }
 }
 

--- a/plugins/modules/win_package.py
+++ b/plugins/modules/win_package.py
@@ -192,7 +192,7 @@ options:
     - Requires Windows Server 2012 or Windows 8 or newer to use.
     type: bool
     default: no
-    version_added: 1.1.0
+    version_added: 1.3.0
 extends_documentation_fragment:
 - ansible.windows.web_request
 

--- a/plugins/modules/win_package.py
+++ b/plugins/modules/win_package.py
@@ -178,8 +178,14 @@ options:
     aliases: [ user_name ]
   wait_for_children:
     description:
-    - Wait for any child process spawned by the install or uninstaller to
-      finish before M(ansible.windows.win_package) returns.
+    - The module will wait for the process it spawns to finish but any
+      processes spawned in that child process as ignored.
+    - Set to C(yes) to wait for all descendent processes to finish before the
+      module returns.
+    - This is useful if the install/uninstaller is just a wrapper which then
+      calls the actual installer as its own child process. When this option is
+      C(yes) then the module will wait for both processes to finish before
+      returning.
     - This should not be required for most installers and setting to C(yes)
       could result in the module not returning until the process it is waiting
       for has been stopped manually.

--- a/plugins/modules/win_package.py
+++ b/plugins/modules/win_package.py
@@ -176,6 +176,17 @@ options:
       C(2022-07-01).
     type: str
     aliases: [ user_name ]
+  wait_for_children:
+    description:
+    - Wait for any child process spawned by the install or uninstaller to
+      finish before M(ansible.windows.win_package) returns.
+    - This should not be required for most installers and setting to C(yes)
+      could result in the module not returning until the process it is waiting
+      for has been stopped manually.
+    - Requires Windows Server 2012 or Windows 8 or newer to use.
+    type: bool
+    default: no
+    version_added: 1.1.0
 extends_documentation_fragment:
 - ansible.windows.web_request
 

--- a/tests/integration/targets/module_utils_Process/aliases
+++ b/tests/integration/targets/module_utils_Process/aliases
@@ -1,0 +1,2 @@
+windows
+shippable/windows/group2

--- a/tests/integration/targets/module_utils_Process/library/process_cs_tests.ps1
+++ b/tests/integration/targets/module_utils_Process/library/process_cs_tests.ps1
@@ -1,0 +1,224 @@
+#!powershell
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -CSharpUtil ansible_collections.ansible.windows.plugins.module_utils.Process
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, @{})
+
+Function Assert-Equals {
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)][AllowNull()]$Actual,
+        [Parameter(Mandatory=$true, Position=0)][AllowNull()]$Expected
+    )
+
+    $matched = $false
+    if ($Actual -is [System.Collections.ArrayList] -or $Actual -is [Array]) {
+        $Actual.Count | Assert-Equals -Expected $Expected.Count
+        for ($i = 0; $i -lt $Actual.Count; $i++) {
+            $actual_value = $Actual[$i]
+            $expected_value = $Expected[$i]
+            Assert-Equals -Actual $actual_value -Expected $expected_value
+        }
+        $matched = $true
+    } else {
+        $matched = $Actual -ceq $Expected
+    }
+
+    if (-not $matched) {
+        if ($Actual -is [PSObject]) {
+            $Actual = $Actual.ToString()
+        }
+
+        $call_stack = (Get-PSCallStack)[1]
+        $module.Result.test = $test
+        $module.Result.actual = $Actual
+        $module.Result.expected = $Expected
+        $module.Result.line = $call_stack.ScriptLineNumber
+        $module.Result.method = $call_stack.Position.Text
+        $module.FailJson("AssertionError: actual != expected")
+    }
+}
+
+$tests = @{
+    "CommandLineToArgv empty string" = {
+        $expected = [Ansible.Windows.Process.ProcessUtil]::CommandLineToArgv((Get-Process -Id $pid).Path)
+        $actual = [Ansible.Windows.Process.ProcessUtil]::CommandLineToArgv("")
+        Assert-Equals -Actual $actual -Expected $expected
+    }
+
+    "CommandLineToArgv single argument" = {
+        $expected = @("powershell.exe")
+        $actual = [Ansible.Windows.Process.ProcessUtil]::CommandLineToArgv("powershell.exe")
+        Assert-Equals -Actual $actual -Expected $expected
+    }
+
+    "CommandLineToArgv multiple arguments" = {
+        $expected = @("powershell.exe", "-File", "C:\temp\script.ps1")
+        $actual = [Ansible.Windows.Process.ProcessUtil]::CommandLineToArgv("powershell.exe -File C:\temp\script.ps1")
+        Assert-Equals -Actual $actual -Expected $expected
+    }
+
+    "CommandLineToArgv comples arguments" = {
+        $expected = @('abc', 'd', 'ef gh', 'i\j', 'k"l', 'm\n op', 'ADDLOCAL=qr, s', 'tuv\', 'w''x', 'yz')
+        $actual = [Ansible.Windows.Process.ProcessUtil]::CommandLineToArgv('abc d "ef gh" i\j k\"l m\\"n op" ADDLOCAL="qr, s" tuv\ w''x yz')
+        Assert-Equals -Actual $actual -Expected $expected
+    }
+
+    "CreateProcess basic" = {
+        $actual = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($null, "whoami.exe", $null, $null, $null, $null, $false)
+        $actual.GetType().FullName | Assert-Equals -Expected "ansible_collections.ansible.windows.plugins.module_utils.Process.Result"
+        $actual.StandardOut | Assert-Equals -Expected "$(&whoami.exe)`r`n"
+        $actual.StandardError | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "CreateProcess stderr" = {
+        $cmd = "powershell.exe [System.Console]::Error.WriteLine('hi')"
+        $actual = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($null, $cmd, $null, $null, $null, $null, $false)
+        $actual.StandardOut | Assert-Equals -Expected ""
+        $actual.StandardError | Assert-Equals -Expected "hi`r`n"
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "CreateProcess exit code" = {
+        $cmd = "powershell.exe exit 10"
+        $actual = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($null, $cmd, $null, $null, $null, $null, $false)
+        $actual.StandardOut | Assert-Equals -Expected ""
+        $actual.StandardError | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 10
+    }
+
+    "CreateProcess bad executable" = {
+        $failed = $false
+        try {
+            [Ansible.Windows.Process.ProcessUtil]::CreateProcess($null, "fake.exe", $null, $null, $null, $null, $false)
+        } catch {
+            $failed = $true
+            $_.Exception.InnerException.GetType().FullName | Assert-Equals -Expected "ansible_collections.ansible.windows.plugins.module_utils.Process.Win32Exception"
+            $expected = 'Exception calling "CreateProcess" with "7" argument(s): "CreateProcessW() failed '
+            $expected += '(The system cannot find the file specified, Win32ErrorCode 2 - 0x00000002)"'
+            $_.Exception.Message | Assert-Equals -Expected $expected
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "CreateProcess with unicode" = {
+        $cmd = "cmd.exe /c echo 💩 café"
+        $actual = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($null, $cmd, $null, $null, $null, $null, $false)
+        $actual.StandardOut | Assert-Equals -Expected "💩 café`r`n"
+        $actual.StandardError | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "CreateProcess without working dir" = {
+        $expected = $pwd.Path + "`r`n"
+        $cmd = 'powershell.exe $pwd.Path'
+        $actual = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($null, $cmd, $null, $null, $null, $null, $false)
+        $actual.StandardOut | Assert-Equals -Expected $expected
+        $actual.StandardError | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "CreateProcess with working dir" = {
+        $expected = "C:\Windows`r`n"
+        $cmd = 'powershell.exe $pwd.Path'
+        $actual = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($null, $cmd, 'C:\Windows', $null, $null, $null, $false)
+        $actual.StandardOut | Assert-Equals -Expected $expected
+        $actual.StandardError | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "CreateProcess without environment" = {
+        $expected = "$($env:USERNAME)`r`n"
+        $cmd = 'powershell.exe $env:TEST; $env:USERNAME'
+        $actual = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($null, $cmd, $null, $null, $null, $null, $false)
+        $actual.StandardOut | Assert-Equals -Expected $expected
+        $actual.StandardError | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "CreateProcess with environment" = {
+        $env_vars = @{
+            TEST = "tesTing"
+            TEST2 = "Testing 2"
+        }
+        $cmd = 'cmd.exe /c set'
+        $actual = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($null, $cmd, $null, $env_vars, $null, $null, $false)
+        ("TEST=tesTing" -cin $actual.StandardOut.Split("`r`n")) | Assert-Equals -Expected $true
+        ("TEST2=Testing 2" -cin $actual.StandardOut.Split("`r`n")) | Assert-Equals -Expected $true
+        ("USERNAME=$($env:USERNAME)" -cnotin $actual.StandardOut.Split("`r`n")) | Assert-Equals -Expected $true
+        $actual.StandardError | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "CreateProcess with byte stdin" = {
+        $expected = "input value`r`n"
+        $cmd = 'powershell.exe [System.Console]::In.ReadToEnd()'
+        $actual = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($null, $cmd, $null, $null,
+            [System.Text.Encoding]::UTF8.GetBytes("input value"), $null, $false)
+        $actual.StandardOut | Assert-Equals -Expected $expected
+        $actual.StandardError | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "CreateProcess with byte stdin and newline" = {
+        $expected = "input value`r`n`r`n"
+        $cmd = 'powershell.exe [System.Console]::In.ReadToEnd()'
+        $actual = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($null, $cmd, $null, $null,
+            [System.Text.Encoding]::UTF8.GetBytes("input value`r`n"), $null, $false)
+        $actual.StandardOut | Assert-Equals -Expected $expected
+        $actual.StandardError | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "CreateProcess with lpApplicationName" = {
+        $expected = "abc`r`n"
+        $full_path = "$($env:SystemRoot)\System32\WindowsPowerShell\v1.0\powershell.exe"
+        $actual = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($full_path, "Write-Output 'abc'", $null, $null, $null, $null, $false)
+        $actual.StandardOut | Assert-Equals -Expected $expected
+        $actual.StandardError | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+
+        $actual = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($full_path, "powershell.exe Write-Output 'abc'", $null, $null, $null, $Null, $false)
+        $actual.StandardOut | Assert-Equals -Expected $expected
+        $actual.StandardError | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "CreateProcess with unicode and us-ascii encoding" = {
+        $poop = [System.Char]::ConvertFromUtf32(0xE05A)  # Coverage breaks due to script parsing encoding issues with unicode chars, just use the code point instead
+        $cmd = "cmd.exe /c echo $poop café"
+        $actual = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($null, $cmd, $null, $null, $null, 'us-ascii', $false)
+        $actual.StandardOut | Assert-Equals -Expected "??? caf??`r`n"
+        $actual.StandardError | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "CreateProcess while waiting for grandchildren" = {
+        $subCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes(@'
+Start-Sleep -Seconds 2
+exit 1
+'@))
+        $cmd = "powershell.exe Start-Process powershell.exe -ArgumentList '-EncodedCommand', '$subCommand'"
+
+        $time = Measure-Command -Expression {
+            $actual = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($null, $cmd, $null, $null, $null, $null, $false)
+        }
+        $time.TotalSeconds -lt 2 | Assert-Equals -Expected $true
+        $actual.ExitCode | Assert-Equals -Expected 0
+
+        $time = Measure-Command -Expression {
+            $actual = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($null, $cmd, $null, $null, $null, $null, $true)
+        }
+        $time.TotalSeconds -ge 2 | Assert-Equals -Expected $true
+        $actual.ExitCode | Assert-Equals -Expected 0  # We still don't expect to get the grandchild rc
+    }
+}
+
+foreach ($test_impl in $tests.GetEnumerator()) {
+    $test = $test_impl.Key
+    &$test_impl.Value
+}
+
+$module.Result.data = "success"
+$module.ExitJson()

--- a/tests/integration/targets/module_utils_Process/library/process_cs_tests.ps1
+++ b/tests/integration/targets/module_utils_Process/library/process_cs_tests.ps1
@@ -201,17 +201,18 @@ exit 1
 '@))
         $cmd = "powershell.exe Start-Process powershell.exe -ArgumentList '-EncodedCommand', '$subCommand'"
 
+        $actual = $null
         $time = Measure-Command -Expression {
             $actual = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($null, $cmd, $null, $null, $null, $null, $false)
+            $actual.ExitCode | Assert-Equals -Expected 0
         }
         $time.TotalSeconds -lt 2 | Assert-Equals -Expected $true
-        $actual.ExitCode | Assert-Equals -Expected 0
 
         $time = Measure-Command -Expression {
             $actual = [Ansible.Windows.Process.ProcessUtil]::CreateProcess($null, $cmd, $null, $null, $null, $null, $true)
+            $actual.ExitCode | Assert-Equals -Expected 0  # We still don't expect to get the grandchild rc
         }
         $time.TotalSeconds -ge 2 | Assert-Equals -Expected $true
-        $actual.ExitCode | Assert-Equals -Expected 0  # We still don't expect to get the grandchild rc
     }
 }
 

--- a/tests/integration/targets/module_utils_Process/library/process_pwsh_tests.ps1
+++ b/tests/integration/targets/module_utils_Process/library/process_pwsh_tests.ps1
@@ -132,7 +132,7 @@ $tests = [Ordered]@{
         $pwshGrandparent = Split-Path $pwshParent -Parent
         $pwshGrandparentName = Split-Path $pwshParent -Leaf
 
-        Push-Location -Path $pwshGrandparent
+        Push-Location -LiteralPath $pwshGrandparent
         $actual = Start-AnsibleWindowsProcess -FilePath "$pwshGrandparentName\powershell" -ArgumentList '$pwd.Path'
         Pop-Location
         $actual.PSTypeNames[0] | Assert-Equals -Expected 'Ansible.Windows.Process.Info'
@@ -259,15 +259,15 @@ exit 1
 
         $time = Measure-Command -Expression {
             $actual = Start-AnsibleWindowsProcess -CommandLine $cmd
+            $actual.ExitCode | Assert-Equals -Expected 0
         }
         $time.TotalSeconds -lt 2 | Assert-Equals -Expected $true
-        $actual.ExitCode | Assert-Equals -Expected 0
 
         $time = Measure-Command -Expression {
             $actual = Start-AnsibleWindowsProcess -CommandLine $cmd -WaitChildren
+            $actual.ExitCode | Assert-Equals -Expected 0  # We still don't expect to get the grandchild rc
         }
         $time.TotalSeconds -ge 2 | Assert-Equals -Expected $true
-        $actual.ExitCode | Assert-Equals -Expected 0  # We still don't expect to get the grandchild rc
     }
 }
 

--- a/tests/integration/targets/module_utils_Process/library/process_pwsh_tests.ps1
+++ b/tests/integration/targets/module_utils_Process/library/process_pwsh_tests.ps1
@@ -47,7 +47,7 @@ $tests = [Ordered]@{
     "Start-AnsibleWindowsProcess basic" = {
         $actual = Start-AnsibleWindowsProcess -FilePath whoami
         $actual.PSTypeNames[0] | Assert-Equals -Expected 'Ansible.Windows.Process.Info'
-        $actual.Command | Assert-Equals -Expected (Get-Command whoami -CommandType Application).Source
+        $actual.Command | Assert-Equals -Expected (Get-Command whoami -CommandType Application).Path
         $actual.Stdout | Assert-Equals -Expected "$(&whoami.exe)`r`n"
         $actual.Stderr | Assert-Equals -Expected ""
         $actual.ExitCode | Assert-Equals -Expected 0
@@ -107,7 +107,7 @@ $tests = [Ordered]@{
     }
 
     "Start-AnsibleWindowsProcess stderr" = {
-        $pwshPath = (Get-Command powershell.exe -CommandType Application).Source
+        $pwshPath = (Get-Command powershell.exe -CommandType Application).Path
         $actual = Start-AnsibleWindowsProcess -FilePath powershell.exe -ArgumentList '[Console]::Error.WriteLine("hi")'
         $actual.PSTypeNames[0] | Assert-Equals -Expected 'Ansible.Windows.Process.Info'
         $actual.Command | Assert-Equals -Expected "$pwshPath `"[Console]::Error.WriteLine(\`"hi\`")`""
@@ -117,7 +117,7 @@ $tests = [Ordered]@{
     }
 
     "Start-AnsibleWindowsProcess exit code" = {
-        $pwshPath = (Get-Command powershell.exe -CommandType Application).Source
+        $pwshPath = (Get-Command powershell.exe -CommandType Application).Path
         $actual = Start-AnsibleWindowsProcess -FilePath powershell.exe -ArgumentList 'exit 10'
         $actual.PSTypeNames[0] | Assert-Equals -Expected 'Ansible.Windows.Process.Info'
         $actual.Command | Assert-Equals -Expected "$pwshPath `"exit 10`""
@@ -127,7 +127,7 @@ $tests = [Ordered]@{
     }
 
     "Start-AnsibleWindowsProcess relative path" = {
-        $pwshPath = (Get-Command powershell.exe -CommandType Application).Source
+        $pwshPath = (Get-Command powershell.exe -CommandType Application).Path
         $pwshParent = Split-Path $pwshPath -Parent
         $pwshGrandparent = Split-Path $pwshParent -Parent
         $pwshGrandparentName = Split-Path $pwshParent -Leaf

--- a/tests/integration/targets/module_utils_Process/library/process_pwsh_tests.ps1
+++ b/tests/integration/targets/module_utils_Process/library/process_pwsh_tests.ps1
@@ -1,0 +1,333 @@
+#!powershell
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -PowerShell ansible_collections.ansible.windows.plugins.module_utils.Process
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, @{
+    options = @{
+        print_argv = @{ type = 'path'; required = $true }
+    }
+})
+
+Function Assert-Equals {
+    param(
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)][AllowNull()]$Actual,
+        [Parameter(Mandatory=$true, Position=0)][AllowNull()]$Expected
+    )
+
+    $matched = $false
+    if ($Actual -is [System.Collections.ArrayList] -or $Actual -is [Array]) {
+        $Actual.Count | Assert-Equals -Expected $Expected.Count
+        for ($i = 0; $i -lt $Actual.Count; $i++) {
+            $actual_value = $Actual[$i]
+            $expected_value = $Expected[$i]
+            Assert-Equals -Actual $actual_value -Expected $expected_value
+        }
+        $matched = $true
+    } else {
+        $matched = $Actual -ceq $Expected
+    }
+
+    if (-not $matched) {
+        if ($Actual -is [PSObject]) {
+            $Actual = $Actual.ToString()
+        }
+
+        $call_stack = (Get-PSCallStack)[1]
+        $module.Result.test = $test
+        $module.Result.actual = $Actual
+        $module.Result.expected = $Expected
+        $module.Result.line = $call_stack.ScriptLineNumber
+        $module.Result.method = $call_stack.Position.Text
+        $module.FailJson("AssertionError: actual != expected")
+    }
+}
+
+$tests = [Ordered]@{
+    "Start-AnsibleWindowsProcess basic" = {
+        $actual = Start-AnsibleWindowsProcess -FilePath whoami
+        $actual.PSTypeNames[0] | Assert-Equals -Expected 'Ansible.Windows.Process.Info'
+        $actual.Command | Assert-Equals -Expected (Get-Command whoami -CommandType Application).Source
+        $actual.Stdout | Assert-Equals -Expected "$(&whoami.exe)`r`n"
+        $actual.Stderr | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "Start-AnsibleWindowsProcess -FilePath with -CommandLine" = {
+        $printArgv = $module.Params.print_argv
+        $actual = Start-AnsibleWindowsProcess -FilePath $printArgv -CommandLine '"abc def" arg2'
+        $actual.PSTypeNames[0] | Assert-Equals -Expected 'Ansible.Windows.Process.Info'
+        $actual.Command | Assert-Equals -Expected "`"abc def`" arg2"
+        $actual.Stdout | Assert-Equals -Expected "{`"command_line`":`"\`"abc def\`" arg2`",`"args`":[`"arg2`"]}`r`n"
+        $actual.Stderr | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "Start-AnsibleWindowsProcess -CommandLine" = {
+        $printArgv = $module.Params.print_argv
+        $cmd = @($printArgv, 'abc def', 'arg2' | ConvertTo-EscapedArgument) -join ' '
+        $expectedOutput = @{
+            command_line = $cmd
+            args = @('abc def', 'arg2')
+        } | ConvertTo-Json -Compress
+
+        $actual = Start-AnsibleWindowsProcess -CommandLine $cmd
+        $actual.PSTypeNames[0] | Assert-Equals -Expected 'Ansible.Windows.Process.Info'
+        $actual.Command | Assert-Equals -Expected $cmd
+        $actual.Stdout | Assert-Equals -Expected "$expectedOutput`r`n"
+        $actual.Stderr | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "Start-AnsibleWindowsProcess -ArgumentList" = {
+        $printArgv = $module.Params.print_argv
+        $cmd = @($printArgv, 'abc def', 'arg2' | ConvertTo-EscapedArgument) -join ' '
+        $expectedOutput = @{
+            command_line = $cmd
+            args = @('abc def', 'arg2')
+        } | ConvertTo-Json -Compress
+
+        $actual = Start-AnsibleWindowsProcess -FilePath $printArgv -ArgumentList @('abc def', 'arg2')
+        $actual.PSTypeNames[0] | Assert-Equals -Expected 'Ansible.Windows.Process.Info'
+        $actual.Command | Assert-Equals -Expected $cmd
+        $actual.Stdout | Assert-Equals -Expected "$expectedOutput`r`n"
+        $actual.Stderr | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "Start-AnsibleWindowsProcess fail with -CommandLine and -ArgumentList" = {
+        $failed = $false
+        try {
+            Start-AnsibleWindowsProcess -FilePath cmd -ArgumentList @('/c') -CommandLine 'echo hi'
+        } catch {
+            $failed = $true
+            $_.Exception.Message -like 'Parameter set cannot be resolved using the specified named parameters*' | Assert-Equals -Expected $true
+        }
+        $failed | Assert-Equals -Expected $true
+    }
+
+    "Start-AnsibleWindowsProcess stderr" = {
+        $pwshPath = (Get-Command powershell.exe -CommandType Application).Source
+        $actual = Start-AnsibleWindowsProcess -FilePath powershell.exe -ArgumentList '[Console]::Error.WriteLine("hi")'
+        $actual.PSTypeNames[0] | Assert-Equals -Expected 'Ansible.Windows.Process.Info'
+        $actual.Command | Assert-Equals -Expected "$pwshPath `"[Console]::Error.WriteLine(\`"hi\`")`""
+        $actual.Stdout | Assert-Equals -Expected ""
+        $actual.Stderr | Assert-Equals -Expected "hi`r`n"
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "Start-AnsibleWindowsProcess exit code" = {
+        $pwshPath = (Get-Command powershell.exe -CommandType Application).Source
+        $actual = Start-AnsibleWindowsProcess -FilePath powershell.exe -ArgumentList 'exit 10'
+        $actual.PSTypeNames[0] | Assert-Equals -Expected 'Ansible.Windows.Process.Info'
+        $actual.Command | Assert-Equals -Expected "$pwshPath `"exit 10`""
+        $actual.Stdout | Assert-Equals -Expected ""
+        $actual.Stderr | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 10
+    }
+
+    "Start-AnsibleWindowsProcess relative path" = {
+        $pwshPath = (Get-Command powershell.exe -CommandType Application).Source
+        $pwshParent = Split-Path $pwshPath -Parent
+        $pwshGrandparent = Split-Path $pwshParent -Parent
+        $pwshGrandparentName = Split-Path $pwshParent -Leaf
+
+        Push-Location -Path $pwshGrandparent
+        $actual = Start-AnsibleWindowsProcess -FilePath "$pwshGrandparentName\powershell" -ArgumentList '$pwd.Path'
+        Pop-Location
+        $actual.PSTypeNames[0] | Assert-Equals -Expected 'Ansible.Windows.Process.Info'
+        $actual.Command | Assert-Equals -Expected "$pwshPath `$pwd.Path"
+        $actual.Stdout | Assert-Equals -Expected "$pwshGrandparent`r`n"
+        $actual.Stderr | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "Start-AnsibleWindowsProcess path in WorkingDir" = {
+        $argvDir = Split-Path $module.Params.print_argv -Parent
+        $argvName = Split-Path $module.Params.print_argv -Leaf
+
+        $actual = Start-AnsibleWindowsProcess -FilePath $argvName -WorkingDirectory $argvDir -ArgumentList 'hi'
+        $actual.ExitCode | Assert-Equals -Expected 0
+        $details = ConvertFrom-Json -InputObject ($actual.Stdout)
+        $details.command_line | Assert-Equals -Expected $actual.Command
+        $details.args | Assert-Equals -Expected @(,'hi')
+    }
+
+    "Start-AnsibleWindowsProcess with missing WorkingDir" = {
+        $output = Start-AnsibleWindowsProcess -FilePath whoami -WorkingDirectory C:\fake -ErrorAction SilentlyContinue -ErrorVariable err
+        Assert-Equals -Actual $output -Expected $null
+        $err[0].Exception.Message | Assert-Equals -Expected "Could not find specified -WorkingDirectory 'C:\fake'"
+    }
+
+    "Start-AnsibleWindowsProcess with unicode output" = {
+        $cmd = "cmd.exe /c echo 💩 café"
+
+        $actual = Start-AnsibleWindowsProcess -CommandLine $cmd
+        $actual.Command | Assert-Equals -Expected $cmd
+        $actual.Stdout | Assert-Equals -Expected "💩 café`r`n"
+        $actual.Stderr | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "Start-AnsibleWindowsProcess without environment" = {
+        $expected = "$($env:USERNAME)`r`n"
+        $cmd = 'powershell.exe $env:TEST; $env:USERNAME'
+        $actual = Start-AnsibleWindowsProcess -CommandLine $cmd
+        $actual.Stdout | Assert-Equals -Expected $expected
+        $actual.Stderr | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "Start-AnsibleWindowsProcess with environment" = {
+        $envVars = @{
+            TEST = "tesTing"
+            TEST2 = "Testing 2"
+        }
+        $cmd = 'cmd.exe /c set'
+        $actual = Start-AnsibleWindowsProcess -CommandLine $cmd -Environment $envVars
+        ("TEST=tesTing" -cin $actual.Stdout.Split("`r`n")) | Assert-Equals -Expected $true
+        ("TEST2=Testing 2" -cin $actual.Stdout.Split("`r`n")) | Assert-Equals -Expected $true
+        ("USERNAME=$($env:USERNAME)" -cnotin $actual.Stdout.Split("`r`n")) | Assert-Equals -Expected $true
+        $actual.Stderr | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "Start-AnsibleWindowsProcess with byte stdin" = {
+        $expected = "input value`r`n"
+        $cmd = 'powershell.exe [System.Console]::In.ReadToEnd()'
+        $actual = Start-AnsibleWindowsProcess -CommandLine $cmd -InputObject ([System.Text.Encoding]::UTF8.GetBytes("input value"))
+        $actual.Stdout | Assert-Equals -Expected $expected
+        $actual.Stderr | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "Start-AnsibleWindowsProcess with byte stdin and newline" = {
+        $expected = "input value`r`n`r`n"
+        $cmd = 'powershell.exe [System.Console]::In.ReadToEnd()'
+        $actual = Start-AnsibleWindowsProcess -CommandLine $cmd -InputObject ([System.Text.Encoding]::UTF8.GetBytes("input value`r`n"))
+        $actual.Stdout | Assert-Equals -Expected $expected
+        $actual.Stderr | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "Start-AnsibleWindowsProcess with string stdin" = {
+        $expected = "input value`r`n"
+        $cmd = 'powershell.exe [System.Console]::In.ReadToEnd()'
+        $actual = Start-AnsibleWindowsProcess -CommandLine $cmd -InputObject "input value"
+        $actual.Stdout | Assert-Equals -Expected $expected
+        $actual.Stderr | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "Start-AnsibleWindowsProcess with string stdin and newline" = {
+        $expected = "input value`r`n`r`n"
+        $cmd = 'powershell.exe [System.Console]::In.ReadToEnd()'
+        $actual = Start-AnsibleWindowsProcess -CommandLine $cmd -InputObject "input value`r`n"
+        $actual.Stdout | Assert-Equals -Expected $expected
+        $actual.Stderr | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "Start-AnsibleWindowsProcess with invalid stdin" = {
+        $out = Start-AnsibleWindowsProcess -CommandLine 'cmd /c echo hi' -InputObject 1 -ErrorAction SilentlyContinue -ErrorVariable err
+        Assert-Equals -Actual $out -Expected $null
+        $err[0].Exception.Message | Assert-Equals -Expected 'InputObject must be a string or byte[]'
+    }
+
+    "Start-AnsibleWindowsProcess with unicode and us-ascii encoding" = {
+        $poop = [System.Char]::ConvertFromUtf32(0xE05A)  # Coverage breaks due to script parsing encoding issues with unicode chars, just use the code point instead
+        $cmd = "cmd.exe /c echo $poop café"
+
+        $actual = Start-AnsibleWindowsProcess -CommandLine $cmd -OutputEncodingOverride 'us-ascii'
+        $actual.Stdout | Assert-Equals -Expected "??? caf??`r`n"
+        $actual.Stderr | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+
+        # With alias
+        $actual = Start-AnsibleWindowsProcess -CommandLine $cmd -OutputEncoding 'us-ascii'
+        $actual.Stdout | Assert-Equals -Expected "??? caf??`r`n"
+        $actual.Stderr | Assert-Equals -Expected ""
+        $actual.ExitCode | Assert-Equals -Expected 0
+    }
+
+    "Start-AnsibleWindowsProcess while waiting for grandchildren" = {
+        $subCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes(@'
+Start-Sleep -Seconds 2
+exit 1
+'@))
+        $cmd = "powershell.exe Start-Process powershell.exe -ArgumentList '-EncodedCommand', '$subCommand'"
+
+        $time = Measure-Command -Expression {
+            $actual = Start-AnsibleWindowsProcess -CommandLine $cmd
+        }
+        $time.TotalSeconds -lt 2 | Assert-Equals -Expected $true
+        $actual.ExitCode | Assert-Equals -Expected 0
+
+        $time = Measure-Command -Expression {
+            $actual = Start-AnsibleWindowsProcess -CommandLine $cmd -WaitChildren
+        }
+        $time.TotalSeconds -ge 2 | Assert-Equals -Expected $true
+        $actual.ExitCode | Assert-Equals -Expected 0  # We still don't expect to get the grandchild rc
+    }
+}
+
+# Add argv <-> argc tests
+$argv_tests = [Ordered]@{
+    # Key = argc - Value = argv
+    # https://docs.microsoft.com/en-us/cpp/c-language/parsing-c-command-line-arguments?view=vs-2019
+    '"a b c" d e' = @('a b c', 'd', 'e')
+    '"ab\"c" \ d' = @('ab"c', '\', 'd')
+    'a\\\b "de fg" h' = @('a\\\b', 'de fg', 'h')
+    '"a\\b c" d e' = @('a\\b c', 'd', 'e')
+    # http://daviddeley.com/autohotkey/parameters/parameters.htm#WINCREATE
+    'CallMeIshmael' = @(,'CallMeIshmael')
+    '"Call Me Ishmael"' = @(,'Call Me Ishmael')
+    '"CallMe\"Ishmael"' = @(,'CallMe"Ishmael')
+    '"Call Me Ishmael\\"' = @(,'Call Me Ishmael\')
+    '"CallMe\\\"Ishmael"' = @(,'CallMe\"Ishmael')
+    'a\\\b' = @(,'a\\\b')
+    '"C:\TEST A\\"' = @(,'C:\TEST A\')
+    '"\"C:\TEST A\\\""' = @(,'"C:\TEST A\"')
+    # Other tests
+    '"C:\Program Files\file\\" "arg with \" quote"' = @('C:\Program Files\file\', 'arg with " quote')
+    '""' = @(,'')
+    '"" "" ""' = @('', $null, '')
+}
+foreach ($kvp in $argv_tests.GetEnumerator()) {
+    $tests."Test argument list to command line - '$($kvp.Key)" = {
+        $argc = $kvp.Key
+        $argv = $kvp.Value
+
+        $escapedActual = @($argv | ConvertTo-EscapedArgument) -join ' '
+        Assert-Equals -Expected $argc -Actual $escapedActual
+
+        $commandActual = Start-AnsibleWindowsProcess -FilePath $module.Params.print_argv -ArgumentList $argv
+        $actualArgs = ($commandActual.Stdout | ConvertFrom-Json)
+
+        # Required to convert any $null args to ""
+        $argv = @($argv | ForEach-Object { [String]$_ })
+        Assert-Equals -Expected $argv -Actual $actualArgs.args
+    }.GetNewClosure()
+
+    $tests."Test argument command line to list - '$($kvp.Key)" = {
+        $argc = $kvp.Key
+        $argv = $kvp.Value
+        $escapedArgv = @($argv | ForEach-Object { [String]$_ })
+
+        $listActual = $argc | ConvertFrom-EscapedArgument
+        Assert-Equals -Expected $escapedArgv -Actual $listActual
+
+        $cmd = '"{0}" {1}' -f $module.Params.print_argv, $argc
+        $commandActual = Start-AnsibleWindowsProcess -FilePath $module.Params.print_argv -CommandLine $cmd
+        $actualArgs = ($commandActual.Stdout | ConvertFrom-Json)
+        Assert-Equals -Expected $escapedArgv -Actual $actualArgs.args
+    }.GetNewClosure()
+}
+
+foreach ($test_impl in $tests.GetEnumerator()) {
+    $test = $test_impl.Key
+    &$test_impl.Value
+}
+
+$module.Result.data = "success"
+$module.ExitJson()

--- a/tests/integration/targets/module_utils_Process/meta/main.yml
+++ b/tests/integration/targets/module_utils_Process/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- setup_win_printargv

--- a/tests/integration/targets/module_utils_Process/tasks/main.yml
+++ b/tests/integration/targets/module_utils_Process/tasks/main.yml
@@ -1,0 +1,21 @@
+- name: run Process.cs tests
+  process_cs_tests:
+  register: process_cs_actual
+
+- assert:
+    that:
+    - process_cs_actual.data == 'success'
+
+- name: run Process.psm1 tests
+  process_pwsh_tests:
+    print_argv: '{{ win_printargv_path }}'
+  register: process_pwsh_actual
+
+- assert:
+    that:
+    - process_pwsh_actual.data == 'success'
+
+- win_copy:
+    src: '{{ win_printargv_path }}'
+    dest: C:\temp\PrintArgvJson.exe
+    remote_src: yes

--- a/tests/integration/targets/module_utils_Process/tasks/main.yml
+++ b/tests/integration/targets/module_utils_Process/tasks/main.yml
@@ -14,8 +14,3 @@
 - assert:
     that:
     - process_pwsh_actual.data == 'success'
-
-- win_copy:
-    src: '{{ win_printargv_path }}'
-    dest: C:\temp\PrintArgvJson.exe
-    remote_src: yes

--- a/tests/integration/targets/setup_win_printargv/files/PrintArgv.cs
+++ b/tests/integration/targets/setup_win_printargv/files/PrintArgv.cs
@@ -1,13 +1,30 @@
 using System;
-// This has been compiled to an exe and uploaded to S3 bucket for argv test
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Web.Script.Serialization;
 
 namespace PrintArgv
 {
     class Program
     {
+        [DllImport("Kernel32.dll")]
+        public static extern IntPtr GetCommandLineW();
+
         static void Main(string[] args)
         {
-            Console.WriteLine(string.Join(System.Environment.NewLine, args));
+            IntPtr cmdLinePtr = GetCommandLineW();
+            string cmdLine = Marshal.PtrToStringUni(cmdLinePtr);
+
+            Dictionary<string, object> cmdInfo = new Dictionary<string, object>()
+            {
+                {"command_line", cmdLine },
+                {"args", args},
+            };
+
+            JavaScriptSerializer jss = new JavaScriptSerializer();
+            jss.MaxJsonLength = int.MaxValue;
+            jss.RecursionLimit = int.MaxValue;
+            Console.WriteLine(jss.Serialize(cmdInfo));
         }
     }
 }

--- a/tests/integration/targets/setup_win_printargv/tasks/main.yml
+++ b/tests/integration/targets/setup_win_printargv/tasks/main.yml
@@ -1,7 +1,18 @@
-- name: download the PrintArgv.exe binary to temp location
-  win_get_url:
-    url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/setup_win_printargv/PrintArgv.exe
-    dest: '{{ remote_tmp_dir }}\PrintArgv.exe'
+- name: copy PrintArgv.cs to remote host
+  win_copy:
+    src: PrintArgv.cs
+    dest: '{{ remote_tmp_dir }}\PrintArgv.cs'
+
+- name: compile PrintArgv.cs
+  win_shell: |
+    $ErrorActionPreference = 'Stop'
+    $addParams = @{
+        TypeDefinition = (Get-Content -LiteralPath '{{ remote_tmp_dir }}\PrintArgv.cs' -Raw)
+        OutputType = 'ConsoleApplication'
+        OutputAssembly = '{{ remote_tmp_dir }}\PrintArgv.exe'
+        ReferencedAssemblies = @('System.Web.Extensions.dll')
+    }
+    Add-Type @addParams
 
 - name: set fact containing PrintArgv binary path
   set_fact:

--- a/tests/integration/targets/win_command/tasks/main.yml
+++ b/tests/integration/targets/win_command/tasks/main.yml
@@ -168,15 +168,18 @@
   win_command: '"{{ win_printargv_path }}" arg1 "arg 2" C:\path\arg "\"quoted arg\""'
   register: cmdout
 
+- set_fact:
+    cmdout_argv: '{{ cmdout.stdout | trim | from_json }}'
+
 - name: assert call to argv binary with absolute path
   assert:
     that:
     - cmdout is changed
     - cmdout.rc == 0
-    - cmdout.stdout_lines[0] == 'arg1'
-    - cmdout.stdout_lines[1] == 'arg 2'
-    - cmdout.stdout_lines[2] == 'C:\\path\\arg'
-    - cmdout.stdout_lines[3] == '"quoted arg"'
+    - cmdout_argv.args[0] == 'arg1'
+    - cmdout_argv.args[1] == 'arg 2'
+    - cmdout_argv.args[2] == 'C:\\path\\arg'
+    - cmdout_argv.args[3] == '"quoted arg"'
 
 - name: call argv binary with relative path
   win_command: '{{ win_printargv_path | win_basename }} C:\path\end\slash\ ADDLOCAL="msi,example" two\\slashes'
@@ -184,14 +187,17 @@
     chdir: '{{ win_printargv_path | win_dirname }}'
   register: cmdout
 
+- set_fact:
+    cmdout_argv: '{{ cmdout.stdout | trim | from_json }}'
+
 - name: assert call to argv binary with relative path
   assert:
     that:
     - cmdout is changed
     - cmdout.rc == 0
-    - cmdout.stdout_lines[0] == 'C:\\path\\end\\slash\\'
-    - cmdout.stdout_lines[1] == 'ADDLOCAL=msi,example'
-    - cmdout.stdout_lines[2] == 'two\\\\slashes'
+    - cmdout_argv.args[0] == 'C:\\path\\end\\slash\\'
+    - cmdout_argv.args[1] == 'ADDLOCAL=msi,example'
+    - cmdout_argv.args[2] == 'two\\\\slashes'
 
 - name: download binary that output shift_jis chars to console
   win_get_url:


### PR DESCRIPTION
##### SUMMARY
Adds a slightly modified version of `Ansible.Process` and `Ansible.ModuleUtils.CommandUtil` to the collection. This util should be the one used for any new work going forward as it can include new features without waiting on ansible-base to be updated.

Adds the option `wait_for_children` to `win_package` that can be used to make sure any child processes spawned by the installer are finished before `win_package` returns. This is an opt-in behaviour as it could cause hangs in existing installers if they spawn any child processes that never exit.

Fixes https://github.com/ansible-collections/ansible.windows/issues/116

Need to add some tests for the new module_utils.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_package