### PR TITLE
win_package - fix msi product code check

### DIFF
--- a/changelogs/fragments/win_package-msi-code.yml
+++ b/changelogs/fragments/win_package-msi-code.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_package - fix msi detection when the msi product is already installed under a different version - https://github.com/ansible-collections/ansible.windows/issues/166


### PR DESCRIPTION
##### SUMMARY
Make sure we ignore the machine state when trying to open an msi. This allows us to get the product code even if it's already been installed under a different package.

Fixes https://github.com/ansible-collections/ansible.windows/issues/166

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_package