### PR TITLE
win_shell_module: fixed the typo 'comand' in examples

### DIFF
--- a/docs/ansible.windows.win_shell_module.rst
+++ b/docs/ansible.windows.win_shell_module.rst
@@ -199,7 +199,7 @@ Examples
 
 .. code-block:: yaml
 
-    - name: Execute a comand in the remote shell, stdout goes to the specified file on the remote
+    - name: Execute a command in the remote shell, stdout goes to the specified file on the remote
       ansible.windows.win_shell: C:\somescript.ps1 >> C:\somelog.txt
 
     - name: Change the working directory to somedir/ before executing the command


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Type within Examples: 'comand' to 'command'
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_shell

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
