### PR TITLE
Update AZP test container for PATH fixes

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -36,7 +36,7 @@ variables:
 resources:
   containers:
     - container: default
-      image: quay.io/ansible/azure-pipelines-test-container:1.7.0
+      image: quay.io/ansible/azure-pipelines-test-container:1.7.1
 
 pool: Standard
 

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -67,7 +67,6 @@ if [ "${SHIPPABLE_BUILD_ID:-}" ]; then
     cd "${TEST_DIR}"
 fi
 
-export PATH="${HOME}/.local/bin:${PATH}"
 sudo chown "$(whoami)" "${PWD}/../../"
 
 export PYTHONIOENCODING='utf-8'


### PR DESCRIPTION
Removes the need for the PATH hack in the testing container