### PR TITLE
win_service - Open drivers and relax required perms

### DIFF
--- a/changelogs/fragments/win_service.yaml
+++ b/changelogs/fragments/win_service.yaml
@@ -1,0 +1,6 @@
+bufixes:
+- win_service - Fix opening services with limited rights - https://github.com/ansible-collections/ansible.windows/issues/118
+- win_service_info - Provide failure details in warning when failing to open service
+
+minor_changes:
+- win_service - Allow opening driver services using this module. Not all functionality is available for these types of services - https://github.com/ansible-collections/ansible.windows/issues/115

--- a/changelogs/fragments/win_service.yaml
+++ b/changelogs/fragments/win_service.yaml
@@ -1,4 +1,4 @@
-bufixes:
+bugfixes:
 - win_service - Fix opening services with limited rights - https://github.com/ansible-collections/ansible.windows/issues/118
 - win_service_info - Provide failure details in warning when failing to open service
 

--- a/plugins/modules/win_service.ps1
+++ b/plugins/modules/win_service.ps1
@@ -244,7 +244,7 @@ Function Get-ServiceDiff {
 
         # Only set the username/password diff if we have the proper type.
         if ( -not (
-            $Service.ServiceType.HasFlag([Ansible.Windows.SCManager.ServiceType]::KernelDriver) -or 
+            $Service.ServiceType.HasFlag([Ansible.Windows.SCManager.ServiceType]::KernelDriver) -or
             $service.ServiceType.HasFlag([Ansible.Windows.SCManager.ServiceType]::FileSystemDriver)
         )) {
             $diff.username = $Service.Account.Value
@@ -996,7 +996,7 @@ if ($state -eq 'absent') {
         # The ServiceStartName for these types of services aren't the account it runs on so running this will fail
         # to convert it to an account. While this could be configured in the future for now we just ignore the values.
         if ( -not (
-            $service.ServiceType.HasFlag([Ansible.Windows.SCManager.ServiceType]::KernelDriver) -or 
+            $service.ServiceType.HasFlag([Ansible.Windows.SCManager.ServiceType]::KernelDriver) -or
             $service.ServiceType.HasFlag([Ansible.Windows.SCManager.ServiceType]::FileSystemDriver)
         )) {
             Set-ServiceAccount -Username $username -Password $password -UpdatePassword:$updatePassword @common

--- a/plugins/modules/win_service.ps1
+++ b/plugins/modules/win_service.ps1
@@ -219,7 +219,7 @@ Function Get-ServiceDiff {
     if (-not $Service) {
         ""
     } else {
-        @{
+        $diff = @{
             dependencies = $Service.DependentOn
             description = $Service.Description
             desktop_interact = $Service.ServiceType.HasFlag(
@@ -233,7 +233,6 @@ Function Get-ServiceDiff {
             failure_reset_period_sec = $Service.FailureActions.ResetPeriod
             load_order_group = $Service.LoadOrderGroup
             name = $Service.ServiceName
-            password = 'REDACTED'
             path = $Service.Path
             pre_shutdown_timeout_ms = $Service.PreShutdownTimeout
             required_privileges = $Service.RequiredPrivileges
@@ -241,8 +240,18 @@ Function Get-ServiceDiff {
             sid_info = $Service.ServiceSidInfo.ToString().ToLowerInvariant()
             start_mode = ConvertTo-ServiceStartModeDiff -StartMode $Service.StartType
             state = ConvertTo-ServiceStateDiff -State $Service.State
-            username = $Service.Account.Value
         }
+
+        # Only set the username/password diff if we have the proper type.
+        if ( -not (
+            $Service.ServiceType.HasFlag([Ansible.Windows.SCManager.ServiceType]::KernelDriver) -or 
+            $service.ServiceType.HasFlag([Ansible.Windows.SCManager.ServiceType]::FileSystemDriver)
+        )) {
+            $diff.username = $Service.Account.Value
+            $diff.password = 'REDACTED'
+        }
+
+        $diff
     }
 }
 
@@ -256,7 +265,15 @@ Function Get-ServiceFromName {
 
     # Get-Service -Name * doesn't work if the name has a wildcard char like '[]'. Use Where-Object to achieve the same
     # result just in a slightly more expensive way.
-    Get-Service | Where-Object { $_.ServiceName -eq $Name -or $_.DisplayName -eq $Name }
+    $service = Get-Service | Where-Object { $_.ServiceName -eq $Name -or $_.DisplayName -eq $Name }
+
+    # https://github.com/ansible-collections/ansible.windows/issues/115
+    # Get-Service without a name will not output driver services whereas -Name does. Fallback to checking with -Name
+    # if we couldn't find a match from above.
+    if ($service) {
+        return $service
+    }
+    Get-Service -Name $Name -ErrorAction SilentlyContinue
 }
 
 Function Set-ServiceAccount {
@@ -280,7 +297,7 @@ Function Set-ServiceAccount {
 
     $Module.Diff.after.username = $Username
     $Module.Diff.after.password = 'REDACTED'
-    if ($null -ne $Service) {
+    if ($null -ne $Service -and $Service.Account) {
         $desiredSid = $null
         if ($Username) {
             $desiredSid = ConvertTo-SecurityIdentifier -Name $Username
@@ -881,7 +898,28 @@ Function Set-ServiceType {
     }
 }
 
-$service = Get-ServiceFromName -Name $name | ForEach-Object { [Ansible.Windows.SCManager.Service]$_.ServiceName }
+# We don't need the full gauntlet of service rights for this module. Only request the ones that are needed in case
+# we come across a more restricted service.
+# https://github.com/ansible-collections/ansible.windows/issues/118
+$rights = [Ansible.Windows.SCManager.ServiceRights]'QueryConfig, QueryStatus, EnumerateDependents'
+
+if ($failureActions) {
+    # If setting an SC_ACTION_RESTART failure action the handle needs to be opened with start rights.
+    $rights = $rights -bor [Ansible.Windows.SCManager.ServiceRights]::Start
+}
+
+if ($state -eq 'absent') {
+    $rights = $rights -bor [Ansible.Windows.SCManager.ServiceRights]::Delete
+}
+else {
+    $rights = $rights -bor [Ansible.Windows.SCManager.ServiceRights]::ChangeConfig
+}
+
+$service = Get-ServiceFromName -Name $name | ForEach-Object {
+    New-Object -TypeName Ansible.Windows.SCManager.Service -ArgumentList @(
+        $_.ServiceName, $rights
+    )
+}
 $module.Diff.before = Get-ServiceDiff -Service $service
 
 if ($state -eq 'absent') {
@@ -954,7 +992,16 @@ if ($state -eq 'absent') {
         }
 
         $common = @{Service = $service; Module = $module}
-        Set-ServiceAccount -Username $username -Password $password -UpdatePassword:$updatePassword @common
+
+        # The ServiceStartName for these types of services aren't the account it runs on so running this will fail
+        # to convert it to an account. While this could be configured in the future for now we just ignore the values.
+        if ( -not (
+            $service.ServiceType.HasFlag([Ansible.Windows.SCManager.ServiceType]::KernelDriver) -or 
+            $service.ServiceType.HasFlag([Ansible.Windows.SCManager.ServiceType]::FileSystemDriver)
+        )) {
+            Set-ServiceAccount -Username $username -Password $password -UpdatePassword:$updatePassword @common
+        }
+
         Set-ServiceDependencies -Dependencies $dependencies -DependencyAction $dependencyAction @common
         Set-ServiceDescription -Description $description @common
         Set-ServiceDisplayName -DisplayName $displayName @common

--- a/plugins/modules/win_service.py
+++ b/plugins/modules/win_service.py
@@ -256,6 +256,9 @@ notes:
   favour of the M(ansible.windows.win_service_info) module.
 - Most of the options in this module are non-driver services that you can view in SCManager. While you can edit driver
   services, not all functionality may be available.
+- The user running the module must have the following access rights on the service to be able to use it with this
+  module - C(SERVICE_CHANGE_CONFIG), C(SERVICE_ENUMERATE_DEPENDENTS), C(SERVICE_QUERY_CONFIG), C(SERVICE_QUERY_STATUS).
+- Changing the state or removing the service will also require futher rights depending on what needs to be done.
 seealso:
 - module: ansible.builtin.service
 - module: community.windows.win_nssm

--- a/plugins/modules/win_service.py
+++ b/plugins/modules/win_service.py
@@ -254,6 +254,8 @@ options:
 notes:
 - This module historically returning information about the service in its return values. These should be avoided in
   favour of the M(ansible.windows.win_service_info) module.
+- Most of the options in this module are non-driver services that you can view in SCManager. While you can edit driver
+  services, not all functionality may be available.
 seealso:
 - module: ansible.builtin.service
 - module: community.windows.win_nssm

--- a/plugins/modules/win_service_info.ps1
+++ b/plugins/modules/win_service_info.ps1
@@ -33,7 +33,8 @@ $module.Result.services = @(foreach ($rawService in ($services)) {
     } catch [Ansible.Windows.SCManager.ServiceManagerException] {
         # ERROR_ACCESS_DENIED, ignore the service and continue on.
         if ($_.Exception.InnerException -and $_.Exception.InnerException.NativeErrorCode -eq 5) {
-            $module.Warn("Failed to access service '$($rawService.Name) to get more info, ignoring")
+            $msg = "Failed to access service '$($rawService.Name) to get more info, ignoring: $($_.Exception.Message)"
+            $module.Warn($msg)
             continue
         }
 

--- a/tests/integration/targets/win_service/tasks/driver.yml
+++ b/tests/integration/targets/win_service/tasks/driver.yml
@@ -1,0 +1,31 @@
+# https://github.com/ansible-collections/ansible.windows/issues/115
+# In lieu of having our own driver which we control, we just test with a inconsequential driver in CI.
+- name: get existing display name for driver
+  win_service_info:
+    name: cdrom
+  register: driver_info
+
+- block:
+  - name: open driver service and set display name
+    win_service:
+      name: cdrom
+      display_name: Ansible Display Name
+    register: driver_change_display
+
+  - name: get result of open driver service and set display name
+    win_service_info:
+      name: cdrom
+    register: driver_change_display_actual
+
+  - name: assert open driver service and set display name
+    assert:
+      that:
+      - driver_change_display is changed
+      - driver_change_display.display_name == 'Ansible Display Name'
+      - driver_change_display_actual.services[0].display_name == 'Ansible Display Name'
+
+  always:
+  - name: reset display name back to default
+    win_service:
+      name: cdrom
+      display_name: '{{ driver_info.services[0].display_name }}'

--- a/tests/integration/targets/win_service/tasks/main.yml
+++ b/tests/integration/targets/win_service/tasks/main.yml
@@ -36,10 +36,14 @@
     name: '{{ item }}'
     force_dependent_services: True
     state: absent
+  become: yes
+  become_method: runas
+  become_user: SYSTEM
   with_items:
   - '{{ test_win_service_name }}'
   - TestServiceParent2
   - TestServiceDependency
+  - TestRestrictedService
 
 - block:
   - name: create new dummy test service
@@ -75,6 +79,7 @@
   - include_tasks: required_privileges.yml
   - include_tasks: service_type.yml
   - include_tasks: sid_info.yml
+  - include_tasks: driver.yml
 
   always:
   - name: remove test services
@@ -82,10 +87,14 @@
       name: '{{ item }}'
       force_dependent_services: True
       state: absent
+    become: yes
+    become_method: runas
+    become_user: SYSTEM
     with_items:
     - '{{ test_win_service_name }}'
     - TestServiceParent2
     - TestServiceDependency
+    - TestRestrictedService
 
   - name: remove test directory
     win_file:

--- a/tests/integration/targets/win_service/tasks/tests.yml
+++ b/tests/integration/targets/win_service/tasks/tests.yml
@@ -1008,3 +1008,29 @@
     state: paused
   register: fail_pause_stopped_service
   failed_when: "fail_pause_stopped_service.msg != 'failed to pause service ' + test_win_service_name + ': The service does not support pausing'"
+
+# https://github.com/ansible-collections/ansible.windows/issues/118
+- name: create service for restricted access tests
+  win_service:
+    name: TestRestrictedService
+    state: stopped
+    path: '{{ test_win_service_path }}'
+
+# Allows SYSTEM full access but limited access for BUILTIN\Administrators
+- name: restrict service to full control for system but limited current user
+  win_command: >-
+    sc.exe sdset
+    TestRestrictedService
+    D:(A;;CCDCLCSWRPWPDTLOCRSDRCWDWO;;;SY)(A;;CCDCLCSWRPWP;;;BA)(A;;CCLCSWLOCRRC;;;SU)
+
+- name: edit service with restricted access
+  win_service:
+    name: TestRestrictedService
+    state: started
+    display_name: Test Restricted Name
+  register: change_restricted
+
+- name: get result of edit service with restricted access
+  win_service_info:
+    name: TestRestrictedService
+  register: change_restricted_actual


### PR DESCRIPTION
##### SUMMARY
Specify explicit permissions when opening the service as we do not require all access. Also allow opening driver services which were being excluded by `Get-Service` due to how it was being called.

Fixes https://github.com/ansible-collections/ansible.windows/issues/115
Fixes https://github.com/ansible-collections/ansible.windows/issues/118

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_service
win_service_info