### PR TITLE
win_powershell - Added module for executing powershell scripts

### DIFF
--- a/plugins/module_utils/Process.cs
+++ b/plugins/module_utils/Process.cs
@@ -432,15 +432,18 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
 
             // $null from PowerShell ends up as an empty string, we need to convert back as an empty string doesn't
             // make sense for these parameters
-            if (applicationName == "")
+            if (String.IsNullOrWhiteSpace(applicationName))
                 applicationName = null;
 
-            if (currentDirectory == "")
+            if (String.IsNullOrWhiteSpace(currentDirectory))
                 currentDirectory = null;
 
             NativeHelpers.STARTUPINFOEX si = new NativeHelpers.STARTUPINFOEX();
-            si.startupInfo.lpDesktop = startupInfo.Desktop;
-            si.startupInfo.lpTitle = startupInfo.Title;
+            if (!String.IsNullOrWhiteSpace(startupInfo.Desktop))
+                si.startupInfo.lpDesktop = startupInfo.Desktop;
+
+            if (!String.IsNullOrWhiteSpace(startupInfo.Title))
+                si.startupInfo.lpTitle = startupInfo.Title;
 
             bool useStdHandles = false;
             if (startupInfo.StandardInput != null)

--- a/plugins/module_utils/Process.cs
+++ b/plugins/module_utils/Process.cs
@@ -1,6 +1,7 @@
 using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.ConstrainedExecution;
@@ -8,8 +9,11 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 
+//TypeAccelerator -Name Ansible.Windows.Process.ProcessInformation -TypeName ProcessInformation
 //TypeAccelerator -Name Ansible.Windows.Process.ProcessUtil -TypeName ProcessUtil
 //TypeAccelerator -Name Ansible.Windows.Process.Result -TypeName Result
+//TypeAccelerator -Name Ansible.Windows.Process.SecurityAttributes -TypeName SecurityAttributes
+//TypeAccelerator -Name Ansible.Windows.Process.StartupInfo -TypeName StartupInfo
 
 namespace ansible_collections.ansible.windows.plugins.module_utils.Process
 {
@@ -35,7 +39,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
         }
 
         [StructLayout(LayoutKind.Sequential)]
-        public class STARTUPINFO
+        public class STARTUPINFOW
         {
             public UInt32 cb;
             public IntPtr lpReserved;
@@ -52,10 +56,11 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
             public UInt16 wShowWindow;
             public UInt16 cbReserved2;
             public IntPtr lpReserved2;
-            public SafeFileHandle hStdInput;
-            public SafeFileHandle hStdOutput;
-            public SafeFileHandle hStdError;
-            public STARTUPINFO()
+            public SafeHandle hStdInput;
+            public SafeHandle hStdOutput;
+            public SafeHandle hStdError;
+
+            public STARTUPINFOW()
             {
                 cb = (UInt32)Marshal.SizeOf(this);
             }
@@ -64,11 +69,11 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
         [StructLayout(LayoutKind.Sequential)]
         public class STARTUPINFOEX
         {
-            public STARTUPINFO startupInfo;
+            public STARTUPINFOW startupInfo;
             public IntPtr lpAttributeList;
             public STARTUPINFOEX()
             {
-                startupInfo = new STARTUPINFO();
+                startupInfo = new STARTUPINFOW();
                 startupInfo.cb = (UInt32)Marshal.SizeOf(this);
             }
         }
@@ -88,18 +93,10 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
         }
 
         [Flags]
-        public enum ProcessCreationFlags : uint
-        {
-            CREATE_SUSPENDED = 0x00000004,
-            CREATE_NEW_CONSOLE = 0x00000010,
-            CREATE_UNICODE_ENVIRONMENT = 0x00000400,
-            EXTENDED_STARTUPINFO_PRESENT = 0x00080000
-        }
-
-        [Flags]
         public enum StartupInfoFlags : uint
         {
-            USESTDHANDLES = 0x00000100
+            STARTF_USESHOWWINDOW = 0x00000001,
+            USESTDHANDLES = 0x00000100,
         }
 
         [Flags]
@@ -152,10 +149,10 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
         public static extern bool CreateProcessW(
             [MarshalAs(UnmanagedType.LPWStr)] string lpApplicationName,
             StringBuilder lpCommandLine,
-            IntPtr lpProcessAttributes,
-            IntPtr lpThreadAttributes,
+            SafeMemoryBuffer lpProcessAttributes,
+            SafeMemoryBuffer lpThreadAttributes,
             bool bInheritHandles,
-            NativeHelpers.ProcessCreationFlags dwCreationFlags,
+            ProcessCreationFlags dwCreationFlags,
             SafeMemoryBuffer lpEnvironment,
             [MarshalAs(UnmanagedType.LPWStr)] string lpCurrentDirectory,
             NativeHelpers.STARTUPINFOEX lpStartupInfo,
@@ -231,7 +228,43 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
         }
     }
 
-    internal class SafeNativeHandle : SafeHandleZeroOrMinusOneIsInvalid
+    [Flags]
+    public enum ProcessCreationFlags : uint
+    {
+        DebugProcess = 0x00000001,
+        DebugOnlyThisProcess = 0x00000002,
+        CreateSuspended = 0x00000004,
+        DetachedProcess = 0x00000008,
+        CreateNewConsole = 0x00000010,
+        NormalPriorityClass = 0x00000020,
+        IdlePriorityClass = 0x00000040,
+        HighPriorityClass = 0x00000080,
+        RealtimePriorityClass = 0x00000100,
+        CreateNewProcessGroup = 0x00000200,
+        CreateUnicodeEnvironment = 0x00000400,
+        CreateSeparateWowVdm = 0x00000800,
+        CreateSharedWowVdm = 0x00001000,
+        CreateForceDos = 0x00002000,
+        BelowNormalPriorityClass = 0x00004000,
+        AboveNormalPriorityClass = 0x00008000,
+        InheritParentAffinity = 0x00010000,
+        InheritCallerPriority = 0x00020000,
+        CreateProctectedProcess = 0x00040000,
+        ExtendedStartupInfoPresent = 0x00080000,
+        ProcessModeBackgroundBegin = 0x00100000,
+        ProcessModeBackgroundEnd = 0x00200000,
+        CreateSecureProcess = 0x00400000,
+        CreateBreakawayFromJob = 0x01000000,
+        CreatePreserveCodeAuthzLevel = 0x02000000,
+        CreateDefaultErrorMode = 0x04000000,
+        CreateNoWindow = 0x08000000,
+        ProfileUser = 0x10000000,
+        ProfileKernel = 0x20000000,
+        ProfileServer = 0x40000000,
+        CreateIgnoreSystemDefault = 0x80000000,
+    }
+
+    public class SafeNativeHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         public SafeNativeHandle() : base(true) { }
         public SafeNativeHandle(IntPtr handle) : base(true) { this.handle = handle; }
@@ -264,6 +297,45 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
         public uint ExitCode { get; internal set; }
     }
 
+    public class ProcessInformation : IDisposable
+    {
+        public SafeNativeHandle Process { get; internal set; }
+        public SafeNativeHandle Thread { get; internal set; }
+        public int ProcessId { get; internal set; }
+        public int ThreadId { get; internal set; }
+
+        public void Dispose()
+        {
+            if (Process != null)
+                Process.Dispose();
+
+            if (Thread != null)
+                Thread.Dispose();
+
+            GC.SuppressFinalize(this);
+        }
+        ~ProcessInformation() { Dispose(); }
+    }
+
+    public class SecurityAttributes
+    {
+        public bool InheritHandle { get; set; }
+        // TODO: Support SecurityDescriptor at some point.
+        // Should it use RawSecurityDescriptor or create a Process SD class that inherits NativeObjectSecurity?
+    }
+
+    public class StartupInfo
+    {
+        public string Desktop { get; set; }
+        public string Title { get; set; }
+        public ProcessWindowStyle? WindowStyle { get; set; }
+        public SafeHandle StandardInput { get; set; }
+        public SafeHandle StandardOutput { get; set; }
+        public SafeHandle StandardError { get; set; }
+
+        // TODO: Support PROC_THREAD_ATTRIBUTE_HANDLE_LIST
+    }
+
     public class ProcessUtil
     {
         /// <summary>
@@ -285,7 +357,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
         }
 
         /// <summary>
-        /// Creates a process based on the CreateProcess API call.
+        /// Creates a process based on the CreateProcess API call and wait for it to complete.
         /// </summary>
         /// <param name="lpApplicationName">The name of the executable or batch file to execute</param>
         /// <param name="lpCommandLine">The command line to execute, typically this includes lpApplication as the first argument</param>
@@ -298,60 +370,158 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
         public static Result CreateProcess(string lpApplicationName, string lpCommandLine, string lpCurrentDirectory,
             IDictionary environment, byte[] stdin, string outputEncoding, bool waitChildren)
         {
-            NativeHelpers.ProcessCreationFlags creationFlags = NativeHelpers.ProcessCreationFlags.CREATE_SUSPENDED |
-                NativeHelpers.ProcessCreationFlags.CREATE_UNICODE_ENVIRONMENT | 
-                NativeHelpers.ProcessCreationFlags.EXTENDED_STARTUPINFO_PRESENT;
-            NativeHelpers.PROCESS_INFORMATION pi = new NativeHelpers.PROCESS_INFORMATION();
-            NativeHelpers.STARTUPINFOEX si = new NativeHelpers.STARTUPINFOEX();
-            si.startupInfo.dwFlags = NativeHelpers.StartupInfoFlags.USESTDHANDLES;
+            ProcessCreationFlags creationFlags = ProcessCreationFlags.CreateSuspended |
+                ProcessCreationFlags.CreateUnicodeEnvironment;
+            StartupInfo si = new StartupInfo();
+            ProcessInformation pi = null;
 
             SafeFileHandle stdoutRead, stdoutWrite, stderrRead, stderrWrite, stdinRead, stdinWrite;
             CreateStdioPipes(si, out stdoutRead, out stdoutWrite, out stderrRead, out stderrWrite, out stdinRead,
                 out stdinWrite);
             FileStream stdinStream = new FileStream(stdinWrite, FileAccess.Write);
 
+            bool isConsole = false;
+            if (NativeMethods.GetConsoleWindow() == IntPtr.Zero)
+            {
+                isConsole = NativeMethods.AllocConsole();
+
+                // Set console input/output codepage to UTF-8
+                NativeMethods.SetConsoleCP(65001);
+                NativeMethods.SetConsoleOutputCP(65001);
+            }
+
+            try
+            {
+                pi = NativeCreateProcess(lpApplicationName, lpCommandLine, null, null, true, creationFlags,
+                    environment, lpCurrentDirectory, si);
+            }
+            finally
+            {
+                if (isConsole)
+                    NativeMethods.FreeConsole();
+            }
+
+            using (pi)
+            {
+                return WaitProcess(stdoutRead, stdoutWrite, stderrRead, stderrWrite, stdinStream, stdin, pi,
+                    outputEncoding, waitChildren);
+            }
+        }
+
+        /// <summary>
+        /// Wrapper around the Win32 CreateProcess API for low level use. This just spawns the new process and does not
+        /// wait until it is complete before returning.
+        /// </summary>
+        /// <param name="applicationName">The name of the executable or batch file to execute</param>
+        /// <param name="commandLine">The command line to execute, typically this includes applicationName as the first argument</param>
+        /// <param name="processAttributes">SecurityAttributes to assign to the new process, set to null to use the defaults</param>
+        /// <param name="threadAttributes">SecurityAttributes to assign to the new thread, set to null to use the defaults</param>
+        /// <param name="inheritHandles">Any inheritable handles in the calling process is inherited in the new process</param>
+        /// <param name="creationFlags">Custom creation flags to use when creating the new process</param>
+        /// <param name="environment">A dictionary of key/value pairs to define the new process environment</param>
+        /// <param name="currentDirectory">The full path to the current directory for the process, null will have the same cwd as the calling process</param>
+        /// <param name="startupInfo">Custom StartupInformation to use when creating the new process</param>
+        /// <returns>ProcessInformation containing a handle to the process and main thread as well as the pid/tid.</returns>
+        public static ProcessInformation NativeCreateProcess(string applicationName, string commandLine,
+            SecurityAttributes processAttributes, SecurityAttributes threadAttributes, bool inheritHandles,
+            ProcessCreationFlags creationFlags, IDictionary environment, string currentDirectory, StartupInfo startupInfo)
+        {
+            // We always have the extended version present.
+            creationFlags |= ProcessCreationFlags.ExtendedStartupInfoPresent;
+
             // $null from PowerShell ends up as an empty string, we need to convert back as an empty string doesn't
             // make sense for these parameters
-            if (lpApplicationName == "")
-                lpApplicationName = null;
+            if (applicationName == "")
+                applicationName = null;
 
-            if (lpCurrentDirectory == "")
-                lpCurrentDirectory = null;
+            if (currentDirectory == "")
+                currentDirectory = null;
 
+            NativeHelpers.STARTUPINFOEX si = new NativeHelpers.STARTUPINFOEX();
+            si.startupInfo.lpDesktop = startupInfo.Desktop;
+            si.startupInfo.lpTitle = startupInfo.Title;
+
+            bool useStdHandles = false;
+            if (startupInfo.StandardInput != null)
+            {
+                si.startupInfo.hStdInput = startupInfo.StandardInput;
+                useStdHandles = true;
+            }
+            else
+                si.startupInfo.hStdInput = new SafeNativeHandle(IntPtr.Zero);
+
+            if (startupInfo.StandardOutput != null)
+            {
+                si.startupInfo.hStdOutput = startupInfo.StandardOutput;
+                useStdHandles = true;
+            }
+            else
+                si.startupInfo.hStdOutput = new SafeNativeHandle(IntPtr.Zero);
+
+            if (startupInfo.StandardError != null)
+            {
+                si.startupInfo.hStdError = startupInfo.StandardError;
+                useStdHandles = true;
+            }
+            else
+                si.startupInfo.hStdError = new SafeNativeHandle(IntPtr.Zero);
+
+            if (useStdHandles)
+                si.startupInfo.dwFlags |= NativeHelpers.StartupInfoFlags.USESTDHANDLES;
+
+            if (startupInfo.WindowStyle != null)
+            {
+                switch (startupInfo.WindowStyle)
+                {
+                    case ProcessWindowStyle.Normal:
+                        si.startupInfo.wShowWindow = 1;  // SW_SHOWNORMAL
+                        break;
+                    case ProcessWindowStyle.Hidden:
+                        si.startupInfo.wShowWindow = 0;  // SW_HIDE
+                        break;
+                    case ProcessWindowStyle.Minimized:
+                        si.startupInfo.wShowWindow = 6;  // SW_MINIMIZE
+                        break;
+                    case ProcessWindowStyle.Maximized:
+                        si.startupInfo.wShowWindow = 3;  // SW_MAXIMIZE
+                        break;
+                }
+                si.startupInfo.dwFlags |= NativeHelpers.StartupInfoFlags.STARTF_USESHOWWINDOW;
+            }
+
+            NativeHelpers.PROCESS_INFORMATION pi = new NativeHelpers.PROCESS_INFORMATION();
+            using (SafeMemoryBuffer lpProcessAttr = CreateSecurityAttributes(processAttributes))
+            using (SafeMemoryBuffer lpThreadAttributes = CreateSecurityAttributes(threadAttributes))
             using (SafeMemoryBuffer lpEnvironment = CreateEnvironmentPointer(environment))
             {
-                // Create console with utf-8 CP if no existing console is present
-                bool isConsole = false;
-                if (NativeMethods.GetConsoleWindow() == IntPtr.Zero)
+                StringBuilder commandLineBuff = new StringBuilder(commandLine);
+                if (!NativeMethods.CreateProcessW(applicationName, commandLineBuff, lpProcessAttr, lpThreadAttributes,
+                    inheritHandles, creationFlags, lpEnvironment, currentDirectory, si, out pi))
                 {
-                    isConsole = NativeMethods.AllocConsole();
-
-                    // Set console input/output codepage to UTF-8
-                    NativeMethods.SetConsoleCP(65001);
-                    NativeMethods.SetConsoleOutputCP(65001);
-                }
-
-                try
-                {
-                    StringBuilder commandLine = new StringBuilder(lpCommandLine);
-                    if (!NativeMethods.CreateProcessW(lpApplicationName, commandLine, IntPtr.Zero, IntPtr.Zero,
-                        true, creationFlags, lpEnvironment, lpCurrentDirectory, si, out pi))
-                    {
-                        throw new Win32Exception("CreateProcessW() failed");
-                    }
-                }
-                finally
-                {
-                    if (isConsole)
-                        NativeMethods.FreeConsole();
+                    throw new Win32Exception("CreateProcessW() failed");
                 }
             }
 
-            return WaitProcess(stdoutRead, stdoutWrite, stderrRead, stderrWrite, stdinStream, stdin, pi,
-                outputEncoding, waitChildren);
+            return new ProcessInformation
+            {
+                Process = new SafeNativeHandle(pi.hProcess),
+                Thread = new SafeNativeHandle(pi.hThread),
+                ProcessId = pi.dwProcessId,
+                ThreadId = pi.dwThreadId,
+            };
         }
 
-        internal static void CreateStdioPipes(NativeHelpers.STARTUPINFOEX si, out SafeFileHandle stdoutRead,
+        /// <summary>
+        /// Resume a suspended thread.
+        /// </summary>
+        /// <param name="thread">The thread handle to resume</param>
+        public static void ResumeThread(SafeHandle thread)
+        {
+            if (NativeMethods.ResumeThread(thread.DangerousGetHandle()) == 0xFFFFFFFF)
+                throw new Win32Exception("ResumeThread() failed");
+        }
+
+        internal static void CreateStdioPipes(StartupInfo si, out SafeFileHandle stdoutRead,
             out SafeFileHandle stdoutWrite, out SafeFileHandle stderrRead, out SafeFileHandle stderrWrite,
             out SafeFileHandle stdinRead, out SafeFileHandle stdinWrite)
         {
@@ -373,9 +543,9 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
             if (!NativeMethods.SetHandleInformation(stdinWrite, NativeHelpers.HandleFlags.INHERIT, 0))
                 throw new Win32Exception("STDIN pipe handle setup failed");
 
-            si.startupInfo.hStdOutput = stdoutWrite;
-            si.startupInfo.hStdError = stderrWrite;
-            si.startupInfo.hStdInput = stdinRead;
+            si.StandardOutput = stdoutWrite;
+            si.StandardError = stderrWrite;
+            si.StandardInput = stdinRead;
         }
 
         internal static SafeMemoryBuffer CreateEnvironmentPointer(IDictionary environment)
@@ -393,8 +563,25 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
             return new SafeMemoryBuffer(lpEnvironment);
         }
 
+        internal static SafeMemoryBuffer CreateSecurityAttributes(SecurityAttributes attributes)
+        {
+            IntPtr lpAttributes = IntPtr.Zero;
+            if (attributes != null)
+            {
+                NativeHelpers.SECURITY_ATTRIBUTES attr = new NativeHelpers.SECURITY_ATTRIBUTES()
+                {
+                    bInheritHandle = attributes.InheritHandle,
+                };
+
+                lpAttributes = Marshal.AllocHGlobal(Marshal.SizeOf(attr));
+                Marshal.StructureToPtr(attr, lpAttributes, false);
+            }
+
+            return new SafeMemoryBuffer(lpAttributes);
+        }
+
         internal static Result WaitProcess(SafeFileHandle stdoutRead, SafeFileHandle stdoutWrite, SafeFileHandle stderrRead,
-            SafeFileHandle stderrWrite, FileStream stdinStream, byte[] stdin, NativeHelpers.PROCESS_INFORMATION pi,
+            SafeFileHandle stderrWrite, FileStream stdinStream, byte[] stdin, ProcessInformation pi,
             string outputEncoding, bool waitChildren)
         {
             // Default to using UTF-8 as the output encoding, this should be a sane default for most scenarios.
@@ -431,12 +618,12 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
 
                     // Server 2012/Win 8 introduced the ability to nest jobs. Older versions will fail with
                     // ERROR_ACCESS_DENIED but we can't do anything about that except not wait for children.
-                    if (!NativeMethods.AssignProcessToJobObject(job, pi.hProcess))
+                    if (!NativeMethods.AssignProcessToJobObject(job, pi.Process.DangerousGetHandle()))
                         throw new Win32Exception("Failed to assign new process to completion watcher job");
                 }
 
                 // Start the process and get the output.
-                NativeMethods.ResumeThread(pi.hThread);
+                ResumeThread(pi.Thread);
 
                 FileStream stdoutFS = new FileStream(stdoutRead, FileAccess.Read, 4096);
                 StreamReader stdout = new StreamReader(stdoutFS, encodingInstance, true, 4096);
@@ -452,7 +639,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
 
                 string stdoutStr, stderrStr = null;
                 GetProcessOutput(stdout, stderr, out stdoutStr, out stderrStr);
-                UInt32 rc = GetProcessExitCode(pi.hProcess);
+                UInt32 rc = GetProcessExitCode(pi.Process.DangerousGetHandle());
 
                 if (waitChildren)
                 {

--- a/plugins/module_utils/Process.cs
+++ b/plugins/module_utils/Process.cs
@@ -231,6 +231,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
     [Flags]
     public enum ProcessCreationFlags : uint
     {
+        None = 0x00000000,
         DebugProcess = 0x00000001,
         DebugOnlyThisProcess = 0x00000002,
         CreateSuspended = 0x00000004,

--- a/plugins/module_utils/Process.psm1
+++ b/plugins/module_utils/Process.psm1
@@ -240,6 +240,6 @@ Function Start-AnsibleWindowsProcess {
 }
 
 $export_members = @{
-    Function = 'ConvertFrom-EscapedArgument', 'ConvertTo-EscapedArgument', 'Start-AnsibleWindowsProcess'
+    Function = 'ConvertFrom-EscapedArgument', 'ConvertTo-EscapedArgument', 'Resolve-ExecutablePath', 'Start-AnsibleWindowsProcess'
 }
 Export-ModuleMember @export_members

--- a/plugins/modules/win_powershell.ps1
+++ b/plugins/modules/win_powershell.ps1
@@ -746,13 +746,16 @@ $module.Result.error = @($ps.Streams.Error | ForEach-Object -Process {
 }
 
 # Use Select-Object as Information may not be present on earlier pwsh version (<v5).
-$module.Result.information = @($ps.Streams | Select-Object -ExpandProperty Information | ForEach-Object -Process {
-    @{
-        message_data = Convert-OutputObject -InputObject $_.MessageData -Depth $module.Params.depth
-        source = $_.Source
-        time_generated = $_.TimeGenerated.ToUniversalTime().ToString('o')
-        tags = @($_.Tags)
+$module.Result.information = @($ps.Streams |
+    Select-Object -ExpandProperty Information -ErrorAction SilentlyContinue |
+    ForEach-Object -Process {
+        @{
+            message_data = Convert-OutputObject -InputObject $_.MessageData -Depth $module.Params.depth
+            source = $_.Source
+            time_generated = $_.TimeGenerated.ToUniversalTime().ToString('o')
+            tags = @($_.Tags)
+        }
     }
-})
+)
 
 $module.ExitJson()

--- a/plugins/modules/win_powershell.ps1
+++ b/plugins/modules/win_powershell.ps1
@@ -1,0 +1,383 @@
+#!powershell
+
+# Copyright: (c) 2021, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    options = @{
+        arguments = @{ type = 'list'; elements = 'str' }
+        creates = @{ type = 'path' }
+        executable = @{ type = 'str' }
+        input = @{ type = 'list' }
+        location = @{ type = 'str' }
+        parameters = @{ type = 'dict' }
+        removes = @{ type = 'path' }
+        script = @{ type = 'str'; required = $true }
+    }
+    supports_check_mode = $true
+}
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$module.Result.result = @{}
+$module.Result.host_out = ''
+$module.Result.host_err = ''
+$module.Result.output = @()
+$module.Result.error = @()
+$module.Result.warning = @()
+$module.Result.verbose = @()
+$module.Result.debug = @()
+$module.Result.information = @()
+
+Add-CSharpType -AnsibleModule $module -References @'
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Management.Automation;
+using System.Management.Automation.Host;
+using System.Security;
+
+namespace Ansible.Windows.WinPowerShell
+{
+    public class Host : PSHost
+    {
+        private readonly PSHost PSHost;
+        private readonly HostUI HostUI;
+
+        public Host(PSHost host){
+            PSHost = host;
+            HostUI = new HostUI();
+        }
+
+        public override CultureInfo CurrentCulture { get { return PSHost.CurrentCulture; } }
+
+        public override CultureInfo CurrentUICulture { get {  return PSHost.CurrentUICulture; } }
+
+        public override Guid InstanceId { get {  return PSHost.InstanceId; } }
+
+        public override string Name { get { return PSHost.Name; } }
+
+        public override PSHostUserInterface UI { get {  return HostUI; } }
+
+        public override Version Version { get {  return PSHost.Version; } }
+
+        public override void EnterNestedPrompt()
+        {
+            PSHost.EnterNestedPrompt();
+        }
+
+        public override void ExitNestedPrompt()
+        {
+            PSHost.ExitNestedPrompt();
+        }
+
+        public override void NotifyBeginApplication()
+        {
+            PSHost.NotifyBeginApplication();
+        }
+
+        public override void NotifyEndApplication()
+        {
+            PSHost.NotifyEndApplication();
+        }
+
+        public override void SetShouldExit(int exitCode)
+        {
+            PSHost.SetShouldExit(exitCode);
+        }
+    }
+
+    public class HostUI : PSHostUserInterface
+    {
+        public HostUI() {}
+
+        public override PSHostRawUserInterface RawUI { get { return null; } }
+
+        public override Dictionary<string, PSObject> Prompt(string caption, string message, Collection<FieldDescription> descriptions)
+        {
+            throw new MethodInvocationException("PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.");
+        }
+
+        public override int PromptForChoice(string caption, string message, Collection<ChoiceDescription> choices, int defaultChoice)
+        {
+            throw new MethodInvocationException("PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.");
+        }
+
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName, PSCredentialTypes allowedCredentialTypes, PSCredentialUIOptions options)
+        {
+            throw new MethodInvocationException("PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.");
+        }
+
+        public override PSCredential PromptForCredential(string caption, string message, string userName, string targetName)
+        {
+            throw new MethodInvocationException("PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.");
+        }
+
+        public override string ReadLine()
+        {
+            throw new MethodInvocationException("PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.");
+        }
+
+        public override SecureString ReadLineAsSecureString()
+        {
+            throw new MethodInvocationException("PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.");
+        }
+
+        public override void Write(ConsoleColor foregroundColor, ConsoleColor backgroundColor, string value)
+        {
+            Console.Write(value);
+        }
+
+        public override void Write(string value)
+        {
+            Console.Write(value);
+        }
+
+        public override void WriteDebugLine(string message)
+        {
+            Console.WriteLine(String.Format("DEBUG: {0}", message));
+        }
+
+        public override void WriteErrorLine(string value)
+        {
+            Console.Error.WriteLine(value);
+        }
+
+        public override void WriteLine(string value)
+        {
+            Console.WriteLine(value);
+        }
+
+        public override void WriteProgress(long sourceId, ProgressRecord record) {}
+
+        public override void WriteVerboseLine(string message)
+        {
+            Console.WriteLine(String.Format("VERBOSE: {0}", message));
+        }
+
+        public override void WriteWarningLine(string message)
+        {
+            Console.WriteLine(String.Format("WARNING: {0}", message));
+        }
+    }
+}
+'@
+
+Function Format-Exception {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory=$true)]
+        [AllowNull()]
+        $Exception
+    )
+
+    if (-not $Exception) {
+        return $null
+    }
+    elseif ($Exception -is [Management.Automation.RemoteException]) {
+        # When using a separate process the exceptions are a RemoteException, we want to get the info on the actual
+        # exception.
+        return Format-Exception -Exception $Exception.SerializedRemoteException
+    }
+
+    $type = if ($Exception -is [Exception]) {
+        $Exception.GetType().FullName
+    }
+    else {
+        # This is a RemoteException, we want to report the original non-serialized type.
+        $Exception.PSTypeNames[0] -replace '^Deserialized.'
+    }
+
+    @{
+        message = $Exception.Message
+        type = $type
+        help_link = $Exception.HelpLink
+        source = $Exception.Source
+        hresult = $Exception.HResult
+        inner_exception = Format-Exception -Exception $Exception.InnerException
+    }
+}
+
+Function Test-AnsiblePath {
+    [CmdletBinding()]
+    Param(
+        [Parameter(Mandatory=$true)]
+        [String]
+        $Path
+    )
+
+    try {
+        $attributes = [System.IO.File]::GetAttributes($Path)
+    } catch [System.IO.FileNotFoundException], [System.IO.DirectoryNotFoundException] {
+        return $false
+    } catch [NotSupportedException] {
+        # When testing a path like Cert:\LocalMachine\My, System.IO.File will
+        # not work, we just revert back to using Test-Path for this
+        return Test-Path -Path $Path
+    }
+
+    if ([Int32]$attributes -eq -1) {
+        return $false
+    } else {
+        return $true
+    }
+}
+
+$creates = $module.Params.creates
+if ($creates -and (Test-AnsiblePath -Path $creates)) {
+    $module.Result.msg = "skipped, since $creates exists"
+    $module.ExitJson()
+}
+
+$removes = $module.Params.removes
+if ($removes -and -not (Test-AnsiblePath -Path $removes)) {
+    $module.Result.msg = "skipped, since $removes does not exist"
+    $module.ExitJson()
+}
+
+if ($module.CheckMode) {
+    $module.Result.changed = $true
+    $module.Result.msg = "skipped, running in check mode"
+    $module.ExitJson()
+}
+
+$runspace = $null
+$process = $null
+$connInfo = $null
+
+if ($module.Params.executable) {
+    # TODO: Fail if running on powershell <5. It does not support NamedPipeConnectionInfo.
+    $processParams = @{
+        FilePath = $module.Params.executable
+        WindowStyle = 'Hidden'  # Really just to help with debugging locally
+        PassThru = $true
+    }
+    if ($module.Params.arguments) {
+        $processParams.ArgumentList = $module.Params.arguments
+    }
+    $process = Start-Process @processParams
+    $connInfo = [System.Management.Automation.Runspaces.NamedPipeConnectionInfo]$process.Id
+
+    # In case a user specified an executable that does not support the PSHost named pipe that PowerShell uses we
+    # specify a timeout so the module does not hang.
+    $connInfo.OpenTimeout = 5000
+}
+
+try {
+    # Using a custom host allows us to capture any host UI calls through our own Console output.
+    $runspaceHost = New-Object -TypeName Ansible.Windows.WinPowerShell.Host -ArgumentList $Host
+    if ($connInfo) {
+        $runspace = [RunspaceFactory]::CreateRunspace($runspaceHost, $connInfo)    
+    }
+    else {
+        $runspace = [RunspaceFactory]::CreateRunspace($runspaceHost)
+    }
+
+    $runspace.Open()
+
+    $ps = [PowerShell]::Create()
+    $ps.Runspace = $runspace
+
+    # TODO: Set the location.
+
+    # TODO: Do we actually want the script to be able to set some of these values?
+    $ps.Runspace.SessionStateProxy.SetVariable('Ansible', [PSCustomObject]@{
+        Result = @{}
+        Changed = $true
+        Failed = $false
+        Tmpdir = $module.Tmpdir
+    })
+
+    [void]$ps.AddScript($module.Params.script)
+
+    if ($module.Params.parameters) {
+        [void]$ps.AddParameters($module.Params.parameters)
+    }
+
+    # We redirect the current stdout and stderr so we can capture any console output.
+    $origStdout = [System.Console]::Out
+    $origStderr = [System.Console]::Error
+    $stdoutBuffer = New-Object -TypeName System.Text.StringBuilder
+    $stderrBuffer = New-Object -TypeName System.Text.StringBuilder
+    $newStdout = New-Object -TypeName System.IO.StringWriter -ArgumentList $stdoutBuffer
+    $newStderr = New-Object -TypeName System.IO.StringWriter -ArgumentList $stderrBuffer
+
+    try {
+        [System.Console]::SetOut($newStdout)
+        [System.Console]::SetError($newStderr)
+
+        # TODO: need to test out various scenarios to see if this will ever throw an exception rather than just output
+        # to the error stream.
+        $module.Result.output = @($ps.Invoke($module.Params.input))
+    }
+    finally {
+        [System.Console]::SetOut($origStdout)
+        [System.Console]::SetError($origStderr)
+
+        $newStdout.Dispose()
+        $newStderr.Dispose()
+    }
+
+    # Get the internal Ansible variable that can contain code specific information.
+    $result = $ps.Runspace.SessionStateProxy.GetVariable('Ansible')
+
+    $module.Result.host_out = $stdoutBuffer.ToString()
+    $module.Result.host_err = $stderrBuffer.ToString()
+    $module.Result.result = $result.Result
+    $module.Result.changed = $result.Changed
+
+    # TODO: check when HadErrors is actually set and document that.
+    $module.Result.failed = $result.Failed -or $ps.HadErrors
+}
+finally {
+    if ($runspace) {
+        $runspace.Dispose()
+    }
+    if ($process) {
+        $process | Stop-Process -Force
+    }
+}
+
+$module.Result.error = @($ps.Streams.Error | ForEach-Object -Process {
+    # TODO: ErrorDetails
+    @{
+        output = ($_ | Out-String)
+        exception = Format-Exception -Exception $_.Exception
+        target_object = $_.TargetObject
+        category_info = @{
+            category = [string]$_.CategoryInfo.Category
+            category_id = [int]$_.CategoryInfo.Category
+            activity = $_.CategoryInfo.Activity
+            reason = $_.CategoryInfo.Reason
+            target_name = $_.CategoryInfo.TargetName
+            target_type = $_.CategoryInfo.TargetType
+        }
+        fully_qualified_error_id = $_.FullyQualifiedErrorId
+        script_stack_trace = $_.ScriptStackTrace
+        pipeline_iteration_info = $_.PipelineIterationInfo
+    }
+})
+
+'debug', 'verbose', 'warning' | ForEach-Object -Process {
+    $module.Result.$_ = @($ps.Streams.$_ | Select-Object -ExpandProperty Message)
+}
+
+# TODO: Will this fail on pre v5 as they don't have the Information stream.
+$module.Result.information = @($ps.Streams.Information | ForEach-Object -Process {
+    @{
+        message_data = $_.MessageData
+        source = $_.Source
+        time_generated = $_.TimeGenerated.ToUniversalTime().ToString('o')
+        tags = @($_.Tags)
+        user = $_.User
+        computer = $_.Computer
+        process_id = $_.ProcessId
+        native_thread_id = $_.NativeThreadId
+        managed_thread_id = $_.ManagedThreadId
+    }
+})
+
+$module.ExitJson()

--- a/plugins/modules/win_powershell.py
+++ b/plugins/modules/win_powershell.py
@@ -1,0 +1,385 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+DOCUMENTATION = r'''
+---
+module: win_powershell
+version_added: 1.5.0
+short_description: Run PowerShell scripts
+description:
+- Runs a PowerShell script and outputs the data in a structured format.
+- Use M(ansible.windows.win_command) or M(ansible.windows.win_shell) to run a tranditional PowerShell process with
+  stdout, stderr, and rc results.
+options:
+  arguments:
+    description:
+    - A list of arguments to pass to I(executable) when running a script in another PowerShell process.
+    type: list
+    elements: str
+  creates:
+    description:  
+    - A path or path filter pattern; when the referenced path exists on the target host, the task will be skipped.
+    type: path
+  executable:
+    description:
+    - A custom PowerShell executable to run the script in.
+    - When not defined the script will run in the current module PowerShell interpreter.
+    - Both the remote PowerShell and the one specified by I(executable) must be running on PowerShell v5.1 or newer.
+    type: str
+  input:
+    description:
+    - A list of objects to pass in as the input to the PowerShell script.
+    type: list
+  location:
+    description:
+    - The PowerShell location to set when starting the script.
+    type: path
+  parameters:
+    description:
+    - Parameters to pass into the script as key value pairs.
+    - The key corresponds to the parameter name and the value is the value for that parameter.
+    type: dict
+  removes:
+    description:
+    - A path or path filter pattern; when the referenced path B(does not) exist on the target host, the task will be
+      skipped.
+    type: path
+  script:
+    description:
+    - The PowerShell script to run.
+    type: str
+    required: true
+seealso:
+- module: ansible.windows.win_command
+- module: ansible.builtin.win_shell
+notes:
+- The output of the script is serialized to json using the C(ConvertTo-Json) cmdlet. There are certain .NET types
+  which do not serialize nicely and can cause the module to hang once it is completed. Take care when outputting any
+  objects.
+- The script has access to the C($Ansible) variable where it can set C(Result), C(Changed), C(Failed), or access
+  C(Tmpdir).
+- Any host output like C(Write-Host) or C([Console]::WriteLine) is not considered an output object.
+author:
+- Jordan Borean (@jborean93)
+'''
+
+EXAMPLES = r'''
+- name: Run basic PowerShell script
+  ansible.windows.win_powershell:
+    script: |
+      echo "Hello World"
+
+- name: Run PowerShell script with parameters
+  ansible.windows.win_powershell:
+    script: |
+      [CmdletBinding()]
+      param (
+        [String]
+        $Path,
+
+        [Switch]
+        $Force
+      )
+
+      New-Item -Path $Path -ItemType Direcotry -Force:$Force
+    parameters:
+      Path: C:\temp
+      Force: true
+
+- name: Run PowerShell script with input
+  ansible.windows.win_powershell:
+    script: |
+      [CmdletBinding()]
+      param (
+        [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
+        [String[]]
+        $Path
+      )
+
+      process {
+        foreach ($pathEntry in $Path) {
+            Test-Path -Path $pathEntry
+        }
+      }
+    input:
+    - C:\Windows
+    - HKLM:\SYSTEM
+
+- name: Run PowerShell script that modifies the module changed result
+  ansible.windows.win_powershell:
+    script: |
+      if (Get-Service -Name test -ErrorAction SilentlyContinue) {
+        Remove-Service -Name test
+      }
+      else {
+        $Ansible.Changed = $false
+      }
+
+- name: Run PowerShell script in PowerShell 7
+  ansible.windows.win_powershell:
+    script: |
+      $PSVersionTable.PSVersion.Major
+    executable: pwsh.exe
+  register: pwsh_output
+  failed_when:
+  - pwsh_output.output[0] != 7
+'''
+
+RETURN = r'''
+result:
+  description:
+  - The values that were set by C($Ansible.Result) in the script.
+  - Defaults to an empty dict but can be set to anything by the script.
+  returned: always
+  type: raw
+  sample: {'key': 'value', 'other key': 1}
+host_out:
+  description:
+  - The strings written to the host output, typically the stdout.
+  - This is not the same as objects sent to the output stream in PowerShell.
+  returned: always
+  type: str
+  sample: "Line 1\nLine 2"
+host_err:
+  description:
+  - The strings written to the host error output, typically the stderr.
+  - This is not the same as objects sent to the error stream in PowerShell.
+  returned: always
+  type: str
+  sample: "Error 1\nError 2"
+output:
+  description:
+  - A list containing all the objects outputted by the script.
+  - The list elements can be anything as it is based on what was ran.
+  returned: always
+  type: list
+  sample: ['output 1', 2, ['inner list'], {'key': 'value'}, None]
+error:
+  description:
+  - A list of error records created by the script.
+  returned: always
+  type: list
+  elements: dict
+  contains:
+    output:
+      description:
+      - The formatted error record message as typically seen in a PowerShell console.
+      type: str
+      returned: always
+      sample: |
+        Write-Error "error" : error
+            + CategoryInfo          : NotSpecified: (:) [Write-Error], WriteErrorException
+            + FullyQualifiedErrorId : Microsoft.PowerShell.Commands.WriteErrorException
+    exception:
+      description:
+      - Details about the exception behind the error record.
+      type: dict
+      contains:
+        message:
+          description:
+          - The exception message.
+          type: str
+          returned: always
+          sample: The method ran into an error
+        type:
+          description:
+          - The full .NET type of the Exception class.
+          type: str
+          returned: always
+          sample: System.Exception
+        help_link:
+          description:
+          - A link to the help details for the exception.
+          - May not be set as it's dependent on whether the .NET exception class provides this info.
+          type: str
+          returned: always
+          sample: http://docs.ansible.com/
+        source:
+          description:
+          - Name of the application or object that causes the error.
+          - This may be an empty string as it's dependent on the code that raises the exception.
+          type: str
+          returned: always
+          sample: C:\Windows
+        hresult:
+          description:
+          - The signed integer assigned to this exception.
+          - May not be set as it's dependent on whether the .NET exception class provides this info.
+          type: int
+          returned: always
+          sample: -1
+        inner_exception:
+          description:
+          - The inner exception details if there is one present.
+          - The dict contains the same keys as a normal exception.
+          returned: always
+          type: dict
+    target_object:
+      description:
+      - The object which the error occured.
+      - May be null if no object was specified when the record was created.
+      type: str
+      returned: always
+      sample: C:\Windows
+    category_info:
+      description:
+      - More information about the error record.
+      type: dict
+      contains:
+        category:
+          description:
+          - The category name of the error record.
+          type: str
+          returned: always
+          sample: NotSpecified
+        category_id:
+          description:
+          - The integer representation of the category.
+          type: int
+          returned: always
+          sample: 0
+        activity:
+          description:
+          - Description of the operation which encountered the error.
+          type: str
+          returned: always
+          sample: Write-Error
+        reason:
+          description:
+          - Description of the error.
+          type: str
+          returned: always
+          sample: WriteErrorException
+        target_name:
+          description:
+          - Description of the target object.
+          - Can be an empty string if no target was specified.
+          type: str
+          returned: always
+          sample: C:\Windows
+        target_type:
+          description:
+          - Description of the type of the target object.
+          - Can be an empty string if no target object was specified.
+          type: str
+          returned: always
+          sample: String
+    fully_qualified_error_id:
+      description:
+      - The unique identifier for the error condition
+      - May be null if no id was specified when the record was created.
+      type: str
+      returned: always
+      sample: ParameterBindingFailed
+    script_stack_trace:
+      description:
+      - The script stack trace for the error record.
+      type: str
+      returned: always
+      sample: at <ScriptBlock>, <No file>: line 1
+    pipeline_iteration_info:
+      description:
+      - The status of the pipeline when this record was created.
+      - The values are 0 index based.
+      - Each element entry represents the command index in a pipeline statement.
+      - The value of each element represents the pipeline input idx in that command.
+      - For Example C('C:\Windows', 'C:\temp' | Get-ChildItem | Get-Item), C([1, 2, 9]) represents an error occured
+        with the 2nd output, 3rd, and 9th output of the 1st, 2nd, and 3rd command in that pipeline respectively.
+      type: list
+      elements: int
+      returned: always
+      sample: [0, 0]
+warning:
+  description:
+  - A list of warning messages created by the script.
+  - TODO: Document $WarningPreference and how it affects this
+  returned: always
+  type: list
+  elements: str
+  sample: ['warning record']
+verbose:
+  description:
+  - A list of warning messages created by the script.
+  - TODO: Document $VerbosePreference and how it affects this
+  returned: always
+  type: list
+  elements: str
+  sample: ['verbose record']
+debug:
+  description:
+  - A list of warning messages created by the script.
+  - TODO: Document $DebugPreference and how it affects this
+  returned: always
+  type: list
+  elements: str
+  sample: ['debug record']
+information:
+  description:
+  - A list of information records created by the script.
+  - The information stream was only added in PowerShell v5, older versions will always have an empty list as a value.
+  returned: always
+  type: list
+  elements: dict
+  contains:
+    message_data:
+      description:
+      - Message data associated with the record.
+      - The value here can be of any type.
+      type: raw
+      returned: always
+      sample: information record
+    source:
+      description:
+      - The source of the record.
+      type: str
+      returned: always
+      sample: Write-Information
+    time_generated:
+      description:
+      - The time the record was generated.
+      - This is the time in UTC as an ISO 8601 formatted string.
+      type: str
+      returned: always
+      sample: 2021-02-11T04:46:00.4694240Z
+    tags:
+      description:
+      - A list of tags associated with the record.
+      type: list
+      elements: str
+      returned: always
+      sample: ['Host']
+    user:
+      description:
+      - The user that generated the record.
+      type: str
+      returned: always
+      sample: MyUser
+    computer:
+      description:
+      - The computer that generated the record.
+      type: str
+      returned: always
+      sample: MY-HOST
+    process_id:
+      description:
+      - The native process that generated the record.
+      type: int
+      returned: always:
+      sample: 12932
+    native_thread_id:
+      description:
+      - The native thread that generated the record.
+      type: int
+      returned: always
+      sample: 2923
+    managed_thread_id:
+      description:
+      - The managed (.NET) thread that generated the record.
+      type: int
+      returned: always
+      sample: 10234
+'''

--- a/plugins/modules/win_powershell.py
+++ b/plugins/modules/win_powershell.py
@@ -28,7 +28,7 @@ options:
     - The default location is dependent on many factors, if relative paths are used then set this option.
     type: str
   creates:
-    description:  
+    description:
     - A path or path filter pattern; when the referenced path exists on the target host, the task will be skipped.
     type: str
   depth:

--- a/plugins/modules/win_powershell.py
+++ b/plugins/modules/win_powershell.py
@@ -141,6 +141,9 @@ EXAMPLES = r'''
     script: |
       $PSVersionTable.PSVersion.Major
     executable: pwsh.exe
+    arguments:
+    - -ExecutionPolicy
+    - ByPass
   register: pwsh_output
   failed_when:
   - pwsh_output.output[0] != 7

--- a/plugins/modules/win_powershell.py
+++ b/plugins/modules/win_powershell.py
@@ -55,12 +55,9 @@ options:
     - A custom PowerShell executable to run the script in.
     - When not defined the script will run in the current module PowerShell interpreter.
     - Both the remote PowerShell and the one specified by I(executable) must be running on PowerShell v5.1 or newer.
+    - Setting this value may change the values returned in the C(output) return value depending on the underlying .NET
+      type.
     type: str
-  input:
-    description:
-    - A list of objects to pass in as the input to the PowerShell script specified by I(script).
-    type: list
-    elements: raw
   parameters:
     description:
     - Parameters to pass into the script as key value pairs.
@@ -128,25 +125,6 @@ EXAMPLES = r'''
     parameters:
       Path: C:\temp
       Force: true
-
-- name: Run PowerShell script with input
-  ansible.windows.win_powershell:
-    script: |
-      [CmdletBinding()]
-      param (
-          [Parameter(Mandatory=$true, ValueFromPipeline=$true)]
-          [String[]]
-          $Path
-      )
-
-      process {
-        foreach ($pathEntry in $Path) {
-            Test-Path -Path $pathEntry
-        }
-      }
-    input:
-    - C:\Windows
-    - HKLM:\SYSTEM
 
 - name: Run PowerShell script that modifies the module changed result
   ansible.windows.win_powershell:

--- a/plugins/modules/win_shell.py
+++ b/plugins/modules/win_shell.py
@@ -63,12 +63,15 @@ notes:
    -  WinRM will not return from a command execution until all child processes created have exited.
       Thus, it is not possible to use M(ansible.windows.win_shell) to spawn long-running child or background processes.
       Consider creating a Windows service for managing background processes.
+    - Consider using M(ansible.windows.win_powershell) if you want to capture the output from the PowerShell script
+      as structured objects.
 seealso:
 - module: community.windows.psexec
 - module: ansible.builtin.raw
 - module: ansible.builtin.script
 - module: ansible.builtin.shell
 - module: ansible.windows.win_command
+- module: ansible.windows.win_powershell
 - module: community.windows.win_psexec
 author:
     - Matt Davis (@nitzmahone)

--- a/tests/integration/targets/win_powershell/aliases
+++ b/tests/integration/targets/win_powershell/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group1

--- a/tests/integration/targets/win_powershell/meta/main.yml
+++ b/tests/integration/targets/win_powershell/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- setup_remote_tmp_dir

--- a/tests/integration/targets/win_powershell/tasks/main.yml
+++ b/tests/integration/targets/win_powershell/tasks/main.yml
@@ -47,3 +47,4 @@
   assert:
     that:
     - exe_with_arguments.output == ['Restricted']
+  when: use_executable.stdout | trim | bool

--- a/tests/integration/targets/win_powershell/tasks/main.yml
+++ b/tests/integration/targets/win_powershell/tasks/main.yml
@@ -1,110 +1,49 @@
-- name: run script with various output types
-  win_powershell:  # TODO: check with executable as well
-    #executable: pwsh.exe
-    script: |
-      $null
-      'string'
-      1
-      [IO.FileAttributes]'Hidden, Archive'
-      [IO.FileAccess]'Read'
-      [object]
-      [string]
-      [char]'a'
-      [Exception]"abc"
+- name: check if executable is supported
+  win_shell: '[Version]$PSVersionTable.PSVersion -gt [Version]"5.0"'
+  register: use_executable
+  changed_when: False
 
-      # Date tests
+- name: get datetimes used for tests
+  win_shell: |
       $epoch_unspec = New-Object -TypeName DateTime -ArgumentList 1970, 1, 1
       $epoch_local = New-Object -TypeName DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, ([DateTimeKind]::Local)
       $epoch_utc = New-Object -TypeName DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, ([DateTimeKind]::Utc)
 
-      $epoch_unspec
-      $epoch_unspec.ToLocalTime()
-      $epoch_unspec.ToUniversalTime()
+      $epoch_unspec.ToString('o')
+      $epoch_unspec.ToLocalTime().ToString('o')
+      $epoch_unspec.ToUniversalTime().ToString('o')
 
-      $epoch_local
-      $epoch_local.ToLocalTime()
-      $epoch_local.ToUniversalTime()
+      $epoch_local.ToString('o')
+      $epoch_local.ToLocalTime().ToString('o')
+      $epoch_local.ToUniversalTime().ToString('o')
 
-      $epoch_utc
-      $epoch_utc.ToLocalTime()
-      $epoch_utc.ToUniversalTime()
+      $epoch_utc.ToString('o')
+      $epoch_utc.ToLocalTime().ToString('o')
+      $epoch_utc.ToUniversalTime().ToString('o')
 
-      ([DateTimeOffset]$epoch_utc).ToOffset([TimeSpan]::FromHours(2))
+      ([DateTimeOffset]$epoch_utc).ToOffset([TimeSpan]::FromHours(2)).ToString('o')
+  register: dt_values
+  changed_when: False
 
-      # List tests
-      ,@()
-      ,@(1)
-      ,@($null)
-      ,@(
-          'entry 1',
-          $null,
-          1,
-          @('nested', @('even more nested', 'other more nested')),
-          @(),
-          @(1),
-          @($null),
-          @{
-              key = 'value'
-              exceed = Get-Item $env:SystemRoot
-          }
-      )
+- name: run tests using current interpreter
+  import_tasks: tests.yml
 
-      # Dictionary tests
-      @{}
-      @{
-          foo = 'bar'
-          list = @(
-            @{ foo = 'bar' }
-            'value 2',
-            [string]
-          )
-          empty_list = ,@()
-          null_list = ,@($null)
-          list_with_1 = ,@(1)
-          nested = @{
-              foo = 'bar'
-              exeed = @{
-                  foo = 'bar'
-              }
-          }
-      }
-      $hash = @{foo = 'bar'}
-      Add-Member -InputObject $has -NotePropertyName foo -NotePropertyValue hidden
-      $hash
+- name: run tests using executable
+  import_tasks: tests.yml
+  when: use_executable.stdout | trim | bool
+  vars:
+    pwsh_executable: powershell.exe
 
-      # Classes with properties
-      [PSCustomObject]@{
-          Key = 'value'
-          DateTime = $epoch
-          Enum = [IO.FileAccess]::Read
-          List = @(
-            'value 1', 'value 2'
-          )
-          Nested = [PSCustomObject]@{
-              Exceed = @{
-                  foo = 'bar'
-              }
-              Key = 'value'
-          }
-      }
+- name: run executable with arguments
+  win_powershell:
+    executable: powershell.exe
+    arguments: -ExecutionPolicy Restricted
+    script: |
+      $env:PSExecutionPolicyPreference
+  register: exe_with_arguments
+  when: use_executable.stdout | trim | bool
 
-      Get-Item $env:SystemRoot
-
-  register: output_types
-
-# Larger depth
-# Failure conditions
-#   output on a failure (should be there)
-#   $Ansible.Failed
-#   error_action with error records
-# Parameters
-# Arguments
-# Executable (v5 only)
-# Information records (v5 only)
-# Console output + Unicode values
-# creates/removes
-# Check mode + $Ansible.CheckMode
-# $Ansible.Tmpdir
-# error_action
-# chdir
-# invalid script
+- name: assert run executable with arguments
+  assert:
+    that:
+    - exe_with_arguments.output == ['Restricted']

--- a/tests/integration/targets/win_powershell/tasks/main.yml
+++ b/tests/integration/targets/win_powershell/tasks/main.yml
@@ -37,7 +37,9 @@
 - name: run executable with arguments
   win_powershell:
     executable: powershell.exe
-    arguments: -ExecutionPolicy Restricted
+    arguments:
+    - -ExecutionPolicy
+    - Restricted
     script: |
       $env:PSExecutionPolicyPreference
   register: exe_with_arguments

--- a/tests/integration/targets/win_powershell/tasks/main.yml
+++ b/tests/integration/targets/win_powershell/tasks/main.yml
@@ -1,0 +1,110 @@
+- name: run script with various output types
+  win_powershell:  # TODO: check with executable as well
+    #executable: pwsh.exe
+    script: |
+      $null
+      'string'
+      1
+      [IO.FileAttributes]'Hidden, Archive'
+      [IO.FileAccess]'Read'
+      [object]
+      [string]
+      [char]'a'
+      [Exception]"abc"
+
+      # Date tests
+      $epoch_unspec = New-Object -TypeName DateTime -ArgumentList 1970, 1, 1
+      $epoch_local = New-Object -TypeName DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, ([DateTimeKind]::Local)
+      $epoch_utc = New-Object -TypeName DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, ([DateTimeKind]::Utc)
+
+      $epoch_unspec
+      $epoch_unspec.ToLocalTime()
+      $epoch_unspec.ToUniversalTime()
+
+      $epoch_local
+      $epoch_local.ToLocalTime()
+      $epoch_local.ToUniversalTime()
+
+      $epoch_utc
+      $epoch_utc.ToLocalTime()
+      $epoch_utc.ToUniversalTime()
+
+      ([DateTimeOffset]$epoch_utc).ToOffset([TimeSpan]::FromHours(2))
+
+      # List tests
+      ,@()
+      ,@(1)
+      ,@($null)
+      ,@(
+          'entry 1',
+          $null,
+          1,
+          @('nested', @('even more nested', 'other more nested')),
+          @(),
+          @(1),
+          @($null),
+          @{
+              key = 'value'
+              exceed = Get-Item $env:SystemRoot
+          }
+      )
+
+      # Dictionary tests
+      @{}
+      @{
+          foo = 'bar'
+          list = @(
+            @{ foo = 'bar' }
+            'value 2',
+            [string]
+          )
+          empty_list = ,@()
+          null_list = ,@($null)
+          list_with_1 = ,@(1)
+          nested = @{
+              foo = 'bar'
+              exeed = @{
+                  foo = 'bar'
+              }
+          }
+      }
+      $hash = @{foo = 'bar'}
+      Add-Member -InputObject $has -NotePropertyName foo -NotePropertyValue hidden
+      $hash
+
+      # Classes with properties
+      [PSCustomObject]@{
+          Key = 'value'
+          DateTime = $epoch
+          Enum = [IO.FileAccess]::Read
+          List = @(
+            'value 1', 'value 2'
+          )
+          Nested = [PSCustomObject]@{
+              Exceed = @{
+                  foo = 'bar'
+              }
+              Key = 'value'
+          }
+      }
+
+      Get-Item $env:SystemRoot
+
+  register: output_types
+
+# Larger depth
+# Failure conditions
+#   output on a failure (should be there)
+#   $Ansible.Failed
+#   error_action with error records
+# Parameters
+# Arguments
+# Executable (v5 only)
+# Information records (v5 only)
+# Console output + Unicode values
+# creates/removes
+# Check mode + $Ansible.CheckMode
+# $Ansible.Tmpdir
+# error_action
+# chdir
+# invalid script

--- a/tests/integration/targets/win_powershell/tasks/tests.yml
+++ b/tests/integration/targets/win_powershell/tasks/tests.yml
@@ -1,0 +1,846 @@
+- name: run script with various output types
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: |
+      $null
+      'string'
+      1
+      [IO.FileAttributes]'Hidden, Archive'
+      [IO.FileAccess]'Read'
+      [object]
+      [string]
+      [char]'a'
+      [Exception]"abc"
+
+      # Date tests
+      $epoch_unspec = New-Object -TypeName DateTime -ArgumentList 1970, 1, 1
+      $epoch_local = New-Object -TypeName DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, ([DateTimeKind]::Local)
+      $epoch_utc = New-Object -TypeName DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, ([DateTimeKind]::Utc)
+
+      $epoch_unspec
+      $epoch_unspec.ToLocalTime()
+      $epoch_unspec.ToUniversalTime()
+
+      $epoch_local
+      $epoch_local.ToLocalTime()
+      $epoch_local.ToUniversalTime()
+
+      $epoch_utc
+      $epoch_utc.ToLocalTime()
+      $epoch_utc.ToUniversalTime()
+
+      ([DateTimeOffset]$epoch_utc).ToOffset([TimeSpan]::FromHours(2))
+
+      # List tests
+      ,@()
+      ,@(1)
+      ,@($null)
+      ,@(
+          'entry 1',
+          $null,
+          1,
+          @(
+              'level2',
+              @(
+                  'level3',
+                  'value'
+              )
+          ),
+          @(),
+          @(1),
+          @($null),
+          @{
+              key = 'value'
+              exceed = Get-Item $env:SystemRoot
+          }
+      )
+
+      # Dictionary tests
+      @{}
+      @{
+          foo = 'bar'
+          list = @(
+            @{ foo = 'bar' }
+            'value 2',
+            [string]
+          )
+          empty_list = @()
+          null_list = @($null)
+          list_with_1 = @(1)
+          nested = @{
+              foo = 'bar'
+              exceed = @{
+                  foo = 'bar'
+              }
+          }
+      }
+      $hash = @{foo = 'bar'}
+      Add-Member -InputObject $hash -NotePropertyName foo -NotePropertyValue hidden
+      $hash
+
+      # Classes with properties
+      [PSCustomObject]@{
+          Key = 'value'
+          DateTime = $epoch_utc
+          Enum = [IO.FileAccess]::Read
+          List = @(
+            'value 1', 'value 2'
+          )
+          Nested = [PSCustomObject]@{
+              Exceed = @{
+                  foo = 'bar'
+              }
+              Key = 'value'
+          }
+      }
+
+      Get-Item $env:SystemRoot
+
+  register: output_types
+
+- name: assert script with various output types
+  assert:
+    that:
+    - output_types is changed
+    - output_types.debug == []
+    - output_types.error == []
+    - output_types.host_err == ''
+    - output_types.host_out == ''
+    - output_types.information == []
+    - output_types.output|length == 28
+    - output_types.output[0] == None
+
+    - output_types.output[1] == 'string'
+
+    - output_types.output[2] == 1
+
+    - output_types.output[3]['String'] == 'Hidden, Archive'
+    - output_types.output[3]['Type'] == 'System.IO.FileAttributes'
+    - output_types.output[3]['Value'] == 34
+
+    - output_types.output[4]['String'] == 'Read'
+    - output_types.output[4]['Type'] == 'System.IO.FileAccess'
+    - output_types.output[4]['Value'] == 1
+
+    - output_types.output[5]['AssemblyQualifiedName'].startswith('System.Object, ')
+    - output_types.output[5]['BaseType'] == None
+    - output_types.output[5]['FullName'] == 'System.Object'
+    - output_types.output[5]['Name'] == 'Object'
+
+    - output_types.output[6]['AssemblyQualifiedName'].startswith('System.String, ')
+    - output_types.output[6]['BaseType']['AssemblyQualifiedName'].startswith('System.Object, ')
+    - output_types.output[6]['BaseType']['BaseType'] == None
+    - output_types.output[6]['BaseType']['FullName'] == 'System.Object'
+    - output_types.output[6]['BaseType']['Name'] == 'Object'
+    - output_types.output[6]['FullName'] == 'System.String'
+    - output_types.output[6]['Name'] == 'String'
+
+    - output_types.output[7] == 'a'
+
+    - output_types.output[8]['Data'] == {}
+    - output_types.output[8]['HResult'] == -2146233088
+    - output_types.output[8]['HelpLink'] == None
+    - output_types.output[8]['InnerException'] == None
+    - output_types.output[8]['Message'] == 'abc'
+    - output_types.output[8]['Source'] == None
+    - output_types.output[8]['StackTrace'] == None
+    - output_types.output[8]['TargetSite'] == None
+
+    - output_types.output[9] == dt_values.stdout_lines[0]
+    - output_types.output[10] == dt_values.stdout_lines[1]
+    - output_types.output[11] == dt_values.stdout_lines[2]
+
+    - output_types.output[12] == dt_values.stdout_lines[3]
+    - output_types.output[13] == dt_values.stdout_lines[4]
+    - output_types.output[14] == dt_values.stdout_lines[5]
+
+    - output_types.output[15] == dt_values.stdout_lines[6]
+    - output_types.output[16] == dt_values.stdout_lines[7]
+    - output_types.output[17] == dt_values.stdout_lines[8]
+
+    - output_types.output[18] == dt_values.stdout_lines[9]
+
+    - output_types.output[19] == []
+
+    - output_types.output[20] == [1]
+
+    - output_types.output[21] == [None]
+
+    - output_types.output[22]|length == 8
+    - output_types.output[22][0] == 'entry 1'
+    - output_types.output[22][1] == None
+    - output_types.output[22][2] == 1
+    - output_types.output[22][3] == ['level2', 'level3 value']
+    - output_types.output[22][4] == []
+    - output_types.output[22][5] == [1]
+    - output_types.output[22][6] == [None]
+    - output_types.output[22][7]['key'] == 'value'
+    - output_types.output[22][7]['exceed'] == 'C:\Windows'
+
+    - output_types.output[23] == {}
+
+    - output_types.output[24]['foo'] == 'bar'
+    - output_types.output[24]['list']|length == 3
+    - output_types.output[24]['list'][0] == 'System.Collections.Hashtable'
+    - output_types.output[24]['list'][1] == 'value 2'
+    - output_types.output[24]['list'][2] == 'System.String'
+    - output_types.output[24]['empty_list'] == []
+    - output_types.output[24]['null_list'] == [None]
+    - output_types.output[24]['list_with_1'] == [1]
+    - output_types.output[24]['nested']['exceed'] == 'System.Collections.Hashtable'
+
+    - 'output_types.output[25] == {"foo": "bar"}'
+
+    - output_types.output[26]['Key'] == 'value'
+    - output_types.output[26]['DateTime'] == '1970-01-01T00:00:00.0000000Z'
+    - output_types.output[26]['Enum']['String'] == 'Read'
+    - output_types.output[26]['Enum']['Type'] == 'System.IO.FileAccess'
+    - output_types.output[26]['Enum']['Value'] == 1
+    - output_types.output[26]['List'] == ['value 1', 'value 2']
+    - output_types.output[26]['Nested']['Exceed'] == 'System.Collections.Hashtable'
+    - output_types.output[26]['Nested']['Key'] == 'value'
+
+    - output_types.output[27]['BaseName'] == 'Windows'
+    - output_types.output[27]['Exists'] == True
+    - output_types.output[27]['FullName'] == 'C:\Windows'
+    - output_types.output[27]['PSDrive']['Name'] == 'C'
+    - output_types.output[27]['PSDrive']['Provider'] == 'Microsoft.PowerShell.Core\FileSystem'
+    - output_types.output[27]['PSProvider']['Drives'] == 'C'
+    - output_types.output[27]['PSProvider']['ImplementingType'] == 'Microsoft.PowerShell.Commands.FileSystemProvider'
+    - output_types.output[27]['PSProvider']['Name'] == 'FileSystem'
+
+    - output_types.result == {}
+    - output_types.verbose == []
+    - output_types.warning == []
+
+- name: output with larger depth
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    depth: 3
+    script: |
+      @(
+          'normal 0',
+          @(
+              'normal 1',
+              @(
+                  'normal 2',
+                  @(
+                      'normal 3',
+                      @(
+                          'squashed',
+                          @(
+                              'even more squashed'
+                          )
+                      )
+
+                  )
+              )
+          )
+      )
+  register: higher_depth
+
+- name: assert output with larger depth without executable
+  assert:
+    that:
+    - higher_depth.output == ['normal 0', ['normal 1', ['normal 2', ['normal 3', 'squashed System.Object[]']]]]
+  when: not pwsh_executable is defined
+
+- name: assert output with larger depth with executable
+  assert:
+    that:
+    - higher_depth.output == ['normal 0', ['normal 1', ['normal 2', ['normal 3', 'squashed System.Collections.ArrayList']]]]
+  when: pwsh_executable is defined
+
+- name: set explicit value on Ansible.Result
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: |
+      $Ansible.Result = @(
+          (New-Object -TypeName DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, ([DateTimeKind]::Utc)),
+          'string'
+      )
+  register: result_ansible
+
+- name: assert set explicit value on Ansible.Result
+  assert:
+    that:
+    - result_ansible is changed
+    - result_ansible.output == []
+    - result_ansible.result == ['1970-01-01T00:00:00.0000000Z', 'string']
+
+- name: get temporary directory
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: |
+      $tmp = $Ansible.Tmpdir
+      $null = New-Item -Path "$tmp\Directory" -ItemType Directory
+
+      $tmp
+  register: tmpdir
+
+- name: check that tmpdir doesn't exist anymore
+  win_stat:
+    path: '{{ tmpdir.output[0] }}'
+  register: tmpdir_actual
+
+- name: assert get temporary directory
+  assert:
+    that:
+    - tmpdir is changed
+    - not tmpdir_actual.stat.exists
+
+- name: dont fail with error record
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: |
+        'output 1'
+        Write-Error -Message 'error'
+        'output 2'
+  register: error_record
+
+- name: assert dont fail with error record
+  assert:
+    that:
+    - error_record is changed
+    - error_record.error|length == 1
+    - error_record.error[0]['category_info']['activity'] == 'Write-Error'
+    - error_record.error[0]['category_info']['category'] == 'NotSpecified'
+    - error_record.error[0]['category_info']['category_id'] == 0
+    - error_record.error[0]['category_info']['reason'] == 'WriteErrorException'
+    - error_record.error[0]['category_info']['target_name'] == ''
+    - error_record.error[0]['category_info']['target_type'] == ''
+    - error_record.error[0]['error_details'] == None
+    - error_record.error[0]['exception']['help_link'] == None
+    - error_record.error[0]['exception']['hresult'] == -2146233087
+    - error_record.error[0]['exception']['inner_exception'] == None
+    - error_record.error[0]['exception']['message'] == 'error'
+    - error_record.error[0]['exception']['source'] == None
+    - error_record.error[0]['exception']['type'] == 'Microsoft.PowerShell.Commands.WriteErrorException'
+    - error_record.error[0]['fully_qualified_error_id'] == 'Microsoft.PowerShell.Commands.WriteErrorException'
+    - error_record.error[0]['output'] is defined
+    - error_record.error[0]['pipeline_iteration_info'] == [0, 0]
+    - "error_record.error[0]['script_stack_trace'] == 'at <ScriptBlock>, <No file>: line 2'"
+    - error_record.error[0]['target_object'] == None
+    - error_record.output == ['output 1', 'output 2']
+
+- name: fail with error record and ErrorActionPreference Stop
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    error_action: stop
+    script: |
+        'output 1'
+        Write-Error -Message 'error'
+        'output 2'
+  register: error_record_stop
+  ignore_errors: yes
+
+- name: assert fail with error record and ErrorActionPreference Stop
+  assert:
+    that:
+    - error_record_stop is failed
+    - error_record_stop is failed
+    - error_record_stop.error|length == 1
+    - error_record_stop.error[0]['exception']['message'] == 'error'
+    - error_record_stop.output == ['output 1']
+
+- name: output more complex error record
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: |
+      Function Test-Function {
+          [CmdletBinding()]
+          param (
+              [Parameter(Mandatory, ValueFromPipeline)]
+              [Object]
+              $InputObject
+          )
+
+          process {
+              if ($InputObject -eq 2) {
+                  $errorParams = @{
+                      Exception = ([ComponentModel.Win32Exception]5)
+                      Message = 'error message'
+                      Category = 'PermissionDenied'
+                      ErrorId = 'error id'
+                      TargetObject = 'some object'
+                      RecommendedAction = 'recommended action'
+                      CategoryActivity = 'ran pipeline'
+                      CategoryReason = 'touch luck'
+                      CategoryTargetName = 'target'
+                      CategoryTargetType = 'directory'
+                  }
+                  Write-Error @errorParams
+              }
+          }
+          
+      }
+      1..3 | Test-Function
+  register: complex_error_record
+
+- name: assert output more complex error record
+  assert:
+    that:
+    - complex_error_record is changed
+    - complex_error_record.error|length == 1
+    - complex_error_record.error[0]['category_info']['activity'] == 'Write-Error'
+    - complex_error_record.error[0]['category_info']['category'] == 'PermissionDenied'
+    - complex_error_record.error[0]['category_info']['category_id'] == 18
+    - complex_error_record.error[0]['category_info']['reason'] == 'touch luck'
+    - complex_error_record.error[0]['category_info']['target_name'] == 'target'
+    - complex_error_record.error[0]['category_info']['target_type'] == 'directory'
+    - complex_error_record.error[0]['error_details']['message'] == 'error message'
+    - complex_error_record.error[0]['error_details']['recommended_action'] == 'recommended action'
+    - complex_error_record.error[0]['exception']['help_link'] == None
+    - complex_error_record.error[0]['exception']['hresult'] == -2147467259
+    - complex_error_record.error[0]['exception']['inner_exception'] == None
+    - complex_error_record.error[0]['exception']['message'] == 'Access is denied'
+    - complex_error_record.error[0]['exception']['source'] == None
+    - complex_error_record.error[0]['exception']['type'] == 'System.ComponentModel.Win32Exception'
+    - complex_error_record.error[0]['fully_qualified_error_id'] == 'error id,Test-Function'
+    - complex_error_record.error[0]['output'] is defined
+    - complex_error_record.error[0]['pipeline_iteration_info'] == [2, 2]
+    - "complex_error_record.error[0]['script_stack_trace'] == 'at Test-Function<Process>, <No file>: line 23\\r\\nat <ScriptBlock>, <No file>: line 28'"
+    - complex_error_record.error[0]['target_object'] == 'some object'
+
+- name: failure with terminating exception
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: |
+      'output 1'
+      throw "exception"
+      'output 2'
+  register: failed_exception
+  ignore_errors: yes
+
+- name: assert failure with terminating exception
+  assert:
+    that:
+    - failed_exception is failed
+    - failed_exception.error|length == 1
+    - failed_exception.error[0]['exception']['message'] == 'exception'
+    - failed_exception.output == ['output 1']
+
+- name: failure with Ansible.Failed
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: |
+      'output 1'
+      $Ansible.Failed = $true
+      'output 2'
+  register: failed_ansible
+  ignore_errors: yes
+
+- name: assert failure with Ansible.Failed
+  assert:
+    that:
+    - failed_ansible is failed
+    - failed_ansible.error == []
+    - failed_ansible.output == ['output 1', 'output 2']
+
+- name: Ansible.Failed cannot overwrite terminating exception
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: |
+      $Ansible.Failed = $false
+      throw "exception"
+  register: term_beats_failed
+  ignore_errors: yes
+
+- name: assert Ansible.Failed cannot overwrite terminating exception
+  assert:
+    that:
+    - term_beats_failed is failed
+    - term_beats_failed.error|length == 1
+    - term_beats_failed.error[0]['exception']['message'] == 'exception'
+
+- name: error with interactive prompt
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: $Host.UI.ReadLine()
+  register: error_noninteractive
+  ignore_errors: yes
+
+- name: assert error with interactive prompt
+  assert:
+    that:
+    - error_noninteractive is changed
+    - not error_noninteractive is failed  # This isn't considered a terminating exception in PowerShell so no failure here.
+    - error_noninteractive.error|length == 1
+    - "'PowerShell is in NonInteractive mode. Read and Prompt functionality is not available.' in error_noninteractive.error[0]['exception']['message']"
+    - error_noninteractive.output == []
+
+- name: run script with parameters
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: |
+      [CmdletBinding()]
+      param (
+          [String]
+          $String,
+
+          [Switch]
+          $Switch,
+
+          [Bool]
+          $Bool,
+
+          [int]
+          $Int,
+
+          [Object[]]
+          $List,
+
+          [Hashtable]
+          $Dict
+      )
+
+      @{
+          String = $String
+          Switch = $Switch
+          Bool = $Bool
+          Int = $Int
+          List = $List
+          Dict = $Dict
+      }
+    parameters:
+      String: string
+      Switch: True
+      Bool: False
+      Int: 1
+      List:
+      - abc
+      - 123
+      Dict:
+        Key: Value
+  register: parameters
+
+- name: assert run script with parameters
+  assert:
+    that:
+    - parameters is changed
+    - parameters.output|length == 1
+    - parameters.output[0]['String'] == 'string'
+    - parameters.output[0]['Switch'] == True
+    - parameters.output[0]['Bool'] == False
+    - parameters.output[0]['Int'] == 1
+    - parameters.output[0]['List'] == ['abc', 123]
+    - "parameters.output[0]['Dict'] == {'Key': 'Value'}"
+
+- name: write debug/verbose/warning streams
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: |
+      $DebugPreference = 'Continue'
+      $VerbosePreference = 'Continue'
+      $WarningPreference = 'Continue'
+
+      Write-Debug 'debug'
+      Write-Verbose 'verbose'
+      Write-Warning 'warning'
+
+  register: extra_streams
+      
+- name: assert write debug/verbose/warning streams
+  assert:
+    that:
+    - extra_streams is changed
+    - "extra_streams.host_out == 'DEBUG: debug\\r\\nVERBOSE: verbose\\r\\nWARNING: warning\\r\\n'"
+    - extra_streams.debug == ['debug']
+    - extra_streams.verbose == ['verbose']
+    - extra_streams.warning == ['warning']
+
+- name: output information record
+  win_powershell:
+    script: |
+      $epoch = New-Object -TypeName DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, ([DateTimeKind]::Utc)
+      Write-Information -MessageData $epoch -Tags tag1
+  register: info_record
+  when: use_executable.stdout | trim | bool  # Information records were only added in v5
+
+- name: assert output information record
+  assert:
+    that:
+    - info_record is changed
+    - info_record.information|length == 1
+    - info_record.information[0]['message_data'] == '1970-01-01T00:00:00.0000000Z'
+    - info_record.information[0]['source'] == 'Write-Information'
+    - info_record.information[0]['tags'] == ['tag1']
+    - info_record.information[0]['time_generated'].endswith('Z')
+    - info_record.output == []
+  when: use_executable.stdout | trim | bool
+
+- name: verify confirmation prompts aren't called
+  win_powershell:
+    script: |
+      [CmdletBinding(SupportsShouldProcess, ConfirmImpact='High')]
+      param ()
+
+      $PSCmdlet.ShouldProcess('action')
+  register: ignore_confirm
+
+- name: assert verify confirmation prompts aren't called
+  assert:
+    that:
+    - ignore_confirm is changed
+    - ignore_confirm.output == [True]
+
+- name: try to run an invalid script
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: |
+        def my_function():
+            print("abc")
+
+        def main():
+            my_function()
+
+        if __name__ == '__main__':
+            main()
+
+  register: invalid_script
+  ignore_errors: yes
+
+- name: assert try to run an invalid script
+  assert:
+    that:
+    - invalid_script is failed
+
+- name: run script with custom location
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: $pwd.Path
+    chdir: '{{ remote_tmp_dir }}'
+  register: filesystem_chdir
+
+- name: assert run script with custom location
+  assert:
+    that:
+    - filesystem_chdir is changed
+    - filesystem_chdir.output == [remote_tmp_dir]
+
+- name: run script with non-filesystem location
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: $pwd.Path
+    chdir: Cert:\LocalMachine\My
+  register: cert_chdir
+
+- name: assert run script with non-filesystem location
+  assert:
+    that:
+    - cert_chdir is changed
+    - cert_chdir.output == ['Cert:\LocalMachine\My']
+
+- name: skip execution when not in check mode
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: echo "hi"
+  register: check
+  check_mode: yes
+
+- name: assert skip execution when not in check mode
+  assert:
+    that:
+    - check is changed
+    - check.msg == 'skipped, running in check mode'
+    - check.output == []
+
+- name: run check mode aware script
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: |
+      [CmdletBinding(SupportsShouldProcess)]
+      param ()
+
+      $Ansible.CheckMode
+  register: check_aware
+  check_mode: yes
+
+- name: assert run check mode aware script
+  assert:
+    that:
+    - check_aware is changed
+    - check_aware.output == [True]
+
+- name: SupportsShouldProcess with explicit value
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: |
+      [CmdletBinding(SupportsShouldProcess=$true)]
+      param ()
+
+      $PSCmdlet.ShouldProcess('resource')
+  register: check_aware_true
+  check_mode: yes
+
+- name: assert SupportsShouldProcess with explicit value
+  assert:
+    that:
+    - check_aware_true is changed
+    - check_aware_true.output == [False]
+
+- name: skip check mode with SupportsShouldProcess=$false
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: |
+      [CmdletBinding(SupportsShouldProcess=$false)]
+      param ()
+
+      $PSCmdlet.ShouldProcess('resource')
+  register: check_aware_false
+  check_mode: yes
+
+- name: assert skip check mode with SupportsShouldProcess=$false
+  assert:
+    that:
+    - check_aware_false is changed
+    - check_aware_false.msg == 'skipped, running in check mode'
+    - check_aware_false.output == []
+
+- name: skip check mode without SupportsShouldProcess
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: |
+      [CmdletBinding()]
+      param ()
+
+      $PSCmdlet.ShouldProcess('resource')
+  register: check_unaware
+  check_mode: yes
+
+- name: assert skip check mode without SupportsShouldProcess
+  assert:
+    that:
+    - check_unaware is changed
+    - check_unaware.msg == 'skipped, running in check mode'
+    - check_unaware.output == []
+
+- name: do not skip if file does not exist
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: '"output"'
+    creates: missing
+  register: creates_missing
+
+- name: assert do not skip if file does not exist
+  assert:
+    that:
+    - creates_missing is changed
+    - creates_missing.output == ['output']
+
+- name: skip if file exists
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: '"output"'
+    creates: '{{ remote_tmp_dir }}'
+  register: creates_exists
+
+- name: assert skip if file exists
+  assert:
+    that:
+    - not creates_exists is changed
+    - creates_exists.msg == 'skipped, since ' + remote_tmp_dir + ' exists'
+    - creates_exists.output == []
+
+- name: skip for creates non-filesystem
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: '"output"'
+    creates: cert:\LocalMachine\*
+  register: creates_non_fs
+
+- name: assert skip for creates non-filesystem
+  assert:
+    that:
+    - not creates_non_fs is changed
+    - creates_non_fs.msg == 'skipped, since cert:\LocalMachine\* exists'
+    - creates_non_fs.output == []
+
+- name: skip if removes does not exist
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: '"output"'
+    removes: C:\Windows\Missing\file.txt
+  register: removes_missing
+
+- name: assert skip if removes does not exist
+  assert:
+    that:
+    - not removes_missing is changed
+    - removes_missing.msg == 'skipped, since C:\\Windows\\Missing\\file.txt does not exist'
+    - removes_missing.output == []
+
+- name: do not skip if removes exists
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: '"output"'
+    removes: '{{ remote_tmp_dir }}'
+  register: removes_exists
+
+- name: assert do not skip if removes exists
+  assert:
+    that:
+    - removes_exists is changed
+    - removes_exists.output == ['output']
+
+- name: do not skip if removes exists non-filesystem
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: '"output"'
+    removes: cert:\LocalMachine\*
+  register: removes_exists_non_fs
+
+- name: assert do not skip if removes exists non-filesystem
+  assert:
+    that:
+    - removes_exists_non_fs is changed
+    - removes_exists_non_fs.output == ['output']
+
+- name: script changed status
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: $Ansible.Changed = $false
+  register: script_changed
+
+- name: assert script changed status
+  assert:
+    that:
+    - not script_changed is changed
+
+- name: capture console output as host output
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: |
+      $poop = [Char]::ConvertFromUtf32(0x1F4A9)
+      $Host.UI.WriteLine("host café $poop")
+      $Host.UI.WriteErrorLine("error café $poop")
+
+      $subProcessCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes({
+          $p = [Char]::ConvertFromUtf32(0x1F4A9)
+
+          [Console]::Out.WriteLine("sub stdout café $p")
+          [Console]::Error.WriteLine("sub stderr café $p")
+      }.ToString()))
+
+      # Calling a process directly goes to the output/error stream. Calling it with Start-Process with -NoNewWindow
+      # means the sub process will inherit the current console handles and should be captured in the host output.
+      $processParams = @{
+          FilePath = 'powershell.exe'
+          ArgumentList = "-EncodedCommand $subProcessCommand"
+          Wait = $true
+          NoNewWindow = $true
+      }
+      Start-Process @processParams
+
+      [Console]::Out.WriteLine("stdout café $poop")
+      [Console]::Error.WriteLine("stderr café $poop")
+  register: host_output
+
+- name: assert capture console output as host output
+  assert:
+    that:
+    - host_output is changed
+    - host_output.host_err == 'error café 💩\r\nsub stderr café 💩\r\nstderr café 💩\r\n'
+    - host_output.host_out == 'host café 💩\r\nsub stdout café 💩\r\nstdout café 💩\r\n'
+    - host_output.error == []
+    - host_output.output == []

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,4 +1,5 @@
 plugins/modules/setup.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
+plugins/modules/win_powershell.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
 tests/integration/targets/win_dsc/files/xTestDsc/1.0.0/DSCResources/ANSIBLE_xTestResource/ANSIBLE_xTestResource.psm1 pslint:PSDSCUseIdenticalMandatoryParametersForDSC # Rule is broken in older PSSA versions
 tests/integration/targets/win_dsc/files/xTestDsc/1.0.1/DSCResources/ANSIBLE_xTestResource/ANSIBLE_xTestResource.psm1 pslint:PSDSCUseIdenticalMandatoryParametersForDSC # Rule is broken in older PSSA versions
 tests/utils/shippable/check_matrix.py replace-urlopen

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,4 +1,5 @@
 plugins/modules/setup.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
+plugins/modules/win_powershell.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
 tests/integration/targets/win_dsc/files/xTestDsc/1.0.0/DSCResources/ANSIBLE_xTestResource/ANSIBLE_xTestResource.psm1 pslint:PSDSCUseIdenticalMandatoryParametersForDSC # Rule is broken in older PSSA versions
 tests/integration/targets/win_dsc/files/xTestDsc/1.0.1/DSCResources/ANSIBLE_xTestResource/ANSIBLE_xTestResource.psm1 pslint:PSDSCUseIdenticalMandatoryParametersForDSC # Rule is broken in older PSSA versions
 tests/utils/shippable/check_matrix.py replace-urlopen

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,4 +1,5 @@
 plugins/modules/setup.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
+plugins/modules/win_powershell.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
 tests/integration/targets/win_dsc/files/xTestDsc/1.0.0/DSCResources/ANSIBLE_xTestResource/ANSIBLE_xTestResource.psm1 pslint:PSDSCUseIdenticalMandatoryParametersForDSC # Rule is broken in older PSSA versions
 tests/integration/targets/win_dsc/files/xTestDsc/1.0.1/DSCResources/ANSIBLE_xTestResource/ANSIBLE_xTestResource.psm1 pslint:PSDSCUseIdenticalMandatoryParametersForDSC # Rule is broken in older PSSA versions
 tests/utils/shippable/check_matrix.py replace-urlopen


### PR DESCRIPTION
##### SUMMARY
Add a module that can be used to execute PowerShell script like `win_shell`. Where this differs with `win_shell` is it adds the outputted objects from the powershell script as a structured return value like:

```powershell
- ansible.windows.win_powershell:
    script: |
      Get-Service | Select Name, @{N='Status'; E={ $_.Status.ToString() }}
  register: service_info

- ansible.windows.win_service:
    name: '{{ item.Name }}'
    state: started
  with_items: '{{ service_info.output }}'
  when: '{{ item.Status != "Running" }}'
```

It also adds a few more benefits like

* Each individual stream record in the registered output
    * Error records can be parsed as a structured object
    * Warning/Verbose/Debug records are a list of string
    * Information records are also a structured object
* Can easily pass in objects as parameters rather than trying to embed them as a string that `win_shell` demands
    * Module options are converted to json then back from json as .NET objects so you can easily pass in a list or dict as a parameter
* No need for starting a new powershell process
    * No more `-EncodedCommand` that ticks up some AVs
* Not really a benefit over `win_shell` but you can use this for both Windows PowerShell and PowerShell using `executable`
* Can have the script modify some of the returned module output through the `$Ansible` var
    * `$Ansible.Changed` sets the changed status of the module
    * `$Ansible.Failed` sets the failed status of the module
    * `$Ansible.Result` can set more structured returned values in whatever format the user desired
    * `$Ansible.Tmpdir` can be used by the script to get the Ansible configured tempdir

Ultimately this is similar to `win_dsc` where you can write your own mini modules in a task instead of manually converting the output to json, registering the stdout, converting the stdout back from json and so on.

There are some downsides to this module:

* We serialize the whole output, there could be cases when it brings `ConvertTo-Json` to its knees and there is nothing we can do about that
    * We are bound to get some issues raised for this but I'm not sure how much we can do except stress the importance to check  what your scripts output
    * Maybe we need to add a final passthru sanity check on the returned objects for known offenders, _cough System.Type cough_.
* Objects are pure objects and not formatted to the host output
    * People will probably think that an `PSCustomObject` should look like the table or list format but in reality we will output the object and their properties like a dict
    * Once again this is really just a behaviour thing, if they want this behaviour then they need to use `win_shell`
The downside with this module will inevitably stem from people expecting it to behave like the `powershell.exe` console
* `Write-Host` won't write to the `output` return value
    * It is captured in `host_out` but some people may expect it to be `normal` output
    * We could try and mix them together but personally I think that's a mistake and we should keep it separate

##### Questions

####### Error and Information Record structure

We currently convert these records into a more structured format to avoid issues with json serializing complex types. It does drop some extra type specific information but IMO it's already providing enough information as is. Maybe we can simplify it even more by dropping some of the return values. Should we keep the behaviour as it is in the PR or change it in some way?

####### $Ansible variable

We inject a `PSCustomObject` as the `$Ansible` variable that the script can interact with. This variable can be used by the script to add explicitly named returned values or set the changed/failed state based on their own logic. Should we even bother to offer this? It's not complicated but it might just be relegated to one of those features no one knows about and thus isn't used at all.

####### Default $ErrorActionPreference

The current `$ErrorActionPreference` is the default in PowerShell (`Continue`) which means any error records are added to the error stream but the script continues on. We have an open issue #122 that has asked to change the default to `Stop` as that is safer when it comes to reporting failures. Should we explicitly set this to `Stop` and expose a module option (or just have them manually set it in their script) to change it to something else?

I personally think we should keep it on `Continue` as anyone making PowerShell functions should be aware of this behaviour. It's really only the people new to PowerShell that might be aware of it. Currently the `failed` state of the module is set to `True` if the pipeline sets the `HadErrors` property. AFAIK this is set to `True` if there are any error records which would alleviate some of the concerns from #122. I need to play with that a bit more to see when `HadErrors` is set to `True` to give some more detail here.

####### Default location/chdir

The current logic is to use whatever the module location (or new process) is set at. This can lead to different defaults depending on the connection plugin used or even if you are becoming an elevated or limited account. I personally think we should always set the default location to `C:\Users\<username>` (`$env:USERPROFILE`) but wondering what others thing.

##### TODO

- [x] Add lots of tests, especially around error handling and host output
- [x] Fix sanity issues with docs
- [x] Add more doc examples
- [x] Add more info the docs in regards to this vs `win_shell`
- [x] Figure out how to set the location, should we default to a certain dir as the various connections differ in what their defaults are

Fixes https://github.com/ansible-collections/ansible.windows/issues/122

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
win_powershell