### PR TITLE
setup - added more virtualization types

### DIFF
--- a/changelogs/fragments/setup-virtual.yml
+++ b/changelogs/fragments/setup-virtual.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- setup - Added more virtualization types to the virtual facts based on the Linux setup module

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -1003,7 +1003,7 @@ $factMeta = @(
                 'Hyper-V' = @('Virtual Machine')
                 VirtualBox = @('VirtualBox')
             }
-            foreach ($modelInfo in $moduleMap.GetEnumerator()) {
+            foreach ($modelInfo in $modelMap.GetEnumerator()) {
                 if ($bios.Model -in $modelInfo.Value) {
                     $ansibleFacts.ansible_virtualization_role = 'guest'
                     $ansibleFacts.ansible_virtualization_type = $modelInfo.Key


### PR DESCRIPTION
##### SUMMARY
While not as complex as `module_utils/facts/virtual/linux.py` used by the Python setup module this PR adds a few more virtualization types based on the code there.

Fixes https://github.com/ansible-collections/ansible.windows/issues/171

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
setup