### PR TITLE
win_package - fix failure on creates_version

### DIFF
--- a/changelogs/fragments/win_package-creates-version.yml
+++ b/changelogs/fragments/win_package-creates-version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_package - treat a missing ``creates_path`` when ``creates_version`` as though the package was not installed instead of a failure - https://github.com/ansible-collections/ansible.windows/issues/169

--- a/plugins/modules/win_package.ps1
+++ b/plugins/modules/win_package.ps1
@@ -599,7 +599,7 @@ Function Get-InstalledStatus {
         $exists = Test-Path -LiteralPath $CreatesPath
         $status.Installed = $exists
 
-        if ($CreatesVersion) {
+        if ($CreatesVersion -and $exists) {
             if (Test-Path -LiteralPath $CreatesPath -PathType Leaf) {
                 $versionRaw = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($CreatesPath)
                 $existingVersion = New-Object -TypeName System.Version -ArgumentList @(

--- a/tests/integration/targets/win_package/tasks/registry_tests.yml
+++ b/tests/integration/targets/win_package/tasks/registry_tests.yml
@@ -364,6 +364,31 @@
     - not creates_path_present is changed
     - not creates_version_present is changed
 
+- name: test creates_version missing path
+  win_package:
+    path: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+    arguments: echo hi
+    creates_path: C:\missing\file.txt
+    creates_version: 1.0.0
+    state: present
+  register: creates_version_missing_path
+
+- name: assert test creates_version missing path
+  assert:
+    that:
+    - creates_version_missing_path is changed
+
+- name: test creates_version failure on dir
+  win_package:
+    path: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe
+    arguments: echo hi
+    creates_path: C:\Windows
+    creates_version: 1.0.0
+    state: present
+  register: creates_version_fail_dir
+  failed_when:
+    - '"creates_path must be a file not a directory when creates_version is set" not in creates_version_fail_dir.msg'
+
 - name: test creates_service overrides product_id
   win_package:
     path: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe


### PR DESCRIPTION
##### SUMMARY
If `creates_version` was set then the code was set to fail when `creates_path` was non-existent. Instead we should only be failing if `creates_path` is the path to a directory, if it doesn't exist then we consider the package to not be installed.

Fixes https://github.com/ansible-collections/ansible.windows/issues/169

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_package