### PR TITLE
setup - handle PATHs with blank entry

### DIFF
--- a/changelogs/fragments/setup_empty_path.yml
+++ b/changelogs/fragments/setup_empty_path.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- setup - handle PATH environment vars that contain blank entries like ``C:\Windows;;C:\Program Files`` - https://github.com/ansible-collections/ansible.windows/pull/78#issuecomment-745229594

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -658,6 +658,11 @@ $factMeta = @(
         Code = {
             # Get-Command can be slow to enumerate the paths, do this ourselves
             $facterDir = $env:PATH -split ([IO.Path]::PathSeparator) | Where-Object {
+                # https://github.com/ansible-collections/ansible.windows/pull/78#issuecomment-745229594
+                # PATHs with missing entries 'C:\Windows;;C:\Program Files' needs to be handled.
+                if ([String]::IsNullOrWhiteSpace($_)) {
+                    return $false
+                }
                 $facterPath = Join-Path -Path $_ -ChildPath facter.exe
                 Test-Path -LiteralPath $facterPath
             } | Select-Object -First 1

--- a/tests/integration/targets/win_setup/tasks/main.yml
+++ b/tests/integration/targets/win_setup/tasks/main.yml
@@ -161,3 +161,16 @@
     - setup_result.ansible_facts.ansible_my_facts.my_complex_custom_fact == {'hello':'world'}
     - setup_result.ansible_facts.ansible_my_facts.my_custom_fact == 'value'
     - setup_result.ansible_facts.ansible_other_facts == ['abc', 'def']
+
+# https://github.com/ansible-collections/ansible.windows/pull/78#issuecomment-745229594
+- name: check for facter with custom PATH
+  setup:
+    gather_subset: facter
+  register: faulty_path
+  environment:
+    PATH: '{{ ansible_env.Path }};;C:\Test'
+
+- name: make sure there were no warnings
+  assert:
+    that:
+    - fault_path.warnings | default([]) | length == 0


### PR DESCRIPTION
##### SUMMARY
When scaning the `PATH` env var we need to skip blank entries as it causes a binding issue when joining to `Join-Path -Path`.

Fixes https://github.com/ansible-collections/ansible.windows/pull/78#issuecomment-745229594

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup