### PR TITLE
win_serivce - fix pwsh 5.0 bug

### DIFF
--- a/changelogs/fragments/win_service-pwsh5.0.yaml
+++ b/changelogs/fragments/win_service-pwsh5.0.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_service - Fix edge case bug when running against PowerShell 5.0 - https://github.com/ansible-collections/ansible.windows/issues/125

--- a/plugins/modules/win_service.ps1
+++ b/plugins/modules/win_service.ps1
@@ -196,7 +196,7 @@ Function ConvertTo-ServiceTypeDiff {
     # Converts the enum ServiceType to the valud for a diff.
     $ServiceType = [uint32]$ServiceType -band -bnot [uint32][Ansible.Windows.SCManager.ServiceType]::InteractiveProcess
     $ServiceType = $ServiceType -band -bnot [uint32][Ansible.Windows.SCManager.ServiceType]::UserServiceInstance
-    switch (([Ansible.Windows.SCManager.ServiceType]$ServiceType).ToString()) {
+    switch ($ServiceType.ToString()) {
         KernelDriver { 'kernel_driver' }
         FileSystemDriver { 'file_system_driver' }
         Adapter { 'adapter' }

--- a/plugins/modules/win_service_info.ps1
+++ b/plugins/modules/win_service_info.ps1
@@ -87,10 +87,10 @@ $module.Result.services = @(foreach ($rawService in ($services)) {
 
     # The ServiceType value can contain other flags which are represented by other properties, this strips them out
     # so we don't include them in the service_type return value.
-    [Ansible.Windows.SCManager.ServiceType]$serviceType = $service.ServiceType
-    $serviceType = [uint32]$serviceType -band -bnot [uint32][Ansible.Windows.SCManager.ServiceType]::InteractiveProcess
-    $serviceType = [uint32]$serviceType -band -bnot [uint32][Ansible.Windows.SCManager.ServiceType]::UserServiceInstance
-    $serviceType = switch ($serviceType.ToString()) {
+    [Ansible.Windows.SCManager.ServiceType]$rawServiceType = $service.ServiceType
+    $rawServiceType = [uint32]$rawServiceType -band -bnot [uint32][Ansible.Windows.SCManager.ServiceType]::InteractiveProcess
+    $rawServiceType = [uint32]$rawServiceType -band -bnot [uint32][Ansible.Windows.SCManager.ServiceType]::UserServiceInstance
+    $serviceType = switch ($rawServiceType.ToString()) {
         KernelDriver { 'kernel_driver' }
         FileSystemDriver { 'file_system_driver' }
         Adapter { 'adapter' }

--- a/plugins/modules/win_service_info.ps1
+++ b/plugins/modules/win_service_info.ps1
@@ -87,9 +87,10 @@ $module.Result.services = @(foreach ($rawService in ($services)) {
 
     # The ServiceType value can contain other flags which are represented by other properties, this strips them out
     # so we don't include them in the service_type return value.
-    $serviceType = [uint32]$service.ServiceType -band -bnot [uint32][Ansible.Windows.SCManager.ServiceType]::InteractiveProcess
-    $serviceType = $serviceType -band -bnot [uint32][Ansible.Windows.SCManager.ServiceType]::UserServiceInstance
-    $serviceType = switch (([Ansible.Windows.SCManager.ServiceType]$serviceType).ToString()) {
+    [Ansible.Windows.SCManager.ServiceType]$serviceType = $service.ServiceType
+    $serviceType = [uint32]$serviceType -band -bnot [uint32][Ansible.Windows.SCManager.ServiceType]::InteractiveProcess
+    $serviceType = [uint32]$serviceType -band -bnot [uint32][Ansible.Windows.SCManager.ServiceType]::UserServiceInstance
+    $serviceType = switch ($serviceType.ToString()) {
         KernelDriver { 'kernel_driver' }
         FileSystemDriver { 'file_system_driver' }
         Adapter { 'adapter' }


### PR DESCRIPTION
##### SUMMARY
I could only ever replicate this issue on PowerShell 5.0 (not 5.1) which has been yanked from existence by Microsoft and really only available on older Windows 10 builds. There's some engine error when you try to cast to an enum inside a group then call `ToString()` on it. A quick reproducer that will fail on WMF 5.0 is

```powershell
[IO.FileAttributes]$a = 'Archive'
([IO.FileAttributes]$a).ToString()
```

There was an alternative solution proposed but this keeps the code somewhat tidier.

Fixes https://github.com/ansible-collections/ansible.windows/issues/125

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_service
win_service_info