### PR TITLE
win_find - return normal files with hidden: yes

### DIFF
--- a/changelogs/fragments/win_find-hidden.yml
+++ b/changelogs/fragments/win_find-hidden.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_find - Change ``hidden: yes`` to return hidden files and normal files to match the behaviour with ``find`` - https://github.com/ansible-collections/ansible.windows/issues/130

--- a/changelogs/fragments/win_find-hidden.yml
+++ b/changelogs/fragments/win_find-hidden.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- win_find - Change ``hidden: yes`` to return hidden files and normal files to match the behaviour with ``find`` - https://github.com/ansible-collections/ansible.windows/issues/130
+- 'win_find - Change ``hidden: yes`` to return hidden files and normal files to match the behaviour with ``find`` - https://github.com/ansible-collections/ansible.windows/issues/130'

--- a/plugins/modules/win_find.ps1
+++ b/plugins/modules/win_find.ps1
@@ -81,8 +81,10 @@ Function Assert-FileHidden {
         [Switch]$IsHidden
     )
 
+    # https://github.com/ansible-collections/ansible.windows/issues/130
+    # We want to always return non-hidden files + hidden files if hidden: yes.
     $file_is_hidden = $File.Attributes.HasFlag([System.IO.FileAttributes]::Hidden)
-    return $IsHidden.IsPresent -eq $file_is_hidden
+    return $IsHidden.IsPresent -or -not $file_is_hidden
 }
 
 

--- a/tests/integration/targets/win_find/tasks/tests.yml
+++ b/tests/integration/targets/win_find/tasks/tests.yml
@@ -147,31 +147,47 @@
     that:
     - not actual is changed
     - actual.examined == 11
-    - actual.matched == 1
-    - actual.files[0].attributes == 'Hidden, Archive'
-    - actual.files[0].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'
-    - actual.files[0].creationtime == 1477984205
-    - actual.files[0].exists == True
-    - actual.files[0].extension == '.ps1'
-    - actual.files[0].filename == 'hidden.ps1'
-    - actual.files[0].hlnk_targets == []
-    - actual.files[0].isarchive == True
-    - actual.files[0].isdir == False
-    - actual.files[0].ishidden == True
-    - actual.files[0].isjunction == False
-    - actual.files[0].islnk == False
-    - actual.files[0].isreadonly == False
-    - actual.files[0].isreg == True
-    - actual.files[0].isshared == False
-    - actual.files[0].lastaccesstime == 1477984205
-    - actual.files[0].lastwritetime == 1477984205
-    - actual.files[0].lnk_source == None
-    - actual.files[0].lnk_target == None
-    - actual.files[0].nlink == 1
-    - actual.files[0].owner == 'BUILTIN\\Administrators'
-    - actual.files[0].path == win_find_dir + '\\single\\hidden.ps1'
-    - actual.files[0].sharename == None
-    - actual.files[0].size == 14
+    - actual.matched == 9
+    - actual.files[0].filename == 'archive.log'
+    - actual.files[0].attributes == 'Archive'
+    - actual.files[1].filename == 'file.ps1'
+    - actual.files[1].attributes == 'Archive'
+    - actual.files[2].filename == 'out.log'
+    - actual.files[2].attributes == 'Archive'
+    - actual.files[3].filename == 'test.ps1'
+    - actual.files[3].attributes == 'Archive'
+    - actual.files[4].attributes == 'Hidden, Archive'
+    - actual.files[4].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'
+    - actual.files[4].creationtime == 1477984205
+    - actual.files[4].exists == True
+    - actual.files[4].extension == '.ps1'
+    - actual.files[4].filename == 'hidden.ps1'
+    - actual.files[4].hlnk_targets == []
+    - actual.files[4].isarchive == True
+    - actual.files[4].isdir == False
+    - actual.files[4].ishidden == True
+    - actual.files[4].isjunction == False
+    - actual.files[4].islnk == False
+    - actual.files[4].isreadonly == False
+    - actual.files[4].isreg == True
+    - actual.files[4].isshared == False
+    - actual.files[4].lastaccesstime == 1477984205
+    - actual.files[4].lastwritetime == 1477984205
+    - actual.files[4].lnk_source == None
+    - actual.files[4].lnk_target == None
+    - actual.files[4].nlink == 1
+    - actual.files[4].owner == 'BUILTIN\\Administrators'
+    - actual.files[4].path == win_find_dir + '\\single\\hidden.ps1'
+    - actual.files[4].sharename == None
+    - actual.files[4].size == 14
+    - actual.files[5].filename == 'large.ps1'
+    - actual.files[5].attributes == 'Archive'
+    - actual.files[6].filename == 'out_20161101-091005.log'
+    - actual.files[6].attributes == 'Archive'
+    - actual.files[7].filename == 'small.ps1'
+    - actual.files[7].attributes == 'Archive'
+    - actual.files[8].filename == 'test.ps1'
+    - actual.files[8].attributes == 'Archive'
 
 - name: find file based on pattern
   win_find:


### PR DESCRIPTION
##### SUMMARY
The `find` module returns both hidden and normal files when `hidden: yes`, this PR changes `win_find` to match that behaviour.

Fixes https://github.com/ansible-collections/ansible.windows/issues/130.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_find