### PR TITLE
win_user - use SIDs for group comparison

### DIFF
--- a/changelogs/fragments/win_user-groups.yml
+++ b/changelogs/fragments/win_user-groups.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- win_user - Support specifying groups using the SecurityIdentifier - https://github.com/ansible-collections/ansible.windows/issues/153
+
+bugfixes:
+- win_user - Compare existing vs desired groups in a case insenstive way - https://github.com/ansible-collections/ansible.windows/issues/168

--- a/plugins/modules/win_user.py
+++ b/plugins/modules/win_user.py
@@ -34,6 +34,7 @@ options:
     - Adds or removes the user from this comma-separated list of groups, depending on the value of I(groups_action).
     - When I(groups_action) is C(replace) and I(groups) is set to the empty string ('groups='), the user is removed
       from all groups.
+    - Since C(ansible.windows v1.5.0) it is possible to specify a group using it's security identifier.
     type: list
     elements: str
   groups_action:

--- a/tests/integration/targets/win_user/tasks/tests.yml
+++ b/tests/integration/targets/win_user/tasks/tests.yml
@@ -36,7 +36,7 @@
     password: '{{ test_win_user_password }}'
     fullname: Test User
     description: Test user account
-    groups: Guests
+    groups: guests  # Makes sure we aren't doing case sensitive checks
   register: win_user_create_result_again
 
 - name: assert test create user (idempotent)
@@ -317,7 +317,7 @@
       - "win_user_replace_groups_again_result is not changed"
 
 - name: add user to another group
-  win_user: name="{{ test_win_user_name }}" groups="Power Users" groups_action="add"
+  win_user: name="{{ test_win_user_name }}" groups="S-1-5-32-547" groups_action="add"
   register: win_user_add_groups_result
 
 - name: check add user to another group result
@@ -331,7 +331,7 @@
 - name: add user to another group again
   win_user:
     name: "{{ test_win_user_name }}"
-    groups: "Power Users"
+    groups: S-1-5-32-547
     groups_action: add
   register: win_user_add_groups_again_result
 


### PR DESCRIPTION
##### SUMMARY
Changes the internal group comparison logic to work with SIDs rather than the human name. Also exposes the ability to specify a group using it's SID which helps for localisation issues and the user wants to be more explicit.

Fixes https://github.com/ansible-collections/ansible.windows/issues/153
Fixes https://github.com/ansible-collections/ansible.windows/issues/168
Supersedes https://github.com/ansible-collections/ansible.windows/pull/154

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
win_user