### PR TITLE
win_user sid support (fix #153)

### DIFF
--- a/plugins/modules/win_user.ps1
+++ b/plugins/modules/win_user.ps1
@@ -59,22 +59,22 @@ $ADS_UF_DONT_EXPIRE_PASSWD = 65536
 $ADSI = [ADSI]"WinNT://$env:COMPUTERNAME"
 
 Function Test-IsValidSecurityIdentifier {
-	[CmdletBinding()]
+    [CmdletBinding()]
     [OutputType('System.Boolean')]
     param (
         [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
         [String]
         $InputObject
     )
-	
-	process {
-		try {
-			$sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList $InputObject
-			return $true
-		} catch {
-			return $false
-		}
-	}
+    
+    process {
+        try {
+            $sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList $InputObject
+            return $true
+        } catch {
+            return $false
+        }
+    }
 }
 
 Function Convert-SecurityIdentifiertoBinary {
@@ -84,14 +84,14 @@ Function Convert-SecurityIdentifiertoBinary {
         [String]
         $InputObject
     )
-	
-	if (Test-IsValidSecurityIdentifier -InputObject $InputObject) {
-		$sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList $InputObject
-		$GroupSIDBinary = New-Object byte[] -ArgumentList $sid.BinaryLength
-		$sid.GetBinaryForm($GroupSIDBinary, 0)
-	
-		return $GroupSIDBinary
-	}
+    
+    if (Test-IsValidSecurityIdentifier -InputObject $InputObject) {
+        $sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList $InputObject
+        $GroupSIDBinary = New-Object byte[] -ArgumentList $sid.BinaryLength
+        $sid.GetBinaryForm($GroupSIDBinary, 0)
+    
+        return $GroupSIDBinary
+    }
 }
 
 Function Get-AnsibleLocalGroup {
@@ -101,17 +101,17 @@ Function Get-AnsibleLocalGroup {
         [String]
         $Name
     )
-	
-	$binarySid = Convert-SecurityIdentifiertoBinary -InputObject $Name
+    
+    $binarySid = Convert-SecurityIdentifiertoBinary -InputObject $Name
 
     $ADSI.Children | Where-Object {
-		$_.SchemaClassName -eq 'Group'
-	} | Where-Object {
-		$_.Name -eq $Name -or (
-			# SID matching logic
-			$binarySid -and ($_.objectSid | Foreach-Object { [System.Linq.Enumerable]::SequenceEqual([byte[]]$binarysid, [byte[]]$_) }) -contains $true
-		)
-	}
+        $_.SchemaClassName -eq 'Group'
+    } | Where-Object {
+        $_.Name -eq $Name -or (
+            # SID matching logic
+            $binarySid -and ($_.objectSid | Foreach-Object { [System.Linq.Enumerable]::SequenceEqual([byte[]]$binarysid, [byte[]]$_) }) -contains $true
+        )
+    }
 }
 
 Function Get-AnsibleLocalUser {

--- a/plugins/modules/win_user.ps1
+++ b/plugins/modules/win_user.ps1
@@ -66,10 +66,10 @@ Function Test-IsValidSecurityIdentifier {
         [String]
         $InputObject
     )
-    
+
     process {
         try {
-            $sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList $InputObject
+            $null = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList $InputObject
             return $true
         } catch {
             return $false
@@ -84,12 +84,12 @@ Function Convert-SecurityIdentifiertoBinary {
         [String]
         $InputObject
     )
-    
+
     if (Test-IsValidSecurityIdentifier -InputObject $InputObject) {
         $sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList $InputObject
         $GroupSIDBinary = New-Object byte[] -ArgumentList $sid.BinaryLength
         $sid.GetBinaryForm($GroupSIDBinary, 0)
-    
+
         return $GroupSIDBinary
     }
 }
@@ -101,7 +101,7 @@ Function Get-AnsibleLocalGroup {
         [String]
         $Name
     )
-    
+
     $binarySid = Convert-SecurityIdentifiertoBinary -InputObject $Name
 
     $ADSI.Children | Where-Object {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
As explained in #153 I wanted to enable `win_user` to take group SIDs in the `groups` list.

The two new functions in this PR are fairly self-explanatory I think so I'm going to focus my explaining on the meat of the change, this code block:

```powershell
    $ADSI.Children | Where-Object {
        $_.SchemaClassName -eq 'Group'
    } | Where-Object {
        $_.Name -eq $Name -or (
            # SID matching logic
            $binarySid -and ($_.objectSid | Foreach-Object { [System.Linq.Enumerable]::SequenceEqual([byte[]]$binarysid, [byte[]]$_) }) -contains $true
        )
    }
```

Design decisions here were:

- Match on `$_.Name` first and return immediately if a match is found so that behavior does not change for existing code
- Only if `$_.Name` does not find a match is the second part of the `-or` operator evaluated
- The current behavior of the Name-based comparison is to return `$true` when any of the Names inside the `$_.Name` array of the ADSI-object (yes, `.Name` is an array) match. That behavior was kept for the SID comparison. Pseudo-code:
```
IF $SidInputByUser IS EQUAL TO any of the SIDs in the array of the ADSI-object THEN return TRUE
```
- The current behavior of the Name-based comparison is to return nothing when no Group was matched. This also stays the same.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #153

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible.windows.win_user

##### ADDITIONAL INFORMATION
Before change, trying to create a user and add them to the 'Users' group on a german system:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
fatal: [172.30.147.238]: FAILED! => changed=false
  msg: group 'Users' not found
```

Before change, trying to create a user and add them to the 'Users' group on a german system by using the SID:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
fatal: [172.30.147.238]: FAILED! => changed=false
  msg: group 'S-1-5-32-545' not found
```

After the change, using SIDs like a sane person:
```
changed: [172.30.147.238]
```

The PR is open for discussion and suggested changes are welcome. I am personally not entirely happy with the ugly comparison login in line 112 but wanted to provide a solution to go along with my issue that we can improve on.
