### PR TITLE
Fix broken tests when run with coverage

### DIFF
--- a/tests/integration/targets/module_utils_Process/library/process_pwsh_tests.ps1
+++ b/tests/integration/targets/module_utils_Process/library/process_pwsh_tests.ps1
@@ -307,7 +307,7 @@ foreach ($kvp in $argv_tests.GetEnumerator()) {
         # Required to convert any $null args to ""
         $argv = @($argv | ForEach-Object { [String]$_ })
         Assert-Equals -Expected $argv -Actual $actualArgs.args
-    }.GetNewClosure()
+    }
 
     $tests."Test argument command line to list - '$($kvp.Key)" = {
         $argc = $kvp.Key
@@ -321,7 +321,7 @@ foreach ($kvp in $argv_tests.GetEnumerator()) {
         $commandActual = Start-AnsibleWindowsProcess -FilePath $module.Params.print_argv -CommandLine $cmd
         $actualArgs = ($commandActual.Stdout | ConvertFrom-Json)
         Assert-Equals -Expected $escapedArgv -Actual $actualArgs.args
-    }.GetNewClosure()
+    }
 }
 
 foreach ($test_impl in $tests.GetEnumerator()) {


### PR DESCRIPTION
##### SUMMARY
The nightly CI run was failing on this test and this PR fixes that problem.

The reason why the CI run failed but the tests ran perfectly fine through a normal PR is because the nightly run enables coverage. When coverage is enabled Ansible will create a file for the module to run and invoke it like `C:\path\to\module.ps1`. The fix for this is to not create it with a new closure, there's no reason why that was needed here so removing simplifies everything.

The reason why `GetNewClosure()` causes a failure here is because it only copies modules and not functions in the current scope. When run it only has access to those vars in that scope at the time and whatever is set globally. In this case the function `Assert-Equals` was not defined globally and is only available in the local scope that defined it, which the closure is not part of.

When run from a Runspace (no coverage) the contents of the module is dot sourced first and thus loaded globally and can now be seen in the closure when it runs. An easy way to reproduce this is to create a script with the following contents and run the script by path.

```powershell
Function Test-Function {
    "a"
}

$c = {
    Test-Function
}.GetNewClosure()

&$c
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests