### PR TITLE
setup - correct epoch_int calculation

### DIFF
--- a/changelogs/fragments/setup-epoch.yml
+++ b/changelogs/fragments/setup-epoch.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - setup - Return correct epoch integer value for the ``ansible_date_time.epoch_int`` fact

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -574,6 +574,8 @@ $factMeta = @(
         Code = {
             $datetime = (Get-Date)
             $datetimeUtc = $datetime.ToUniversalTime()
+            $epochDatetimeUtc = New-Object -TypeName DateTime -ArgumentList @(1970, 1, 1, 0, 0, 0, [DateTimeKind]::Utc)
+            $epoch = (New-TimeSpan -Start $epochDatetimeUtc -End $dateTimeUtc).TotalSeconds
 
             $ansibleFacts.ansible_date_time = @{
                 date = $datetime.ToString("yyyy-MM-dd")


### PR DESCRIPTION
##### SUMMARY
While a PR set `epoch_int` to the value of `$epoch` we never actually defined `$epoch`. This PR fixes that problem.

Fixes https://github.com/ansible-collections/ansible.windows/issues/183

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup