### PR TITLE
win_serivce - Fix up username split code

### DIFF
--- a/changelogs/fragments/win_service-sid.yml
+++ b/changelogs/fragments/win_service-sid.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_service - Fix up account name lookup when dealing with netlogon formatted accounts (``DOMAIN\account``) - https://github.com/ansible-collections/ansible.windows/issues/156

--- a/plugins/modules/win_service.ps1
+++ b/plugins/modules/win_service.ps1
@@ -108,7 +108,7 @@ Function ConvertTo-SecurityIdentifier {
 
     # Handle cases when referencing a local user like .\account.
     if ($Name.Contains('\')) {
-        $nameSplit = $Name.Split('\.', 2)
+        $nameSplit = $Name.Split('\', 2)
         if ($nameSplit[0] -eq '.') {
             $domain = $env:COMPUTERNAME
         } else {


### PR DESCRIPTION
##### SUMMARY
Fix the code that splits netlogon account names to split by `\` and not `\.`.

Fixes https://github.com/ansible-collections/ansible.windows/issues/156

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_service