### PR TITLE
win_acl.ps1 modified to have reset func., check_mode, environment string support, and right handling corrected

### DIFF
--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -54,9 +54,9 @@ Function SetPrivilegeTokens() {
     # Set privilege tokens only if admin.
     # Admins would have these privs or be able to set these privs in the UI Anyway
 
-    $adminRole=[System.Security.Principal.WindowsBuiltInRole]::Administrator
-    $myWindowsID=[System.Security.Principal.WindowsIdentity]::GetCurrent()
-    $myWindowsPrincipal=new-object System.Security.Principal.WindowsPrincipal($myWindowsID)
+    $adminRole = [System.Security.Principal.WindowsBuiltInRole]::Administrator
+    $myWindowsID = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+    $myWindowsPrincipal = new-object System.Security.Principal.WindowsPrincipal($myWindowsID)
 
 
     if ($myWindowsPrincipal.IsInRole($adminRole)) {

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -132,18 +132,6 @@ Function HandleReset() {
    Exit-Json -obj $result
 }
 
-Function MountReg() {
-   if ($path_qualifier -eq "HKCR:" -and (-not (Test-Path -LiteralPath HKCR:\))) {
-       New-PSDrive -Name HKCR -PSProvider Registry -Root HKEY_CLASSES_ROOT > $null
-   }
-   if ($path_qualifier -eq "HKU:" -and (-not (Test-Path -LiteralPath HKU:\))) {
-       New-PSDrive -Name HKU -PSProvider Registry -Root HKEY_USERS > $null
-   }
-   if ($path_qualifier -eq "HKCC:" -and (-not (Test-Path -LiteralPath HKCC:\))) {
-       New-PSDrive -Name HKCC -PSProvider Registry -Root HKEY_CURRENT_CONFIG > $null
-   }
-}
-
 $params = Parse-Args $args
 
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -default $false
@@ -153,7 +141,15 @@ $path = (New-Object -ComObject Wscript.Shell).ExpandEnvironmentStrings($path)
 # We mount the HKCR, HKU, and HKCC registry hives so PS can access them.
 # Network paths have no qualifiers so we use -EA SilentlyContinue to ignore that
 $path_qualifier = Split-Path -Path $path -Qualifier -ErrorAction SilentlyContinue
-MountReg
+if ($path_qualifier -eq "HKCR:" -and (-not (Test-Path -LiteralPath HKCR:\))) {
+    New-PSDrive -Name HKCR -PSProvider Registry -Root HKEY_CLASSES_ROOT > $null
+}
+if ($path_qualifier -eq "HKU:" -and (-not (Test-Path -LiteralPath HKU:\))) {
+    New-PSDrive -Name HKU -PSProvider Registry -Root HKEY_USERS > $null
+}
+if ($path_qualifier -eq "HKCC:" -and (-not (Test-Path -LiteralPath HKCC:\))) {
+    New-PSDrive -Name HKCC -PSProvider Registry -Root HKEY_CURRENT_CONFIG > $null
+}
 If (-Not (Test-Path -LiteralPath $path)) {
     Fail-Json -obj $result -message "$path does not exist on the host"
 }

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -118,7 +118,7 @@ Function HandleReset() {
                 (Get-Item -LiteralPath $path).SetAccessControl($objACL)
             }
          }
-   } 
+   }
    catch {
        if ($null -ne $path_qualifier) {
            Pop-Location

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -90,7 +90,8 @@ $result = @{
 
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -default $false
 # Get the path parameter with expanded environment variables.
-$path = (New-Object -ComObject Wscript.Shell).ExpandEnvironmentStrings(Get-AnsibleParam -obj $params -name "path" -type "str" -failifempty $true)
+$path=Get-AnsibleParam -obj $params -name "path" -type "str" -failifempty $true
+$path = (New-Object -ComObject Wscript.Shell).ExpandEnvironmentStrings($path)
 # We mount the HKCR, HKU, and HKCC registry hives so PS can access them.
 # Network paths have no qualifiers so we use -EA SilentlyContinue to ignore that
 $path_qualifier = Split-Path -Path $path -Qualifier -ErrorAction SilentlyContinue

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -132,7 +132,7 @@ Function HandleReset() {
    Exit-Json -obj $result
 }
 
-$params = Parse-Args $args
+$params = Parse-Args $args -supports_check_mode $true
 
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -default $false
 # Get the path parameter with expanded environment variables.
@@ -238,8 +238,6 @@ Try {
               } else {
                   (Get-Item -LiteralPath $path).SetAccessControl($objACL)
               }
-		   } else {
-                  Set-ACL -LiteralPath $path -AclObject $objACL -WhatIf $true
 		   }
            $result.changed = $true
 		   $myMessage=$myMessage.Replace('Actual rights: ','New rights: ')

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -244,7 +244,7 @@ Try {
 		   $result.msg=$myMessage
 		}
 		# result Failed if SID still has any of the rights to be removed.
-		if(($ar) -and (([int]($ar -band $objRights).value__) -ne 0 ) -and ($state -ne "present")){
+		if(((([int]$ar) -band ([int]$objRights)) -ne 0 ) -and ($state -ne "present")){
 		   $result.stderr="$user still has $ar rights!"
 		   $result.msg=$myMessage
            if ($null -ne $path_qualifier) {

--- a/plugins/modules/win_acl.py
+++ b/plugins/modules/win_acl.py
@@ -24,9 +24,9 @@ options:
   user:
     description:
     - User or Group to add specified rights to act on src file/folder or
-      registry key.
+      registry key. Only required when state is not 'reset'
     type: str
-    required: Only when state is not 'reset'
+    required: true
   state:
     description:
     - Specify whether to add C(present) or remove C(absent) the specified access rule.
@@ -36,20 +36,20 @@ options:
     default: present
   type:
     description:
-    - Specify whether to allow or deny the rights specified.
+    - Specify whether to allow or deny the rights specified. Only required when state is not 'reset'
     type: str
-    required: Only when state is not 'reset'
+    required: true
     choices: [ allow, deny ]
   rights:
     description:
     - The rights/permissions that are to be allowed/denied for the specified
-      user or group for the item at C(path).
+      user or group for the item at C(path). Only required when state is not 'reset'
     - If C(path) is a file or directory, rights can be any right under MSDN
       FileSystemRights U(https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.filesystemrights.aspx).
     - If C(path) is a registry key, rights can be any right under MSDN
       RegistryRights U(https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.registryrights.aspx).
     type: str
-    required: Only when state is not 'reset'
+    required: true
   inherit:
     description:
     - Inherit flags on the ACL rules.
@@ -70,13 +70,11 @@ options:
     default: "None"
 notes:
 - If adding ACL's for AppPool identities, the Windows Feature "Web-Scripting-Tools" must be enabled.
-- In Windows there are simple, and complex rights, for example the "FullControl" right is a complex one, 
-  containing all simple rights like ReadData, CreateFile and so on. Removing complex rights (state=absent) 
-  means removing every element of the complex right: 
-    rights: FullControl
-    type: allow
-    state: absent
-  will result no right for the user on the defined object at all. 
+- In Windows there are simple, and complex rights, for example the "FullControl" right is a complex one,
+  containing all simple rights like ReadData, CreateFile and so on. Removing complex rights (state=absent)
+  means removing every element of the complex right.
+  By specifying rights= FullControl, type= allow and state= absent
+  will result no right for the user on the defined object at all.
   (Removing all element of the complex FullControl right.)
 seealso:
 - module: ansible.windows.win_acl_inheritance

--- a/tests/integration/targets/win_acl/tasks/tests.yml
+++ b/tests/integration/targets/win_acl/tasks/tests.yml
@@ -381,32 +381,32 @@
     that:
     - not remove_deny_right_again is changed
 
-- name: remove ReadAndExecute rights from Users (should fail because of inherited rights)
+- name: remove read rights from Users (should fail because of inherited rights)
   win_acl:
     path: '{{ test_acl_path }}'
     type: allow
     user: Users
-    rights: ReadAndExecute
+    rights: Read
     state: absent
   ignore_errors: yes
   register: remove_read_right_users
 
-- name: assert remove ReadAndExecute rights from Users (should fail)
+- name: assert remove read rights from Users (should fail)
   assert:
     that:
     - remove_read_right_users is failed
 
-- name: remove ReadAndExecute rights from users - network (should fail because of inherited rights)
+- name: remove read rights from users - network (should fail because of inherited rights)
   win_acl:
     path: '{{ test_acl_network_path }}'
     type: allow
     user: Users
-    rights: ReadAndExecute
+    rights: Read
     state: absent
   ignore_errors: yes
   register: remove_read_right_users_network
 
-- name: assert remove ReadAndExecute rights from Users - network (should fail)
+- name: assert remove read rights from Users - network (should fail)
   assert:
     that:
     - remove_read_right_users_network is failed

--- a/tests/integration/targets/win_acl/tasks/tests.yml
+++ b/tests/integration/targets/win_acl/tasks/tests.yml
@@ -381,32 +381,32 @@
     that:
     - not remove_deny_right_again is changed
 
-- name: remove read rights from Users (should fail because of inherited rights)
+- name: remove ReadAndExecute rights from Users (should fail because of inherited rights)
   win_acl:
     path: '{{ test_acl_path }}'
     type: allow
     user: Users
-    rights: Read
+    rights: ReadAndExecute
     state: absent
   ignore_errors: yes
   register: remove_read_right_users
 
-- name: assert remove read rights from Users (should fail)
+- name: assert remove ReadAndExecute rights from Users (should fail)
   assert:
     that:
     - remove_read_right_users is failed
 
-- name: remove read rights from users - network (should fail because of inherited rights)
+- name: remove ReadAndExecute rights from users - network (should fail because of inherited rights)
   win_acl:
     path: '{{ test_acl_network_path }}'
     type: allow
     user: Users
-    rights: Read
+    rights: ReadAndExecute
     state: absent
   ignore_errors: yes
   register: remove_read_right_users_network
 
-- name: assert remove read rights from Users - network (should fail)
+- name: assert remove ReadAndExecute rights from Users - network (should fail)
   assert:
     that:
     - remove_read_right_users_network is failed

--- a/tests/integration/targets/win_acl/tasks/tests.yml
+++ b/tests/integration/targets/win_acl/tasks/tests.yml
@@ -5,6 +5,7 @@
     test_ace_cmd: |
       # Overcome bug in Set-Acl/Get-Acl for registry paths and -LiteralPath
       New-PSDrive -Name HKU -PSProvider Registry -Root HKEY_USERS > $null
+      $path = (New-Object -ComObject Wscript.Shell).ExpandEnvironmentStrings($path)
       Push-Location -LiteralPath (Split-Path -Path $path -Qualifier)
       $rights_key = if ((Get-Item -LiteralPath $path -Force).PSProvider.Name -eq "Registry") {
           "RegistryRights"
@@ -22,6 +23,55 @@
       }
       Pop-Location
       ConvertTo-Json -InputObject @($ace_list)
+    test_all_ace_cmd: |
+      # Overcome bug in Set-Acl/Get-Acl for registry paths and -LiteralPath
+      New-PSDrive -Name HKU -PSProvider Registry -Root HKEY_USERS > $null
+      $path = (New-Object -ComObject Wscript.Shell).ExpandEnvironmentStrings($path)
+      Push-Location -LiteralPath (Split-Path -Path $path -Qualifier)
+      $rights_key = if ((Get-Item -LiteralPath $path -Force).PSProvider.Name -eq "Registry") {
+          "RegistryRights"
+      } else {
+          "FileSystemRights"
+      }
+      $ace_list = (Get-Acl -LiteralPath $path).Access | ForEach-Object {
+          @{
+              rights = $_."$rights_key".ToString()
+              type = $_.AccessControlType.ToString()
+              identity = $_.IdentityReference.Value.ToString()
+              inherited = if($_.IsInherited){"yes"}else{"no"}
+              inheritance_flags = $_.InheritanceFlags.ToString()
+              propagation_flags = $_.PropagationFlags.ToString()
+          }
+      }
+      Pop-Location
+      ConvertTo-Json -InputObject @($ace_list)
+    break_reg_inh_cmd: |
+      # Overcome bug in Set-Acl/Get-Acl for registry paths and -LiteralPath
+      New-PSDrive -Name HKU -PSProvider Registry -Root HKEY_USERS > $null
+      $path = (New-Object -ComObject Wscript.Shell).ExpandEnvironmentStrings($path)
+      Push-Location -LiteralPath (Split-Path -Path $path -Qualifier)
+      $acl = Get-Acl -LiteralPath $path
+      $acl.SetAccessRuleProtection($true,$false)
+      Set-ACL -LiteralPath $path -AclObject $acl
+
+- name: add write rights to Guest check_mode
+  win_acl:
+    path: '{{ test_acl_path }}'
+    type: allow
+    user: Guests
+    rights: Write
+  check_mode: yes
+  register: allow_right_check
+
+- name: get result of add write rights to Guest
+  win_shell: '$path = ''{{ test_acl_path }}''; {{ test_ace_cmd }}'
+  register: allow_right_actual_check
+
+- name: assert add write rights to Guest check_mode (reported as changed but no explicite rights)
+  assert:
+    that:
+    - allow_right_check is changed
+    - allow_right_actual_check.stdout_lines == ["[", "", "]"]
 
 - name: add write rights to Guest
   win_acl:
@@ -58,6 +108,166 @@
   assert:
     that:
     - not allow_right_again is changed
+
+- name: reset rights check_mode (remove added write rights to Guest)
+  win_acl:
+    path: '{{ test_acl_path }}'
+    state: reset
+  check_mode: yes
+  register: reset_right_check
+
+- name: get result of reset check_mode
+  win_shell: '$path = ''{{ test_acl_path }}''; {{ test_ace_cmd }}'
+  register: reset_right_actual_check
+
+- name: assert reset rights check_mode (reported as changed but write rights to Guest still present)
+  assert:
+    that:
+    - reset_right_check is changed
+    - (reset_right_actual_check.stdout|from_json)|count == 1
+    - (reset_right_actual_check.stdout|from_json)[0].identity == 'BUILTIN\Guests'
+    - (reset_right_actual_check.stdout|from_json)[0].inheritance_flags == 'ContainerInherit, ObjectInherit'
+    - (reset_right_actual_check.stdout|from_json)[0].propagation_flags == 'None'
+    - (reset_right_actual_check.stdout|from_json)[0].rights == 'Write, Synchronize'
+    - (reset_right_actual_check.stdout|from_json)[0].type == 'Allow'
+
+- name: reset rights (remove added write rights to Guest)
+  win_acl:
+    path: '{{ test_acl_path }}'
+    state: reset
+  register: reset_right
+
+- name: get result of reset rights
+  win_shell: '$path = ''{{ test_acl_path }}''; {{ test_ace_cmd }}'
+  register: reset_right_actual
+
+- name: assert reset rights (No explicite rights)
+  assert:
+    that:
+    - reset_right is changed
+    - reset_right_actual.stdout_lines == ["[", "", "]"]
+
+- name: reset rights (idempotent)
+  win_acl:
+    path: '{{ test_acl_path }}'
+    state: reset
+  register: reset_right_idempotent
+
+- name: assert reset rights (idempotent)
+  assert:
+    that:
+    - not reset_right_idempotent is changed
+
+- name: add full rights to Everyone
+  win_acl:
+    path: '{{ test_acl_path }}'
+    type: allow
+    user: Everyone
+    rights: FullControl
+
+- name: Remove inheritance
+  win_acl_inheritance:
+    path: '{{ test_acl_path }}'
+    state: absent
+    reorganize: no
+
+- name: reset rights
+  win_acl:
+    path: '{{ test_acl_path }}'
+    state: reset
+  register: reset_right_1
+
+- name: get explicite result of reset rights
+  win_shell: '$path = ''{{ test_acl_path }}''; {{ test_ace_cmd }}'
+  register: reset_right_actual_1
+
+- name: assert reset rights (no explicite rights present)
+  assert:
+    that:
+    - reset_right_1 is changed
+    - reset_right_actual_1.stdout_lines == ["[", "", "]"]
+
+- name: get all result of reset rights
+  win_shell: '$path = ''{{ test_acl_path }}''; {{ test_all_ace_cmd }}'
+  register: reset_right_actual_all
+
+- name: assert reset rights (inherited rights present)
+  assert:
+    that:
+    - reset_right_1 is changed
+    - (reset_right_actual_all.stdout|from_json)|count >= 1
+    - (reset_right_actual_all.stdout|from_json)[0].inherited == 'yes'
+
+- name: add write rights back to Guest
+  win_acl:
+    path: '{{ test_acl_path }}'
+    type: allow
+    user: Guests
+    rights: Write
+
+- name: add read&exec rights to Guest
+  win_acl:
+    path: '{{ test_acl_path }}'
+    type: allow
+    user: Guests
+    rights: ReadAndExecute
+  register: allow_read_right
+
+- name: add delete rights to Guest
+  win_acl:
+    path: '{{ test_acl_path }}'
+    type: allow
+    user: Guests
+    rights: Delete
+  register: allow_read_right
+
+- name: get result of add read rights to Guest
+  win_shell: '$path = ''{{ test_acl_path }}''; {{ test_ace_cmd }}'
+  register: allow_read_right_actual
+
+- name: assert add write+read&exec+delete rights to Guest as Modify
+  assert:
+    that:
+    - allow_read_right is changed
+    - (allow_read_right_actual.stdout|from_json)|count == 1
+    - (allow_read_right_actual.stdout|from_json)[0].identity == 'BUILTIN\Guests'
+    - (allow_read_right_actual.stdout|from_json)[0].inheritance_flags == 'ContainerInherit, ObjectInherit'
+    - (allow_read_right_actual.stdout|from_json)[0].propagation_flags == 'None'
+    - (allow_read_right_actual.stdout|from_json)[0].rights == 'Modify, Synchronize'
+    - (allow_read_right_actual.stdout|from_json)[0].type == 'Allow'
+
+- name: remove read&exec rights for Guest
+  win_acl:
+    path: '{{ test_acl_path }}'
+    type: allow
+    user: Guests
+    rights: ReadAndExecute
+    state: absent
+  register: remove_read_right
+
+- name: remove delete rights for Guest
+  win_acl:
+    path: '{{ test_acl_path }}'
+    type: allow
+    user: Guests
+    rights: Delete
+    state: absent
+  register: allow_read_right
+
+- name: get result of remove read rights to Guest
+  win_shell: '$path = ''{{ test_acl_path }}''; {{ test_ace_cmd }}'
+  register: remove_read_right_actual
+
+- name: assert remove read&exec+delete from Modify rights to Guest should be Write
+  assert:
+    that:
+    - remove_read_right is changed
+    - (remove_read_right_actual.stdout|from_json)|count == 1
+    - (remove_read_right_actual.stdout|from_json)[0].identity == 'BUILTIN\Guests'
+    - (remove_read_right_actual.stdout|from_json)[0].inheritance_flags == 'ContainerInherit, ObjectInherit'
+    - (remove_read_right_actual.stdout|from_json)[0].propagation_flags == 'None'
+    - (remove_read_right_actual.stdout|from_json)[0].rights == 'Write, Synchronize'
+    - (remove_read_right_actual.stdout|from_json)[0].type == 'Allow'
 
 - name: remove write rights from Guest
   win_acl:
@@ -171,6 +381,36 @@
     that:
     - not remove_deny_right_again is changed
 
+- name: remove read rights from Users (should fail because of inherited rights)
+  win_acl:
+    path: '{{ test_acl_path }}'
+    type: allow
+    user: Users
+    rights: Read
+    state: absent
+  ignore_errors: yes
+  register: remove_read_right_users
+
+- name: assert remove read rights from Users (should fail)
+  assert:
+    that:
+    - remove_read_right_users is failed
+
+- name: remove read rights from users - network (should fail because of inherited rights)
+  win_acl:
+    path: '{{ test_acl_network_path }}'
+    type: allow
+    user: Users
+    rights: Read
+    state: absent
+  ignore_errors: yes
+  register: remove_read_right_users_network
+
+- name: assert remove read rights from Users - network (should fail)
+  assert:
+    that:
+    - remove_read_right_users_network is failed
+
 - name: add write rights to Guest - network
   win_acl:
     path: '{{ test_acl_network_path }}'
@@ -212,6 +452,21 @@
     that:
     - remove_right is changed
     - remove_right_actual.stdout_lines == ["[", "", "]"]
+
+- name: remove read rights from users - registry (should fail because of inherited rights)
+  win_acl:
+    path: '{{ test_acl_reg_path }}'
+    type: allow
+    user: Users
+    rights: ReadKey
+    state: absent
+  ignore_errors: yes
+  register: remove_read_right_users_reg
+
+- name: assert remove read rights from Users - registry (should fail)
+  assert:
+    that:
+    - remove_read_right_users_reg is failed
 
 - name: add write rights to Guest - registry
   win_acl:
@@ -360,3 +615,72 @@
   assert:
     that:
     - not remove_deny_right_reg_again is changed
+
+- name: add fullcontrol rights to everyone - registry
+  win_acl:
+    path: '{{ test_acl_reg_path }}'
+    type: allow
+    user: Everyone
+    rights: fullcontrol
+    state: present
+
+- name: break inheritance - registry
+  win_shell: '$path = ''{{ test_acl_reg_path }}''; {{ break_reg_inh_cmd }}'
+
+- name: reset registry check_mode
+  win_acl:
+    path: '{{ test_acl_reg_path }}'
+    state: reset
+  check_mode: yes
+  register: reset_reg_check
+
+- name: get result of reset - registry check_mode
+  win_shell: '$path = ''{{ test_acl_reg_path }}''; {{ test_ace_cmd }}'
+  register: reset_reg_actual_check
+
+- name: assert reset - registry (still explicite rights for everyone fullcontrol)
+  assert:
+    that:
+    - reset_reg_check is changed
+    - (reset_reg_actual_check.stdout|from_json)|count == 1
+    - (reset_reg_actual_check.stdout|from_json)[0].identity == 'Everyone'
+    - (reset_reg_actual_check.stdout|from_json)[0].rights == 'FullControl'
+    - (reset_reg_actual_check.stdout|from_json)[0].type == 'Allow'
+
+- name: reset registry
+  win_acl:
+    path: '{{ test_acl_reg_path }}'
+    state: reset
+  register: reset_reg
+
+- name: get result of reset - registry
+  win_shell: '$path = ''{{ test_acl_reg_path }}''; {{ test_ace_cmd }}'
+  register: reset_reg_actual
+
+- name: assert reset - registry (no explicite rights)
+  assert:
+    that:
+    - reset_reg is changed
+    - reset_reg_actual.stdout_lines == ["[", "", "]"]
+
+- name: get all result of reset rights - registry
+  win_shell: '$path = ''{{ test_acl_reg_path }}''; {{ test_all_ace_cmd }}'
+  register: reset_right_registry_all
+
+- name: assert reset rights - registry (inherited rights present)
+  assert:
+    that:
+    - reset_reg is changed
+    - (reset_right_registry_all.stdout|from_json)|count >= 1
+    - (reset_right_registry_all.stdout|from_json)[0].inherited == 'yes'
+
+- name: reset registry (idempotent)
+  win_acl:
+    path: '{{ test_acl_reg_path }}'
+    state: reset
+  register: reset_reg_idemp
+
+- name: assert reset - registry (idempotent)
+  assert:
+    that:
+    - not reset_reg_idemp is changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I've corrected the removing of rights, with post check for any remaining ACE and reporting if unsuccessful.
Added the requested reset functionality,
Added the requested support for environment variable in path,
Added check_mode support.
Also updated the doc win_acl.py
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Executed some test with below playbook:
````
---
- hosts: win-test1.adtest.celab.ibm.cloud
  gather_facts: no
  tasks:
    - name: Query ACL
      win_shell: (get-acl c:\TestFldr\SubFldr).AccessToString
      register: GetACL
    - debug:
        var: GetACL.stdout_lines
    - name: Query ChildACL
      win_shell: (get-acl c:\TestFldr\SubFldr\ChildFldr).AccessToString
      register: GetChildACL
    - debug:
        var: GetChildACL.stdout_lines
    - name: Remove standard user access
      win_acl:
        path: "%SystemDrive%\\TestFldr\\SubFldr"
        user: Users
        rights: ReadAndExecute
        type: allow
        state: absent
      register: SetACL
      ignore_errors: yes
    - debug:
        var: SetACL
    - name: Query ACL1
      win_shell: (get-acl c:\TestFldr\SubFldr).AccessToString
      register: GetACL1
    - debug:
        var: GetACL1.stdout_lines
    - name: add Read and Execute rights to Built-in Users
      win_acl:
        path: c:\TestFldr\SubFldr
        user: Users
        rights: ReadAndExecute
        type: allow
        state: present
    - name: Query ACL2
      win_shell: (get-acl c:\TestFldr\SubFldr).AccessToString
      register: GetACL2
    - debug:
        var: GetACL2.stdout_lines
    - name: add Write rights to Built-in Users group
      win_acl:
        path: c:\TestFldr\SubFldr
        user: Users
        rights: Write
        type: allow
        state: present
    - name: Query ACL31
      win_shell: (get-acl c:\TestFldr\SubFldr).AccessToString
      register: GetACL31
    - debug:
        var: GetACL31.stdout_lines
    - name: Query ChildACL31
      win_shell: (get-acl c:\TestFldr\SubFldr\ChildFldr).AccessToString
      register: GetChildACL31
    - debug:
        var: GetChildACL31.stdout_lines
    - name: revoke the previously added Write rights from Built-in Users group
      win_acl:
        path: c:\TestFldr\SubFldr
        user: Users
        rights: Write
        type: allow
        state: absent
      ignore_errors: yes
    - name: Query ACL32
      win_shell: (get-acl c:\TestFldr\SubFldr).AccessToString
      register: GetACL32
    - debug:
        var: GetACL32.stdout_lines
    - name: add Read and Execute rights to TestUser
      win_acl:
        path: c:\TestFldr\SubFldr
        user: TestUser
        rights: ReadAndExecute
        type: allow
        state: present
    - name: Query ACL4
      win_shell: (get-acl c:\TestFldr\SubFldr).AccessToString
      register: GetACL4
    - debug:
        var: GetACL4.stdout_lines
    - name: Query ChildACL4
      win_shell: (get-acl c:\TestFldr\SubFldr\ChildFldr).AccessToString
      register: GetChildACL4
    - debug:
        var: GetChildACL4.stdout_lines
    - name: add Modify rights to TestUser
      win_acl:
        path: c:\TestFldr\SubFldr
        user: TestUser
        rights: Modify
        type: allow
        state: present
    - name: Query ACL41
      win_shell: (get-acl c:\TestFldr\SubFldr).AccessToString
      register: GetACL41
    - debug:
        var: GetACL41.stdout_lines
    - name: Query ChildACL41
      win_shell: (get-acl c:\TestFldr\SubFldr\ChildFldr).AccessToString
      register: GetChildACL41
    - debug:
        var: GetChildACL41.stdout_lines
    - name: revoke Modify rights from TestUser
      win_acl:
        path: c:\TestFldr\SubFldr
        user: TestUser
        rights: Modify
        type: allow
        state: absent
    - name: Query ACL42
      win_shell: (get-acl c:\TestFldr\SubFldr).AccessToString
      register: GetACL42
    - debug:
        var: GetACL42.stdout_lines
    - name: restore the expected state
      win_acl:
        path: c:\TestFldr\SubFldr
        user: TestUser
        rights: ReadAndExecute
        type: allow
        state: present
    - name: Query ACL43
      win_shell: (get-acl c:\TestFldr\SubFldr).AccessToString
      register: GetACL43
    - debug:
        var: GetACL43.stdout_lines
    - name: add Write rights to TestUser
      win_acl:
        path: c:\TestFldr\SubFldr
        user: TestUser
        rights: Write
        type: allow
        state: present
    - name: Query ACL44
      win_shell: (get-acl c:\TestFldr\SubFldr).AccessToString
      register: GetACL44
    - debug:
        var: GetACL44.stdout_lines
    - name: revoke Write rights from TestUser
      win_acl:
        path: c:\TestFldr\SubFldr
        user: TestUser
        rights: Write
        type: allow
        state: absent
    - name: Query ACL45
      win_shell: (get-acl c:\TestFldr\SubFldr).AccessToString
      register: GetACL45
    - debug:
        var: GetACL45.stdout_lines
    - name: Reset ACL
      win_acl:
        path: c:\TestFldr\SubFldr
        state: reset
      register: ReSetACL
      ignore_errors: yes
    - debug:
        var: ReSetACL
    - name: Query ACL5
      win_shell: (get-acl c:\TestFldr\SubFldr).AccessToString
      register: GetACL5
    - debug:
        var: GetACL5.stdout_lines
    - name: Reset ACL on root (M:\)
      win_acl:
        path: m:\
        state: reset
      register: ReSetACL
      ignore_errors: yes
    - debug:
        var: ReSetACL
    - name: Query ACL6
      win_shell: (get-acl c:\TestFldr\SubFldr).AccessToString
      register: GetACL6
    - debug:
        var: GetACL6.stdout_lines

````
<!--- Paste verbatim command output below, e.g. before and after your change -->
The result:
```paste below

PLAY [win-test1.adtest.celab.ibm.cloud] ****************************************

TASK [Query ACL] ***************************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "GetACL.stdout_lines": [
        "NT AUTHORITY\\SYSTEM Allow  FullControl",
        "BUILTIN\\Administrators Allow  FullControl",
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "BUILTIN\\Users Allow  AppendData",
        "BUILTIN\\Users Allow  CreateFiles",
        "CREATOR OWNER Allow  268435456"
    ]
}

TASK [Query ChildACL] **********************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "GetChildACL.stdout_lines": [
        "NT AUTHORITY\\SYSTEM Allow  FullControl",
        "BUILTIN\\Administrators Allow  FullControl",
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "BUILTIN\\Users Allow  AppendData",
        "BUILTIN\\Users Allow  CreateFiles",
        "CREATOR OWNER Allow  268435456"
    ]
}

TASK [Remove standard user access] *********************************************
fatal: [win-test1.adtest.celab.ibm.cloud]: FAILED! => {"changed": false, "msg": "Users still has CreateFiles, AppendData, ReadAndExecute, Synchronize rights! Actual rights: Allow: ReadAndExecute, Synchronize: Inherited, ContainerInherit, ObjectInherit; Allow: AppendData: Inherited, ContainerInherit; Allow: CreateFiles: Inherited, ContainerInherit; ", "stderr": "Users still has CreateFiles, AppendData, ReadAndExecute, Synchronize rights!", "stderr_lines": ["Users still has CreateFiles, AppendData, ReadAndExecute, Synchronize rights!"]}
...ignoring

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "SetACL": {
        "changed": false,
        "failed": true,
        "msg": "Users still has CreateFiles, AppendData, ReadAndExecute, Synchronize rights! Actual rights: Allow: ReadAndExecute, Synchronize: Inherited, ContainerInherit, ObjectInherit; Allow: AppendData: Inherited, ContainerInherit; Allow: CreateFiles: Inherited, ContainerInherit; ",
        "stderr": "Users still has CreateFiles, AppendData, ReadAndExecute, Synchronize rights!",
        "stderr_lines": [
            "Users still has CreateFiles, AppendData, ReadAndExecute, Synchronize rights!"
        ]
    }
}

TASK [Query ACL1] **************************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "GetACL1.stdout_lines": [
        "NT AUTHORITY\\SYSTEM Allow  FullControl",
        "BUILTIN\\Administrators Allow  FullControl",
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "BUILTIN\\Users Allow  AppendData",
        "BUILTIN\\Users Allow  CreateFiles",
        "CREATOR OWNER Allow  268435456"
    ]
}

TASK [add Read and Execute rights to Built-in Users] ***************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [Query ACL2] **************************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "GetACL2.stdout_lines": [
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "NT AUTHORITY\\SYSTEM Allow  FullControl",
        "BUILTIN\\Administrators Allow  FullControl",
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "BUILTIN\\Users Allow  AppendData",
        "BUILTIN\\Users Allow  CreateFiles",
        "CREATOR OWNER Allow  268435456"
    ]
}

TASK [add Write rights to Built-in Users group] ********************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [Query ACL31] *************************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "GetACL31.stdout_lines": [
        "BUILTIN\\Users Allow  Write, ReadAndExecute, Synchronize",
        "NT AUTHORITY\\SYSTEM Allow  FullControl",
        "BUILTIN\\Administrators Allow  FullControl",
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "BUILTIN\\Users Allow  AppendData",
        "BUILTIN\\Users Allow  CreateFiles",
        "CREATOR OWNER Allow  268435456"
    ]
}

TASK [Query ChildACL31] ********************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "GetChildACL31.stdout_lines": [
        "BUILTIN\\Users Allow  Write, ReadAndExecute, Synchronize",
        "NT AUTHORITY\\SYSTEM Allow  FullControl",
        "BUILTIN\\Administrators Allow  FullControl",
        "CREATOR OWNER Allow  268435456"
    ]
}

TASK [revoke the previously added Write rights from Built-in Users group] ******
fatal: [win-test1.adtest.celab.ibm.cloud]: FAILED! => {"changed": true, "msg": "Users still has CreateFiles, AppendData, ReadAndExecute, Synchronize rights! New rights: Allow: ReadAndExecute, Synchronize:  ContainerInherit, ObjectInherit; Allow: ReadAndExecute, Synchronize: Inherited, ContainerInherit, ObjectInherit; Allow: AppendData: Inherited, ContainerInherit; Allow: CreateFiles: Inherited, ContainerInherit; ", "stderr": "Users still has CreateFiles, AppendData, ReadAndExecute, Synchronize rights!", "stderr_lines": ["Users still has CreateFiles, AppendData, ReadAndExecute, Synchronize rights!"]}
...ignoring

TASK [Query ACL32] *************************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "GetACL32.stdout_lines": [
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "NT AUTHORITY\\SYSTEM Allow  FullControl",
        "BUILTIN\\Administrators Allow  FullControl",
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "BUILTIN\\Users Allow  AppendData",
        "BUILTIN\\Users Allow  CreateFiles",
        "CREATOR OWNER Allow  268435456"
    ]
}

TASK [add Read and Execute rights to TestUser] *********************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [Query ACL4] **************************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "GetACL4.stdout_lines": [
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "WIN-TEST1\\TestUser Allow  ReadAndExecute, Synchronize",
        "NT AUTHORITY\\SYSTEM Allow  FullControl",
        "BUILTIN\\Administrators Allow  FullControl",
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "BUILTIN\\Users Allow  AppendData",
        "BUILTIN\\Users Allow  CreateFiles",
        "CREATOR OWNER Allow  268435456"
    ]
}

TASK [Query ChildACL4] *********************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "GetChildACL4.stdout_lines": [
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "WIN-TEST1\\TestUser Allow  ReadAndExecute, Synchronize",
        "NT AUTHORITY\\SYSTEM Allow  FullControl",
        "BUILTIN\\Administrators Allow  FullControl",
        "BUILTIN\\Users Allow  AppendData",
        "BUILTIN\\Users Allow  CreateFiles",
        "CREATOR OWNER Allow  268435456"
    ]
}

TASK [add Modify rights to TestUser] *******************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [Query ACL41] *************************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "GetACL41.stdout_lines": [
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "WIN-TEST1\\TestUser Allow  Modify, Synchronize",
        "NT AUTHORITY\\SYSTEM Allow  FullControl",
        "BUILTIN\\Administrators Allow  FullControl",
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "BUILTIN\\Users Allow  AppendData",
        "BUILTIN\\Users Allow  CreateFiles",
        "CREATOR OWNER Allow  268435456"
    ]
}

TASK [Query ChildACL41] ********************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "GetChildACL41.stdout_lines": [
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "WIN-TEST1\\TestUser Allow  Modify, Synchronize",
        "NT AUTHORITY\\SYSTEM Allow  FullControl",
        "BUILTIN\\Administrators Allow  FullControl",
        "BUILTIN\\Users Allow  AppendData",
        "BUILTIN\\Users Allow  CreateFiles",
        "CREATOR OWNER Allow  268435456"
    ]
}

TASK [revoke Modify rights from TestUser] **************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [Query ACL42] *************************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "GetACL42.stdout_lines": [
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "NT AUTHORITY\\SYSTEM Allow  FullControl",
        "BUILTIN\\Administrators Allow  FullControl",
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "BUILTIN\\Users Allow  AppendData",
        "BUILTIN\\Users Allow  CreateFiles",
        "CREATOR OWNER Allow  268435456"
    ]
}

TASK [restore the expected state] **********************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [Query ACL43] *************************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "GetACL43.stdout_lines": [
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "WIN-TEST1\\TestUser Allow  ReadAndExecute, Synchronize",
        "NT AUTHORITY\\SYSTEM Allow  FullControl",
        "BUILTIN\\Administrators Allow  FullControl",
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "BUILTIN\\Users Allow  AppendData",
        "BUILTIN\\Users Allow  CreateFiles",
        "CREATOR OWNER Allow  268435456"
    ]
}

TASK [add Write rights to TestUser] ********************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [Query ACL44] *************************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "GetACL44.stdout_lines": [
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "WIN-TEST1\\TestUser Allow  Write, ReadAndExecute, Synchronize",
        "NT AUTHORITY\\SYSTEM Allow  FullControl",
        "BUILTIN\\Administrators Allow  FullControl",
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "BUILTIN\\Users Allow  AppendData",
        "BUILTIN\\Users Allow  CreateFiles",
        "CREATOR OWNER Allow  268435456"
    ]
}

TASK [revoke Write rights from TestUser] ***************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [Query ACL45] *************************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "GetACL45.stdout_lines": [
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "WIN-TEST1\\TestUser Allow  ReadAndExecute, Synchronize",
        "NT AUTHORITY\\SYSTEM Allow  FullControl",
        "BUILTIN\\Administrators Allow  FullControl",
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "BUILTIN\\Users Allow  AppendData",
        "BUILTIN\\Users Allow  CreateFiles",
        "CREATOR OWNER Allow  268435456"
    ]
}

TASK [Reset ACL] ***************************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "ReSetACL": {
        "changed": true,
        "failed": false,
        "msg": ""
    }
}

TASK [Query ACL5] **************************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "GetACL5.stdout_lines": [
        "NT AUTHORITY\\SYSTEM Allow  FullControl",
        "BUILTIN\\Administrators Allow  FullControl",
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "BUILTIN\\Users Allow  AppendData",
        "BUILTIN\\Users Allow  CreateFiles",
        "CREATOR OWNER Allow  268435456"
    ]
}

TASK [Reset ACL on root (M:\)] *************************************************
fatal: [win-test1.adtest.celab.ibm.cloud]: FAILED! => {"changed": false, "msg": "m:\\ is a root folder! Cannot reset ACL!"}
...ignoring

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "ReSetACL": {
        "changed": false,
        "failed": true,
        "msg": "m:\\ is a root folder! Cannot reset ACL!"
    }
}

TASK [Query ACL6] **************************************************************
changed: [win-test1.adtest.celab.ibm.cloud]

TASK [debug] *******************************************************************
ok: [win-test1.adtest.celab.ibm.cloud] => {
    "GetACL6.stdout_lines": [
        "NT AUTHORITY\\SYSTEM Allow  FullControl",
        "BUILTIN\\Administrators Allow  FullControl",
        "BUILTIN\\Users Allow  ReadAndExecute, Synchronize",
        "BUILTIN\\Users Allow  AppendData",
        "BUILTIN\\Users Allow  CreateFiles",
        "CREATOR OWNER Allow  268435456"
    ]
}

PLAY RECAP *********************************************************************
win-test1.adtest.celab.ibm.cloud : ok=49   changed=27   unreachable=0    failed=0    skipped=0    rescued=0    ignored=3   


```
