### PR TITLE
win_package - fix installs from readonly location

### DIFF
--- a/changelogs/fragments/win_package-readonly.yaml
+++ b/changelogs/fragments/win_package-readonly.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_package - Do not fail when trying to set SYSTEM ACE on read only path - https://github.com/ansible-collections/ansible.windows/issues/142

--- a/tests/integration/targets/win_package/tasks/msi_tests.yml
+++ b/tests/integration/targets/win_package/tasks/msi_tests.yml
@@ -463,7 +463,7 @@
     path: '{{ test_path }}\good.msi'
     state: absent
 
-# MSI arguments KEY="value" are known to fail when set as a list, for this test just create a simple folder path that
+  # MSI arguments KEY="value" are known to fail when set as a list, for this test just create a simple folder path that
 # does not need to be escaped and cleanup at the end.
 - name: create a simple spaceless folder for argument list test
   win_file:
@@ -503,6 +503,73 @@
     win_package:
       path: '{{ test_path }}\good.msi'
       state: absent
+
+  # https://github.com/ansible-collections/ansible.windows/issues/142
+  # Mount VHD on a FAT formatted volume. This doesn't support ACLs and will test that the SYSTEM ACE doesn't bring down the module.
+  - name: get first free drive letter
+    win_shell: |
+      Get-ChildItem -Path 'function:[d-z]:' -Name |
+        Where-Object { -not (Test-Path -LiteralPath $_) } |
+        Select-Object -Last 1
+    register: drive
+
+  - set_fact:
+      drive: '{{ drive.stdout | trim }}'
+
+  - name: template mount and umount scripts
+    win_template:
+      src: '{{ item }}.j2'
+      dest: C:\ansible_win_package\{{ item }}
+    vars:
+      path: C:\ansible_win_package\image.vhd
+    with_items:
+    - mount.txt
+    - mount_readonly.txt
+    - umount.txt
+
+  - name: create VHD and mount it
+    win_command: diskpart.exe /s C:\ansible_win_package\mount.txt
+
+  - block:
+    - name: copy MSI to image
+      win_copy:
+        src: '{{ test_path }}\good.msi'
+        dest: '{{ drive }}\good.msi'
+        remote_src: yes
+
+    - name: unmount VHD
+      win_command: diskpart.exe /s C:\ansible_win_package\umount.txt
+
+    - name: mount VHD as read only
+      win_command: diskpart.exe /s C:\ansible_win_package\mount_readonly.txt
+
+    - name: install msi from read only location
+      win_package:
+        path: '{{ drive }}\good.msi'
+        state: present
+      register: install_readonly
+
+    - name: get result of install msi from read only location
+      win_reg_stat:
+        path: HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\{{ good_id }}
+      register: install_readonly_actual
+
+    - name: assert install local msi
+      assert:
+        that:
+        - install_readonly is changed
+        - not install_readonly.reboot_required
+        - install_readonly.rc == 0
+        - install_readonly_actual.exists
+
+    - name: remove msi from read only location
+      win_package:
+        path: '{{ drive }}\good.msi'
+        state: absent
+
+    always:
+    - name: unmount FAT volume
+      win_command: diskpart.exe /s C:\ansible_win_package\umount.txt
 
   always:
   - name: remove spaceless folder for argument list test

--- a/tests/integration/targets/win_package/templates/mount.txt.j2
+++ b/tests/integration/targets/win_package/templates/mount.txt.j2
@@ -1,0 +1,11 @@
+create vdisk file="{{ path }}" maximum=128 type=fixed
+
+attach vdisk
+
+convert mbr
+
+create partition primary
+
+format FS=NTFS label=FATDrive quick
+
+assign letter="{{ drive }}"

--- a/tests/integration/targets/win_package/templates/mount_readonly.txt.j2
+++ b/tests/integration/targets/win_package/templates/mount_readonly.txt.j2
@@ -1,0 +1,3 @@
+select vdisk file="{{ path }}"
+
+attach vdisk readonly

--- a/tests/integration/targets/win_package/templates/umount.txt.j2
+++ b/tests/integration/targets/win_package/templates/umount.txt.j2
@@ -1,0 +1,3 @@
+select vdisk file="{{ path }}"
+
+detach vdisk


### PR DESCRIPTION
##### SUMMARY
When installing from a readonly location the `win_package` module fails as it cannot add the ACE for the `SYSTEM` account to the path. This may not be necessary so we can just ignore a failure and wait until it either succeeds or fails later on.

Fixes https://github.com/ansible-collections/ansible.windows/issues/142

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_package