### PR TITLE
update documment for category_names

### DIFF
--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -28,7 +28,7 @@ options:
           be the full category string, but is case insensitive.
         - Some possible categories are Application, Connectors, Critical Updates,
           Definition Updates, Developer Kits, Feature Packs, Guidance, Security
-          Updates, Service Packs, Tools, Update Rollups and Updates.
+          Updates, Service Packs, Tools, Update Rollups, Updates, and Upgrades.
         type: list
         default: [ CriticalUpdates, SecurityUpdates, UpdateRollups ]
     reboot:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added "Upgrades" to the category name
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_updates
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
During the Windows 10 update, I noticed that some patches could not be applied.
The following 12 categories are picked up as the main categories in the document.
(Application, Connectors, Critical Updates, Definition Updates, Developer Kits, Feature Packs, Guidance, Security Updates, Service Packs, Tools, Update Rollups and Updates.)

However, the following patches only exist in the "Upgrades" category.

```json
"fbcf5b50-4e5f-4be7-9c72-e9d505860d10": {
    "categories": [
        "Upgrades"
    ],
    "filtered_reason": "category_names",
    "id": "fbcf5b50-4e5f-4be7-9c72-e9d505860d10",
    "installed": false,
    "kb": [
        "4592449"
    ]
```
I suggest that anyone who browses the documentation can apply all patches.
<!--- Paste verbatim command output below, e.g. before and after your change -->
