### PR TITLE
Stabilise CI

### DIFF
--- a/tests/integration/targets/win_command/tasks/main.yml
+++ b/tests/integration/targets/win_command/tasks/main.yml
@@ -203,6 +203,10 @@
   win_get_url:
     url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/win_command/OutputEncodingOverride.exe
     dest: '{{ remote_tmp_dir }}\OutputEncodingOverride.exe'
+  register: download_res
+  until: download_res is successful
+  retries: 3
+  delay: 5
 
 - name: call binary with shift_jis output encoding override
   win_command: '"{{ remote_tmp_dir }}\OutputEncodingOverride.exe"'

--- a/tests/integration/targets/win_get_url/tasks/main.yml
+++ b/tests/integration/targets/win_get_url/tasks/main.yml
@@ -26,6 +26,10 @@
   win_get_url:
     url: https://ansible-ci-files.s3.amazonaws.com/test/integration/roles/test_win_get_url/SlimFTPd.exe
     dest: '{{ testing_dir }}\SlimFTPd.exe'
+  register: download_res
+  until: download_res is successful
+  retries: 3
+  delay: 5
 
 # SlimFTPd does not work with special chars because it is so old, use a symlink as a workaround
 - name: set fact of temp symlink for SlimFTPd

--- a/tests/integration/targets/win_get_url/tasks/tests_url.yml
+++ b/tests/integration/targets/win_get_url/tasks/tests_url.yml
@@ -55,6 +55,10 @@
   win_get_url:
     url: https://ansible-ci-files.s3.amazonaws.com/test/integration/roles/test_win_get_url/SlimFTPd.exe
     dest: '{{ testing_dir }}\output'
+  register: download_res
+  until: download_res is successful
+  retries: 3
+  delay: 5
 
 - name: download single file with force no
   win_get_url:
@@ -62,6 +66,9 @@
     dest: '{{ testing_dir }}\output'
     force: no
   register: http_download_no_force
+  until: http_download_no_force is successful
+  retries: 3
+  delay: 5
 
 - name: assert download single file with force no
   assert:

--- a/tests/integration/targets/win_package/tasks/main.yml
+++ b/tests/integration/targets/win_package/tasks/main.yml
@@ -15,6 +15,10 @@
   win_get_url:
     url: '{{ item.url }}'
     dest: '{{ test_path }}\{{ item.name }}'
+  register: download_res
+  until: download_res is successful
+  retries: 3
+  delay: 5
   with_items:
   - url: '{{ good_url }}'
     name: good.msi

--- a/tests/integration/targets/win_package/tasks/msix_tests.yml
+++ b/tests/integration/targets/win_package/tasks/msix_tests.yml
@@ -11,6 +11,10 @@
   win_get_url:
     url: '{{ makeappx_url }}'
     dest: '{{ test_path }}\makeappx.zip'
+  register: download_res
+  until: download_res is successful
+  retries: 3
+  delay: 5
 
 - name: extract makeappx binaries
   win_shell: Expand-Archive -LiteralPath '{{ test_path }}\makeappx.zip' -DestinationPath '{{ test_path }}\makeappx'

--- a/tests/integration/targets/win_service/tasks/main.yml
+++ b/tests/integration/targets/win_service/tasks/main.yml
@@ -26,6 +26,10 @@
   win_get_url:
     url: '{{ test_win_service_binary_url }}'
     dest: '{{ test_win_service_path }}'
+  register: download_res
+  until: download_res is successful
+  retries: 3
+  delay: 5
 
 - name: remove the dummy test services if it is left over from previous tests
   win_service:

--- a/tests/integration/targets/win_service_info/tasks/main.yml
+++ b/tests/integration/targets/win_service_info/tasks/main.yml
@@ -8,6 +8,10 @@
   win_get_url:
     url: '{{ service_url }}'
     dest: '{{ test_path }}\SleepService.exe'
+  register: download_res
+  until: download_res is successful
+  retries: 3
+  delay: 5
 
 - name: create test service
   win_service:


### PR DESCRIPTION
##### SUMMARY
Sometimes CI can fail to download files from an external source which fails the whole thing. This adds a retry to these tasks to hopefully reduce the number of unstable test results we get from these issues.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests