### PR TITLE
win_certificate_store - added ability to manage a service store

### DIFF
--- a/changelogs/fragments/win_certificate_store_service.yml
+++ b/changelogs/fragments/win_certificate_store_service.yml
@@ -1,4 +1,2 @@
 minor_changes:
 - win_certificate_store - Added functionality to open the store for a service account using ``store_type=service store_location=<service name>``
-- win_certificate_store - Added functionality to create a new store name with ``state=present create_store=yes``
-- win_certificate_store - Added functionality to remove a store with ``state=absent``

--- a/changelogs/fragments/win_certificate_store_service.yml
+++ b/changelogs/fragments/win_certificate_store_service.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- win_certificate_store - Added functionality to open the store for a service account using ``store_type=service store_location=<service name>``
+- win_certificate_store - Added functionality to create a new store name with ``state=present create_store=yes``
+- win_certificate_store - Added functionality to remove a store with ``state=absent``

--- a/plugins/modules/win_certificate_store.py
+++ b/plugins/modules/win_certificate_store.py
@@ -73,7 +73,7 @@ options:
     choices:
     - system
     - service
-    default: system.
+    default: system
     type: str
     version_added: '1.5.0'
   password:

--- a/plugins/modules/win_certificate_store.py
+++ b/plugins/modules/win_certificate_store.py
@@ -55,23 +55,27 @@ options:
     - "C(TrustedPeople): The X.509 certificate store for directly trusted people and resources"
     - "C(TrustedPublisher): The X.509 certificate store for directly trusted publishers"
     type: str
-    choices:
-    - AddressBook
-    - AuthRoot
-    - CertificateAuthority
-    - Disallowed
-    - My
-    - Root
-    - TrustedPeople
-    - TrustedPublisher
     default: My
   store_location:
     description:
     - The store location to use when importing a certificate or searching for a
       certificate.
-    choices: [ CurrentUser, LocalMachine ]
-    default: LocalMachine
+    - Can be set to C(CurrentUser) or C(LocalMachine) when C(store_type=system).
+    - Defaults to C(LocalMachine) when C(store_type=system).
+    - Must be set to any service name when C(store_type=service).
     type: str
+    default: LocalMachine
+  store_type:
+    description:
+    - The store type to manage.
+    - Use C(system) to manage locations in the system store, C(LocalMachine) and C(CurrentUser).
+    - Use C(service) to manage the store of a service account specified by I(store_location).
+    choices:
+    - system
+    - service
+    default: system.
+    type: str
+    version_added: '1.5.0'
   password:
     description:
     - The password of the pkcs12 certificate key.
@@ -195,6 +199,16 @@ EXAMPLES = r'''
   become: yes
   become_method: runas
   become_user: SYSTEM
+
+- name: Import certificate to be used for LDAPS
+  ansible.windows.win_certificate_store:
+    path: C:\Temp\cert.pfx
+    password: StrongPassword!
+    store_type: service
+    store_location: NTDS
+    key_exportable: no
+    key_storage: machine
+    state: present
 '''
 
 RETURN = r'''

--- a/tests/integration/targets/win_certificate_store/tasks/test.yml
+++ b/tests/integration/targets/win_certificate_store/tasks/test.yml
@@ -1,798 +1,798 @@
-#---
-#- name: fail with invalid store location
-#  win_certificate_store:
-#    state: present
-#    path: '{{win_cert_dir}}\subj-cert.pem'
-#    store_location: FakeLocation
-#  register: fail_fake_location
-#  failed_when: "fail_fake_location.msg != 'value of store_location must be one of: CurrentUser, LocalMachine. Got no match for: FakeLocation'"
-#
-#- name: fail to open non-existing store without the creates flag
-#  win_certificate_store:
-#    state: present
-#    path: '{{win_cert_dir}}\subj-cert.pem'
-#    store_name: FakeName
-#  register: fail_fake_name
-#  failed_when: '"unable to find store ''FakeName''" not in fail_fake_name.msg'
-#
-#- name: fail when state=present and no path is set
-#  win_certificate_store:
-#    state: present
-#  register: fail_present_no_path
-#  failed_when: "fail_present_no_path.msg != 'state is present but all of the following are missing: path'"
-#
-#- name: fail when state=exported and no path is set
-#  win_certificate_store:
-#    state: exported
-#    thumbprint: ABC
-#  register: fail_export_no_path
-#  failed_when: "fail_export_no_path.msg != 'state is exported but all of the following are missing: path'"
-#
-#- name: fail when state=exported and no thumbprint is set
-#  win_certificate_store:
-#    state: exported
-#    path: '{{win_cert_dir}}'
-#  register: fail_export_no_thumbprint
-#  failed_when: "fail_export_no_thumbprint.msg != 'state is exported but all of the following are missing: thumbprint'"
-#
-#- name: fail to export thumbprint when path is a dir
-#  win_certificate_store:
-#    state: exported
-#    thumbprint: '{{subj_thumbprint}}'
-#    path: '{{win_cert_dir}}'
-#  register: fail_export_path_is_dir
-#  failed_when: fail_export_path_is_dir.msg != "Cannot export cert to path '" + win_cert_dir + "' as it is a directory"
-#
-#- name: import pem certificate (check)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\subj-cert.pem'
-#    state: present
-#  register: import_pem_check
-#  check_mode: yes
-#
-#- name: get result of import pem certificate (check)
-#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-#  register: import_pem_result_check
-#
-#- name: assert results of import pem certificate (check)
-#  assert:
-#    that:
-#    - import_pem_check is changed
-#    - import_pem_check.thumbprints == [subj_thumbprint]
-#    - import_pem_result_check.stdout_lines[0] == "False"
-#
-#- name: import pem certificate
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\subj-cert.pem'
-#    state: present
-#  register: import_pem
-#
-#- name: get result of import pem certificate
-#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-#  register: import_pem_result
-#
-#- name: assert results of import pem certificate
-#  assert:
-#    that:
-#    - import_pem is changed
-#    - import_pem.thumbprints == [subj_thumbprint]
-#    - import_pem_result.stdout_lines[0] == "True"
-#
-#- name: import pem certificate (idempotent)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\subj-cert.pem'
-#    state: present
-#  register: import_pem_again
-#
-#- name: assert results of import pem certificate (idempotent)
-#  assert:
-#    that:
-#    - not import_pem_again is changed
-#
-#- name: remove certificate based on thumbprint (check)
-#  win_certificate_store:
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: absent
-#  register: remove_thumbprint_check
-#  check_mode: yes
-#
-#- name: get result of remove certificate based on thumbprint (check)
-#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-#  register: remove_thumbprint_result_check
-#
-#- name: assert results of remove certificate based on thumbprint (check)
-#  assert:
-#    that:
-#    - remove_thumbprint_check is changed
-#    - remove_thumbprint_check.thumbprints == [subj_thumbprint]
-#    - remove_thumbprint_result_check.stdout_lines[0] == "True"
-#
-#- name: remove certificate based on thumbprint
-#  win_certificate_store:
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: absent
-#  register: remove_thumbprint
-#
-#- name: get result of remove certificate based on thumbprint
-#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-#  register: remove_thumbprint_result
-#
-#- name: assert results of remove certificate based on thumbprint
-#  assert:
-#    that:
-#    - remove_thumbprint is changed
-#    - remove_thumbprint.thumbprints == [subj_thumbprint]
-#    - remove_thumbprint_result.stdout_lines[0] == "False"
-#
-#- name: remove certificate based on thumbprint (idempotent)
-#  win_certificate_store:
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: absent
-#  register: remove_thumbprint_again
-#
-#- name: assert results of remove certificate based on thumbprint (idempotent)
-#  assert:
-#    that:
-#    - not remove_thumbprint_again is changed
-#
-#- name: import der certificate (check)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\subj-cert.cer'
-#    state: present
-#  register: import_der_check
-#  check_mode: yes
-#
-#- name: get result of import der certificate (check)
-#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-#  register: import_der_result_check
-#
-#- name: assert results of import der certificate (check)
-#  assert:
-#    that:
-#    - import_der_check is changed
-#    - import_der_check.thumbprints == [subj_thumbprint]
-#    - import_der_result_check.stdout_lines[0] == "False"
-#
-#- name: import der certificate
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\subj-cert.cer'
-#    state: present
-#  register: import_der
-#
-#- name: get result of import der certificate
-#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-#  register: import_der_result
-#
-#- name: assert results of import der certificate
-#  assert:
-#    that:
-#    - import_der is changed
-#    - import_der.thumbprints == [subj_thumbprint]
-#    - import_der_result.stdout_lines[0] == "True"
-#
-#- name: import der certificate (idempotent)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\subj-cert.cer'
-#    state: present
-#  register: import_der_again
-#
-#- name: assert results of import der certificate (idempotent)
-#  assert:
-#    that:
-#    - not import_der_again is changed
-#
-#- name: remove certificate based on path (check)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\subj-cert.cer'
-#    state: absent
-#  register: remove_path_check
-#  check_mode: yes
-#
-#- name: get result of remove certificate based on path (check)
-#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-#  register: remove_path_result_check
-#
-#- name: assert results of remove certificate based on path (check)
-#  assert:
-#    that:
-#    - remove_path_check is changed
-#    - remove_path_check.thumbprints == [subj_thumbprint]
-#    - remove_path_result_check.stdout_lines[0] == "True"
-#
-#- name: remove certificate based on path
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\subj-cert.cer'
-#    state: absent
-#  register: remove_path
-#
-#- name: get result of remove certificate based on path
-#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-#  register: remove_path_result
-#
-#- name: assert results of remove certificate based on path
-#  assert:
-#    that:
-#    - remove_path is changed
-#    - remove_path.thumbprints == [subj_thumbprint]
-#    - remove_path_result.stdout_lines[0] == "False"
-#
-#- name: remove certificate based on path (idempotent)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\subj-cert.cer'
-#    state: absent
-#  register: remove_path_again
-#
-#- name: assert results of remove certificate based on path (idempotent)
-#  assert:
-#    that:
-#    - not remove_path_again is changed
-#
-#- name: import PEM encoded p7b chain (check)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\chain.pem'
-#    state: present
-#  register: import_pem_p7b_check
-#  check_mode: yes
-#
-#- name: get result of subj in p7b chain (check)
-#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-#  register: import_pem_p7b_subj_result_check
-#
-#- name: get result of root in p7b chain (check)
-#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
-#  register: import_pem_p7b_root_result_check
-#
-#- name: assert results of import PEM encoded p7b chain (check)
-#  assert:
-#    that:
-#    - import_pem_p7b_check is changed
-#    - import_pem_p7b_check.thumbprints|count == 2
-#    - subj_thumbprint in import_pem_p7b_check.thumbprints
-#    - root_thumbprint in import_pem_p7b_check.thumbprints
-#    - import_pem_p7b_subj_result_check.stdout_lines[0] == "False"
-#    - import_pem_p7b_root_result_check.stdout_lines[0] == "False"
-#
-#- name: import PEM encoded p7b chain
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\chain.pem'
-#    state: present
-#  register: import_pem_p7b
-#
-#- name: get result of subj in p7b chain
-#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-#  register: import_pem_p7b_subj_result
-#
-#- name: get result of root in p7b chain
-#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
-#  register: import_pem_p7b_root_result
-#
-#- name: assert results of import PEM encoded p7b chain
-#  assert:
-#    that:
-#    - import_pem_p7b is changed
-#    - import_pem_p7b.thumbprints|count == 2
-#    - subj_thumbprint in import_pem_p7b.thumbprints
-#    - root_thumbprint in import_pem_p7b.thumbprints
-#    - import_pem_p7b_subj_result.stdout_lines[0] == "True"
-#    - import_pem_p7b_root_result.stdout_lines[0] == "True"
-#
-#- name: import PEM encoded p7b chain (idempotent)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\chain.pem'
-#    state: present
-#  register: import_pem_p7b_again
-#
-#- name: assert results of import PEM encoded p7b chain (idempotent)
-#  assert:
-#    that:
-#    - not import_pem_p7b_again is changed
-#
-#- name: remove p7b chain certs
-#  win_certificate_store:
-#    thumbprint: '{{item}}'
-#    state: absent
-#  with_items:
-#  - '{{subj_thumbprint}}'
-#  - '{{root_thumbprint}}'
-#
-#- name: import DER encoded p7b chain into custom store (check)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\chain.p7b'
-#    state: present
-#    store_name: TrustedPeople
-#    store_location: CurrentUser
-#  register: import_der_p7b_check
-#  check_mode: yes
-#
-#- name: get result of subj in p7b chain in custom store (check)
-#  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-#  register: import_der_p7b_subj_result_check
-#
-#- name: get result of root in p7b chain in custom store (check)
-#  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
-#  register: import_der_p7b_root_result_check
-#
-#- name: assert results of import DER encoded p7b chain into custom store (check)
-#  assert:
-#    that:
-#    - import_der_p7b_check is changed
-#    - import_der_p7b_check.thumbprints|count == 2
-#    - subj_thumbprint in import_der_p7b_check.thumbprints
-#    - root_thumbprint in import_der_p7b_check.thumbprints
-#    - import_der_p7b_subj_result_check.stdout_lines[0] == "False"
-#    - import_der_p7b_root_result_check.stdout_lines[0] == "False"
-#
-#- name: import DER encoded p7b chain into custom store
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\chain.p7b'
-#    state: present
-#    store_name: TrustedPeople
-#    store_location: CurrentUser
-#  register: import_der_p7b
-#
-#- name: get result of subj in p7b chain in custom store
-#  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-#  register: import_der_p7b_subj_result
-#
-#- name: get result of root in p7b chain in custom store
-#  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
-#  register: import_der_p7b_root_result
-#
-#- name: assert results of import DER encoded p7b chain into custom store
-#  assert:
-#    that:
-#    - import_der_p7b is changed
-#    - import_der_p7b.thumbprints|count == 2
-#    - subj_thumbprint in import_der_p7b.thumbprints
-#    - root_thumbprint in import_der_p7b.thumbprints
-#    - import_der_p7b_root_result.stdout_lines[0] == "True"
-#    - import_der_p7b_root_result.stdout_lines[0] == "True"
-#
-#- name: import DER encoded p7b chain into custom store (idempotent)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\chain.p7b'
-#    state: present
-#    store_name: TrustedPeople
-#    store_location: CurrentUser
-#  register: import_der_p7b_again
-#
-#- name: assert results of import DER encoded p7b chain into custom store (idempotent)
-#  assert:
-#    that:
-#    - not import_der_p7b_again is changed
-#
-#- name: remove p7b chain certs from custom store
-#  win_certificate_store:
-#    thumbprint: '{{item}}'
-#    state: absent
-#    store_name: TrustedPeople
-#    store_location: CurrentUser
-#  with_items:
-#  - '{{subj_thumbprint}}'
-#  - '{{root_thumbprint}}'
-#
-#- name: import pfx without password and non exportable (check)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\subj-cert-without-pass.pfx'
-#    state: present
-#    key_exportable: no
-#  vars: &become_vars
-#    ansible_become: yes
-#    ansible_become_method: runas
-#    ansible_become_user: '{{ansible_user}}'
-#    ansible_become_pass: '{{ansible_password}}'
-#  register: import_pfx_without_pass_check
-#  check_mode: yes
-#
-#- name: get results of import pfx without password and non exportable (check)
-#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-#  register: import_pfx_without_pass_result_check
-#
-#- name: assert results of import pfx without password and non exportable (check)
-#  assert:
-#    that:
-#    - import_pfx_without_pass_check is changed
-#    - import_pfx_without_pass_check.thumbprints == [subj_thumbprint]
-#    - import_pfx_without_pass_result_check.stdout_lines[0] == "False"
-#
-#- name: import pfx without password and non exportable
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\subj-cert-without-pass.pfx'
-#    state: present
-#    key_exportable: no
-#  vars: *become_vars
-#  register: import_pfx_without_pass
-#
-#- name: get results of import pfx without password and non exportable
-#  win_shell: (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }).PrivateKey.CspKeyContainerInfo.Exportable
-#  vars: *become_vars
-#  register: import_pfx_without_pass_result
-#
-#- name: assert results of import pfx without password and non exportable
-#  assert:
-#    that:
-#    - import_pfx_without_pass is changed
-#    - import_pfx_without_pass.thumbprints == [subj_thumbprint]
-#    - import_pfx_without_pass_result.stdout_lines[0] == "False"
-#
-#- name: import pfx without password and non exportable (idempotent)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\subj-cert-without-pass.pfx'
-#    state: present
-#    key_exportable: no
-#  vars: *become_vars
-#  register: import_pfx_without_pass_again
-#
-#- name: assert results of import pfx without password and non exportable (idempotent)
-#  assert:
-#    that:
-#    - not import_pfx_without_pass_again is changed
-#
-#- name: fail import pfx with password and none set
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\subj-cert-with-pass.pfx'
-#    state: present
-#    store_location: CurrentUser
-#    store_name: TrustedPeople
-#  register: fail_import_pfx_with_password
-#  failed_when: "'Failed to load cert from file' not in fail_import_pfx_with_password.msg and 'The specified network password is not correct' not in fail_import_pfx_with_password.msg"
-#
-#- name: import pfx with password (check)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\subj-cert-with-pass.pfx'
-#    state: present
-#    password: '{{key_password}}'
-#    store_location: CurrentUser
-#    store_name: TrustedPeople
-#  register: import_pfx_with_pass_check
-#  vars: *become_vars
-#  check_mode: yes
-#
-#- name: get results of import pfx with password (check)
-#  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-#  register: import_pfx_with_pass_result_check
-#
-#- name: assert results of import pfx with password (check)
-#  assert:
-#    that:
-#    - import_pfx_with_pass_check is changed
-#    - import_pfx_with_pass_check.thumbprints == [subj_thumbprint]
-#    - import_pfx_with_pass_result_check.stdout_lines[0] == "False"
-#
-#- name: import pfx with password
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\subj-cert-with-pass.pfx'
-#    state: present
-#    password: '{{key_password}}'
-#    store_location: CurrentUser
-#    store_name: TrustedPeople
-#  vars: *become_vars
-#  register: import_pfx_with_pass
-#
-#- name: get results of import pfx with password
-#  win_shell: (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }).PrivateKey.CspKeyContainerInfo.Exportable
-#  vars: *become_vars
-#  register: import_pfx_with_pass_result
-#
-#- name: assert results of import pfx with password
-#  assert:
-#    that:
-#    - import_pfx_with_pass is changed
-#    - import_pfx_with_pass.thumbprints == [subj_thumbprint]
-#    - import_pfx_with_pass_result.stdout_lines[0] == "True"
-#
-#- name: import pfx with password (idempotent)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\subj-cert-with-pass.pfx'
-#    state: present
-#    password: '{{key_password}}'
-#    store_location: CurrentUser
-#    store_name: TrustedPeople
-#  vars: *become_vars
-#  register: import_pfx_with_pass_again
-#
-#- name: assert results of import pfx with password (idempotent)
-#  assert:
-#    that:
-#    - not import_pfx_with_pass_again is changed
-#
-#- name: import root cert for export tests
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\root-cert.pem'
-#    state: present
-#
-#- name: export cert as pem (check)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\exported\cert.pem'
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: exported
-#    file_type: pem
-#  register: export_pem_check
-#  check_mode: yes
-#
-#- name: get result of export cert as pem (check)
-#  win_stat:
-#    path: '{{win_cert_dir}}\exported\cert.pem'
-#  register: export_pem_result_check
-#
-#- name: assert results of export cert as pem (check)
-#  assert:
-#    that:
-#    - export_pem_check is changed
-#    - export_pem_check.thumbprints == [subj_thumbprint]
-#    - export_pem_result_check.stat.exists == False
-#
-#- name: export cert as pem
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\exported\cert.pem'
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: exported
-#    file_type: pem
-#  register: export_pem
-#
-#- name: get result of export cert as pem
-#  win_stat:
-#    path: '{{win_cert_dir}}\exported\cert.pem'
-#  register: export_pem_result
-#
-#- name: assert results of export cert as pem
-#  assert:
-#    that:
-#    - export_pem is changed
-#    - export_pem.thumbprints == [subj_thumbprint]
-#    - export_pem_result.stat.checksum == '1ebf5467d18230e9f611940a74d12f1d0bc819b7'
-#
-#- name: export cert as pem (idempotent)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\exported\cert.pem'
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: exported
-#    file_type: pem
-#  register: export_pem_again
-#
-#- name: assert results of export cert as pem
-#  assert:
-#    that:
-#    - not export_pem_again is changed
-#
-#- name: export cert as der (check)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\exported\cert.cer'
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: exported
-#    file_type: der
-#  register: export_der_check
-#  check_mode: yes
-#
-#- name: get result of export cert as der (check)
-#  win_stat:
-#    path: '{{win_cert_dir}}\exported\cert.cer'
-#  register: export_der_result_check
-#
-#- name: assert results of export cert as der (check)
-#  assert:
-#    that:
-#    - export_der_check is changed
-#    - export_der_check.thumbprints == [subj_thumbprint]
-#    - export_der_result_check.stat.exists == False
-#
-#- name: export cert as der
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\exported\cert.cer'
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: exported
-#    file_type: der
-#  register: export_der
-#
-#- name: get result of export cert as der
-#  win_stat:
-#    path: '{{win_cert_dir}}\exported\cert.cer'
-#  register: export_der_result
-#
-#- name: assert results of export cert as der
-#  assert:
-#    that:
-#    - export_der is changed
-#    - export_der.thumbprints == [subj_thumbprint]
-#    - export_der_result.stat.checksum == 'bd7af104cf1872bdb518d95c9534ea941665fd27'
-#
-#- name: export cert as der (idempotent)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\exported\cert.cer'
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: exported
-#    file_type: der
-#  register: export_der_again
-#
-#- name: assert results of export cert as der
-#  assert:
-#    that:
-#    - not export_der_again is changed
-#
-#- name: export cert as der replacing pem
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\exported\cert.pem'
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: exported
-#    file_type: der
-#  register: export_der_over_pem
-#
-#- name: get result of export cert as der replacing pem
-#  win_stat:
-#    path: '{{win_cert_dir}}\exported\cert.pem'
-#  register: export_der_over_pem_result
-#
-#- name: assert results of export cert as der replacing pem
-#  assert:
-#    that:
-#    - export_der_over_pem is changed
-#    - export_der_over_pem.thumbprints == [subj_thumbprint]
-#    - export_der_over_pem_result.stat.checksum == 'bd7af104cf1872bdb518d95c9534ea941665fd27'
-#
-#- name: export cert as pem replacing der
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\exported\cert.cer'
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: exported
-#    file_type: pem
-#  register: export_pem_over_der
-#
-#- name: get result of export cert as pem replacing der
-#  win_stat:
-#    path: '{{win_cert_dir}}\exported\cert.cer'
-#  register: export_pem_over_der_result
-#
-#- name: assert results of export cert as pem replacing der
-#  assert:
-#    that:
-#    - export_pem_over_der is changed
-#    - export_pem_over_der.thumbprints == [subj_thumbprint]
-#    - export_pem_over_der_result.stat.checksum == '1ebf5467d18230e9f611940a74d12f1d0bc819b7'
-#
-#- name: export cert with key and password as pfx (check)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\exported\cert-pass.pfx'
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: exported
-#    file_type: pkcs12
-#    store_location: CurrentUser
-#    store_name: TrustedPeople
-#    password: '{{key_password}}'
-#  register: export_pfx_with_pass_check
-#  vars: *become_vars
-#  check_mode: yes
-#
-#- name: get result of export cert with key and password as pfx (check)
-#  win_stat:
-#    path: '{{win_cert_dir}}\exported\cert-pass.pfx'
-#  register: export_pfx_with_pass_result_check
-#
-#- name: assert results of export cert with key and password as pfx (check)
-#  assert:
-#    that:
-#    - export_pfx_with_pass_check is changed
-#    - export_pfx_with_pass_check.thumbprints == [subj_thumbprint]
-#    - export_pfx_with_pass_result_check.stat.exists == False
-#
-#- name: export cert with key and password as pfx
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\exported\cert-pass.pfx'
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: exported
-#    file_type: pkcs12
-#    store_location: CurrentUser
-#    store_name: TrustedPeople
-#    password: '{{key_password}}'
-#  vars: *become_vars
-#  register: export_pfx_with_pass
-#
-#- name: get result of export cert with key and password as pfx
-#  win_shell: |
-#    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
-#    $cert.Import("{{win_cert_dir}}\exported\cert-pass.pfx", "{{key_password}}", 0)
-#    $cert.HasPrivateKey
-#  vars: *become_vars
-#  register: export_pfx_with_pass_result
-#
-#- name: assert results of export cert with key and password as pfx
-#  assert:
-#    that:
-#    - export_pfx_with_pass is changed
-#    - export_pfx_with_pass.thumbprints == [subj_thumbprint]
-#    - export_pfx_with_pass_result.stdout_lines[0] == "True"
-#
-#- name: export cert with key and password as pfx (idempotent)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\exported\cert-pass.pfx'
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: exported
-#    file_type: pkcs12
-#    store_location: CurrentUser
-#    store_name: TrustedPeople
-#    password: '{{key_password}}'
-#  vars: *become_vars
-#  register: export_pfx_with_pass_again
-#
-#- name: assert results of export cert with key and password as pfx (idempotent)
-#  assert:
-#    that:
-#    - not export_pfx_with_pass_again is changed
-#
-#- name: export cert with key without password as pfx (check)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\exported\cert-without-pass.pfx'
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: exported
-#    file_type: pkcs12
-#    store_location: CurrentUser
-#    store_name: TrustedPeople
-#  vars: *become_vars
-#  register: export_pfx_without_pass_check
-#  check_mode: yes
-#
-#- name: get result of export cert with key without password as pfx (check)
-#  win_stat:
-#    path: '{{win_cert_dir}}\exported\cert-without-pass.pfx'
-#  register: export_pfx_without_pass_result_check
-#
-#- name: assert results of export cert with key without password as pfx (check)
-#  assert:
-#    that:
-#    - export_pfx_without_pass_check is changed
-#    - export_pfx_without_pass_check.thumbprints == [subj_thumbprint]
-#    - export_pfx_without_pass_result_check.stat.exists == False
-#
-#- name: export cert with key without password as pfx
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\exported\cert-without-pass.pfx'
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: exported
-#    file_type: pkcs12
-#    store_location: CurrentUser
-#    store_name: TrustedPeople
-#  vars: *become_vars
-#  register: export_pfx_without_pass
-#
-#- name: get result of export cert with key without password as pfx
-#  win_shell: |
-#    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
-#    $cert.Import("{{win_cert_dir}}\exported\cert-without-pass.pfx", $null, 0)
-#    $cert.HasPrivateKey
-#  vars: *become_vars
-#  register: export_pfx_without_pass_result
-#
-#- name: assert results of export cert with key without password as pfx
-#  assert:
-#    that:
-#    - export_pfx_without_pass is changed
-#    - export_pfx_without_pass.thumbprints == [subj_thumbprint]
-#    - export_pfx_without_pass_result.stdout_lines[0] == "True"
-#
-#- name: export cert with key without password as pfx (idempotent)
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\exported\cert-without-pass.pfx'
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: exported
-#    file_type: pkcs12
-#    store_location: CurrentUser
-#    store_name: TrustedPeople
-#  vars: *become_vars
-#  register: export_pfx_without_pass_again
-#
-#- name: assert results of export cert with key without password as pfx (idempotent)
-#  assert:
-#    that:
-#    - not export_pfx_without_pass_again is changed
-#
-#- name: fail to export cert with key as pfx when not marked as exportable
-#  win_certificate_store:
-#    path: '{{win_cert_dir}}\exported\cert-fail.pfx'
-#    thumbprint: '{{subj_thumbprint}}'
-#    state: exported
-#    file_type: pkcs12
-#  vars: *become_vars
-#  register: fail_export_non_exportable
-#  failed_when: fail_export_non_exportable.msg != 'Cannot export cert with key as PKCS12 when the key is not marked as exportable or not accessible by the current user'
+---
+- name: fail with invalid store location
+  win_certificate_store:
+    state: present
+    path: '{{win_cert_dir}}\subj-cert.pem'
+    store_location: FakeLocation
+  register: fail_fake_location
+  failed_when: "fail_fake_location.msg != 'value of store_location must be one of: CurrentUser, LocalMachine. Got no match for: FakeLocation'"
+
+- name: fail to open non-existing store without the creates flag
+  win_certificate_store:
+    state: present
+    path: '{{win_cert_dir}}\subj-cert.pem'
+    store_name: FakeName
+  register: fail_fake_name
+  failed_when: '"unable to find store ''FakeName''" not in fail_fake_name.msg'
+
+- name: fail when state=present and no path is set
+  win_certificate_store:
+    state: present
+  register: fail_present_no_path
+  failed_when: "fail_present_no_path.msg != 'state is present but all of the following are missing: path'"
+
+- name: fail when state=exported and no path is set
+  win_certificate_store:
+    state: exported
+    thumbprint: ABC
+  register: fail_export_no_path
+  failed_when: "fail_export_no_path.msg != 'state is exported but all of the following are missing: path'"
+
+- name: fail when state=exported and no thumbprint is set
+  win_certificate_store:
+    state: exported
+    path: '{{win_cert_dir}}'
+  register: fail_export_no_thumbprint
+  failed_when: "fail_export_no_thumbprint.msg != 'state is exported but all of the following are missing: thumbprint'"
+
+- name: fail to export thumbprint when path is a dir
+  win_certificate_store:
+    state: exported
+    thumbprint: '{{subj_thumbprint}}'
+    path: '{{win_cert_dir}}'
+  register: fail_export_path_is_dir
+  failed_when: fail_export_path_is_dir.msg != "Cannot export cert to path '" + win_cert_dir + "' as it is a directory"
+
+- name: import pem certificate (check)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\subj-cert.pem'
+    state: present
+  register: import_pem_check
+  check_mode: yes
+
+- name: get result of import pem certificate (check)
+  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+  register: import_pem_result_check
+
+- name: assert results of import pem certificate (check)
+  assert:
+    that:
+    - import_pem_check is changed
+    - import_pem_check.thumbprints == [subj_thumbprint]
+    - import_pem_result_check.stdout_lines[0] == "False"
+
+- name: import pem certificate
+  win_certificate_store:
+    path: '{{win_cert_dir}}\subj-cert.pem'
+    state: present
+  register: import_pem
+
+- name: get result of import pem certificate
+  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+  register: import_pem_result
+
+- name: assert results of import pem certificate
+  assert:
+    that:
+    - import_pem is changed
+    - import_pem.thumbprints == [subj_thumbprint]
+    - import_pem_result.stdout_lines[0] == "True"
+
+- name: import pem certificate (idempotent)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\subj-cert.pem'
+    state: present
+  register: import_pem_again
+
+- name: assert results of import pem certificate (idempotent)
+  assert:
+    that:
+    - not import_pem_again is changed
+
+- name: remove certificate based on thumbprint (check)
+  win_certificate_store:
+    thumbprint: '{{subj_thumbprint}}'
+    state: absent
+  register: remove_thumbprint_check
+  check_mode: yes
+
+- name: get result of remove certificate based on thumbprint (check)
+  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+  register: remove_thumbprint_result_check
+
+- name: assert results of remove certificate based on thumbprint (check)
+  assert:
+    that:
+    - remove_thumbprint_check is changed
+    - remove_thumbprint_check.thumbprints == [subj_thumbprint]
+    - remove_thumbprint_result_check.stdout_lines[0] == "True"
+
+- name: remove certificate based on thumbprint
+  win_certificate_store:
+    thumbprint: '{{subj_thumbprint}}'
+    state: absent
+  register: remove_thumbprint
+
+- name: get result of remove certificate based on thumbprint
+  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+  register: remove_thumbprint_result
+
+- name: assert results of remove certificate based on thumbprint
+  assert:
+    that:
+    - remove_thumbprint is changed
+    - remove_thumbprint.thumbprints == [subj_thumbprint]
+    - remove_thumbprint_result.stdout_lines[0] == "False"
+
+- name: remove certificate based on thumbprint (idempotent)
+  win_certificate_store:
+    thumbprint: '{{subj_thumbprint}}'
+    state: absent
+  register: remove_thumbprint_again
+
+- name: assert results of remove certificate based on thumbprint (idempotent)
+  assert:
+    that:
+    - not remove_thumbprint_again is changed
+
+- name: import der certificate (check)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\subj-cert.cer'
+    state: present
+  register: import_der_check
+  check_mode: yes
+
+- name: get result of import der certificate (check)
+  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+  register: import_der_result_check
+
+- name: assert results of import der certificate (check)
+  assert:
+    that:
+    - import_der_check is changed
+    - import_der_check.thumbprints == [subj_thumbprint]
+    - import_der_result_check.stdout_lines[0] == "False"
+
+- name: import der certificate
+  win_certificate_store:
+    path: '{{win_cert_dir}}\subj-cert.cer'
+    state: present
+  register: import_der
+
+- name: get result of import der certificate
+  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+  register: import_der_result
+
+- name: assert results of import der certificate
+  assert:
+    that:
+    - import_der is changed
+    - import_der.thumbprints == [subj_thumbprint]
+    - import_der_result.stdout_lines[0] == "True"
+
+- name: import der certificate (idempotent)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\subj-cert.cer'
+    state: present
+  register: import_der_again
+
+- name: assert results of import der certificate (idempotent)
+  assert:
+    that:
+    - not import_der_again is changed
+
+- name: remove certificate based on path (check)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\subj-cert.cer'
+    state: absent
+  register: remove_path_check
+  check_mode: yes
+
+- name: get result of remove certificate based on path (check)
+  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+  register: remove_path_result_check
+
+- name: assert results of remove certificate based on path (check)
+  assert:
+    that:
+    - remove_path_check is changed
+    - remove_path_check.thumbprints == [subj_thumbprint]
+    - remove_path_result_check.stdout_lines[0] == "True"
+
+- name: remove certificate based on path
+  win_certificate_store:
+    path: '{{win_cert_dir}}\subj-cert.cer'
+    state: absent
+  register: remove_path
+
+- name: get result of remove certificate based on path
+  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+  register: remove_path_result
+
+- name: assert results of remove certificate based on path
+  assert:
+    that:
+    - remove_path is changed
+    - remove_path.thumbprints == [subj_thumbprint]
+    - remove_path_result.stdout_lines[0] == "False"
+
+- name: remove certificate based on path (idempotent)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\subj-cert.cer'
+    state: absent
+  register: remove_path_again
+
+- name: assert results of remove certificate based on path (idempotent)
+  assert:
+    that:
+    - not remove_path_again is changed
+
+- name: import PEM encoded p7b chain (check)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\chain.pem'
+    state: present
+  register: import_pem_p7b_check
+  check_mode: yes
+
+- name: get result of subj in p7b chain (check)
+  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+  register: import_pem_p7b_subj_result_check
+
+- name: get result of root in p7b chain (check)
+  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
+  register: import_pem_p7b_root_result_check
+
+- name: assert results of import PEM encoded p7b chain (check)
+  assert:
+    that:
+    - import_pem_p7b_check is changed
+    - import_pem_p7b_check.thumbprints|count == 2
+    - subj_thumbprint in import_pem_p7b_check.thumbprints
+    - root_thumbprint in import_pem_p7b_check.thumbprints
+    - import_pem_p7b_subj_result_check.stdout_lines[0] == "False"
+    - import_pem_p7b_root_result_check.stdout_lines[0] == "False"
+
+- name: import PEM encoded p7b chain
+  win_certificate_store:
+    path: '{{win_cert_dir}}\chain.pem'
+    state: present
+  register: import_pem_p7b
+
+- name: get result of subj in p7b chain
+  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+  register: import_pem_p7b_subj_result
+
+- name: get result of root in p7b chain
+  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
+  register: import_pem_p7b_root_result
+
+- name: assert results of import PEM encoded p7b chain
+  assert:
+    that:
+    - import_pem_p7b is changed
+    - import_pem_p7b.thumbprints|count == 2
+    - subj_thumbprint in import_pem_p7b.thumbprints
+    - root_thumbprint in import_pem_p7b.thumbprints
+    - import_pem_p7b_subj_result.stdout_lines[0] == "True"
+    - import_pem_p7b_root_result.stdout_lines[0] == "True"
+
+- name: import PEM encoded p7b chain (idempotent)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\chain.pem'
+    state: present
+  register: import_pem_p7b_again
+
+- name: assert results of import PEM encoded p7b chain (idempotent)
+  assert:
+    that:
+    - not import_pem_p7b_again is changed
+
+- name: remove p7b chain certs
+  win_certificate_store:
+    thumbprint: '{{item}}'
+    state: absent
+  with_items:
+  - '{{subj_thumbprint}}'
+  - '{{root_thumbprint}}'
+
+- name: import DER encoded p7b chain into custom store (check)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\chain.p7b'
+    state: present
+    store_name: TrustedPeople
+    store_location: CurrentUser
+  register: import_der_p7b_check
+  check_mode: yes
+
+- name: get result of subj in p7b chain in custom store (check)
+  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+  register: import_der_p7b_subj_result_check
+
+- name: get result of root in p7b chain in custom store (check)
+  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
+  register: import_der_p7b_root_result_check
+
+- name: assert results of import DER encoded p7b chain into custom store (check)
+  assert:
+    that:
+    - import_der_p7b_check is changed
+    - import_der_p7b_check.thumbprints|count == 2
+    - subj_thumbprint in import_der_p7b_check.thumbprints
+    - root_thumbprint in import_der_p7b_check.thumbprints
+    - import_der_p7b_subj_result_check.stdout_lines[0] == "False"
+    - import_der_p7b_root_result_check.stdout_lines[0] == "False"
+
+- name: import DER encoded p7b chain into custom store
+  win_certificate_store:
+    path: '{{win_cert_dir}}\chain.p7b'
+    state: present
+    store_name: TrustedPeople
+    store_location: CurrentUser
+  register: import_der_p7b
+
+- name: get result of subj in p7b chain in custom store
+  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+  register: import_der_p7b_subj_result
+
+- name: get result of root in p7b chain in custom store
+  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
+  register: import_der_p7b_root_result
+
+- name: assert results of import DER encoded p7b chain into custom store
+  assert:
+    that:
+    - import_der_p7b is changed
+    - import_der_p7b.thumbprints|count == 2
+    - subj_thumbprint in import_der_p7b.thumbprints
+    - root_thumbprint in import_der_p7b.thumbprints
+    - import_der_p7b_root_result.stdout_lines[0] == "True"
+    - import_der_p7b_root_result.stdout_lines[0] == "True"
+
+- name: import DER encoded p7b chain into custom store (idempotent)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\chain.p7b'
+    state: present
+    store_name: TrustedPeople
+    store_location: CurrentUser
+  register: import_der_p7b_again
+
+- name: assert results of import DER encoded p7b chain into custom store (idempotent)
+  assert:
+    that:
+    - not import_der_p7b_again is changed
+
+- name: remove p7b chain certs from custom store
+  win_certificate_store:
+    thumbprint: '{{item}}'
+    state: absent
+    store_name: TrustedPeople
+    store_location: CurrentUser
+  with_items:
+  - '{{subj_thumbprint}}'
+  - '{{root_thumbprint}}'
+
+- name: import pfx without password and non exportable (check)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\subj-cert-without-pass.pfx'
+    state: present
+    key_exportable: no
+  vars: &become_vars
+    ansible_become: yes
+    ansible_become_method: runas
+    ansible_become_user: '{{ansible_user}}'
+    ansible_become_pass: '{{ansible_password}}'
+  register: import_pfx_without_pass_check
+  check_mode: yes
+
+- name: get results of import pfx without password and non exportable (check)
+  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+  register: import_pfx_without_pass_result_check
+
+- name: assert results of import pfx without password and non exportable (check)
+  assert:
+    that:
+    - import_pfx_without_pass_check is changed
+    - import_pfx_without_pass_check.thumbprints == [subj_thumbprint]
+    - import_pfx_without_pass_result_check.stdout_lines[0] == "False"
+
+- name: import pfx without password and non exportable
+  win_certificate_store:
+    path: '{{win_cert_dir}}\subj-cert-without-pass.pfx'
+    state: present
+    key_exportable: no
+  vars: *become_vars
+  register: import_pfx_without_pass
+
+- name: get results of import pfx without password and non exportable
+  win_shell: (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }).PrivateKey.CspKeyContainerInfo.Exportable
+  vars: *become_vars
+  register: import_pfx_without_pass_result
+
+- name: assert results of import pfx without password and non exportable
+  assert:
+    that:
+    - import_pfx_without_pass is changed
+    - import_pfx_without_pass.thumbprints == [subj_thumbprint]
+    - import_pfx_without_pass_result.stdout_lines[0] == "False"
+
+- name: import pfx without password and non exportable (idempotent)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\subj-cert-without-pass.pfx'
+    state: present
+    key_exportable: no
+  vars: *become_vars
+  register: import_pfx_without_pass_again
+
+- name: assert results of import pfx without password and non exportable (idempotent)
+  assert:
+    that:
+    - not import_pfx_without_pass_again is changed
+
+- name: fail import pfx with password and none set
+  win_certificate_store:
+    path: '{{win_cert_dir}}\subj-cert-with-pass.pfx'
+    state: present
+    store_location: CurrentUser
+    store_name: TrustedPeople
+  register: fail_import_pfx_with_password
+  failed_when: "'Failed to load cert from file' not in fail_import_pfx_with_password.msg and 'The specified network password is not correct' not in fail_import_pfx_with_password.msg"
+
+- name: import pfx with password (check)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\subj-cert-with-pass.pfx'
+    state: present
+    password: '{{key_password}}'
+    store_location: CurrentUser
+    store_name: TrustedPeople
+  register: import_pfx_with_pass_check
+  vars: *become_vars
+  check_mode: yes
+
+- name: get results of import pfx with password (check)
+  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+  register: import_pfx_with_pass_result_check
+
+- name: assert results of import pfx with password (check)
+  assert:
+    that:
+    - import_pfx_with_pass_check is changed
+    - import_pfx_with_pass_check.thumbprints == [subj_thumbprint]
+    - import_pfx_with_pass_result_check.stdout_lines[0] == "False"
+
+- name: import pfx with password
+  win_certificate_store:
+    path: '{{win_cert_dir}}\subj-cert-with-pass.pfx'
+    state: present
+    password: '{{key_password}}'
+    store_location: CurrentUser
+    store_name: TrustedPeople
+  vars: *become_vars
+  register: import_pfx_with_pass
+
+- name: get results of import pfx with password
+  win_shell: (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }).PrivateKey.CspKeyContainerInfo.Exportable
+  vars: *become_vars
+  register: import_pfx_with_pass_result
+
+- name: assert results of import pfx with password
+  assert:
+    that:
+    - import_pfx_with_pass is changed
+    - import_pfx_with_pass.thumbprints == [subj_thumbprint]
+    - import_pfx_with_pass_result.stdout_lines[0] == "True"
+
+- name: import pfx with password (idempotent)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\subj-cert-with-pass.pfx'
+    state: present
+    password: '{{key_password}}'
+    store_location: CurrentUser
+    store_name: TrustedPeople
+  vars: *become_vars
+  register: import_pfx_with_pass_again
+
+- name: assert results of import pfx with password (idempotent)
+  assert:
+    that:
+    - not import_pfx_with_pass_again is changed
+
+- name: import root cert for export tests
+  win_certificate_store:
+    path: '{{win_cert_dir}}\root-cert.pem'
+    state: present
+
+- name: export cert as pem (check)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\exported\cert.pem'
+    thumbprint: '{{subj_thumbprint}}'
+    state: exported
+    file_type: pem
+  register: export_pem_check
+  check_mode: yes
+
+- name: get result of export cert as pem (check)
+  win_stat:
+    path: '{{win_cert_dir}}\exported\cert.pem'
+  register: export_pem_result_check
+
+- name: assert results of export cert as pem (check)
+  assert:
+    that:
+    - export_pem_check is changed
+    - export_pem_check.thumbprints == [subj_thumbprint]
+    - export_pem_result_check.stat.exists == False
+
+- name: export cert as pem
+  win_certificate_store:
+    path: '{{win_cert_dir}}\exported\cert.pem'
+    thumbprint: '{{subj_thumbprint}}'
+    state: exported
+    file_type: pem
+  register: export_pem
+
+- name: get result of export cert as pem
+  win_stat:
+    path: '{{win_cert_dir}}\exported\cert.pem'
+  register: export_pem_result
+
+- name: assert results of export cert as pem
+  assert:
+    that:
+    - export_pem is changed
+    - export_pem.thumbprints == [subj_thumbprint]
+    - export_pem_result.stat.checksum == '1ebf5467d18230e9f611940a74d12f1d0bc819b7'
+
+- name: export cert as pem (idempotent)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\exported\cert.pem'
+    thumbprint: '{{subj_thumbprint}}'
+    state: exported
+    file_type: pem
+  register: export_pem_again
+
+- name: assert results of export cert as pem
+  assert:
+    that:
+    - not export_pem_again is changed
+
+- name: export cert as der (check)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\exported\cert.cer'
+    thumbprint: '{{subj_thumbprint}}'
+    state: exported
+    file_type: der
+  register: export_der_check
+  check_mode: yes
+
+- name: get result of export cert as der (check)
+  win_stat:
+    path: '{{win_cert_dir}}\exported\cert.cer'
+  register: export_der_result_check
+
+- name: assert results of export cert as der (check)
+  assert:
+    that:
+    - export_der_check is changed
+    - export_der_check.thumbprints == [subj_thumbprint]
+    - export_der_result_check.stat.exists == False
+
+- name: export cert as der
+  win_certificate_store:
+    path: '{{win_cert_dir}}\exported\cert.cer'
+    thumbprint: '{{subj_thumbprint}}'
+    state: exported
+    file_type: der
+  register: export_der
+
+- name: get result of export cert as der
+  win_stat:
+    path: '{{win_cert_dir}}\exported\cert.cer'
+  register: export_der_result
+
+- name: assert results of export cert as der
+  assert:
+    that:
+    - export_der is changed
+    - export_der.thumbprints == [subj_thumbprint]
+    - export_der_result.stat.checksum == 'bd7af104cf1872bdb518d95c9534ea941665fd27'
+
+- name: export cert as der (idempotent)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\exported\cert.cer'
+    thumbprint: '{{subj_thumbprint}}'
+    state: exported
+    file_type: der
+  register: export_der_again
+
+- name: assert results of export cert as der
+  assert:
+    that:
+    - not export_der_again is changed
+
+- name: export cert as der replacing pem
+  win_certificate_store:
+    path: '{{win_cert_dir}}\exported\cert.pem'
+    thumbprint: '{{subj_thumbprint}}'
+    state: exported
+    file_type: der
+  register: export_der_over_pem
+
+- name: get result of export cert as der replacing pem
+  win_stat:
+    path: '{{win_cert_dir}}\exported\cert.pem'
+  register: export_der_over_pem_result
+
+- name: assert results of export cert as der replacing pem
+  assert:
+    that:
+    - export_der_over_pem is changed
+    - export_der_over_pem.thumbprints == [subj_thumbprint]
+    - export_der_over_pem_result.stat.checksum == 'bd7af104cf1872bdb518d95c9534ea941665fd27'
+
+- name: export cert as pem replacing der
+  win_certificate_store:
+    path: '{{win_cert_dir}}\exported\cert.cer'
+    thumbprint: '{{subj_thumbprint}}'
+    state: exported
+    file_type: pem
+  register: export_pem_over_der
+
+- name: get result of export cert as pem replacing der
+  win_stat:
+    path: '{{win_cert_dir}}\exported\cert.cer'
+  register: export_pem_over_der_result
+
+- name: assert results of export cert as pem replacing der
+  assert:
+    that:
+    - export_pem_over_der is changed
+    - export_pem_over_der.thumbprints == [subj_thumbprint]
+    - export_pem_over_der_result.stat.checksum == '1ebf5467d18230e9f611940a74d12f1d0bc819b7'
+
+- name: export cert with key and password as pfx (check)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\exported\cert-pass.pfx'
+    thumbprint: '{{subj_thumbprint}}'
+    state: exported
+    file_type: pkcs12
+    store_location: CurrentUser
+    store_name: TrustedPeople
+    password: '{{key_password}}'
+  register: export_pfx_with_pass_check
+  vars: *become_vars
+  check_mode: yes
+
+- name: get result of export cert with key and password as pfx (check)
+  win_stat:
+    path: '{{win_cert_dir}}\exported\cert-pass.pfx'
+  register: export_pfx_with_pass_result_check
+
+- name: assert results of export cert with key and password as pfx (check)
+  assert:
+    that:
+    - export_pfx_with_pass_check is changed
+    - export_pfx_with_pass_check.thumbprints == [subj_thumbprint]
+    - export_pfx_with_pass_result_check.stat.exists == False
+
+- name: export cert with key and password as pfx
+  win_certificate_store:
+    path: '{{win_cert_dir}}\exported\cert-pass.pfx'
+    thumbprint: '{{subj_thumbprint}}'
+    state: exported
+    file_type: pkcs12
+    store_location: CurrentUser
+    store_name: TrustedPeople
+    password: '{{key_password}}'
+  vars: *become_vars
+  register: export_pfx_with_pass
+
+- name: get result of export cert with key and password as pfx
+  win_shell: |
+    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
+    $cert.Import("{{win_cert_dir}}\exported\cert-pass.pfx", "{{key_password}}", 0)
+    $cert.HasPrivateKey
+  vars: *become_vars
+  register: export_pfx_with_pass_result
+
+- name: assert results of export cert with key and password as pfx
+  assert:
+    that:
+    - export_pfx_with_pass is changed
+    - export_pfx_with_pass.thumbprints == [subj_thumbprint]
+    - export_pfx_with_pass_result.stdout_lines[0] == "True"
+
+- name: export cert with key and password as pfx (idempotent)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\exported\cert-pass.pfx'
+    thumbprint: '{{subj_thumbprint}}'
+    state: exported
+    file_type: pkcs12
+    store_location: CurrentUser
+    store_name: TrustedPeople
+    password: '{{key_password}}'
+  vars: *become_vars
+  register: export_pfx_with_pass_again
+
+- name: assert results of export cert with key and password as pfx (idempotent)
+  assert:
+    that:
+    - not export_pfx_with_pass_again is changed
+
+- name: export cert with key without password as pfx (check)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\exported\cert-without-pass.pfx'
+    thumbprint: '{{subj_thumbprint}}'
+    state: exported
+    file_type: pkcs12
+    store_location: CurrentUser
+    store_name: TrustedPeople
+  vars: *become_vars
+  register: export_pfx_without_pass_check
+  check_mode: yes
+
+- name: get result of export cert with key without password as pfx (check)
+  win_stat:
+    path: '{{win_cert_dir}}\exported\cert-without-pass.pfx'
+  register: export_pfx_without_pass_result_check
+
+- name: assert results of export cert with key without password as pfx (check)
+  assert:
+    that:
+    - export_pfx_without_pass_check is changed
+    - export_pfx_without_pass_check.thumbprints == [subj_thumbprint]
+    - export_pfx_without_pass_result_check.stat.exists == False
+
+- name: export cert with key without password as pfx
+  win_certificate_store:
+    path: '{{win_cert_dir}}\exported\cert-without-pass.pfx'
+    thumbprint: '{{subj_thumbprint}}'
+    state: exported
+    file_type: pkcs12
+    store_location: CurrentUser
+    store_name: TrustedPeople
+  vars: *become_vars
+  register: export_pfx_without_pass
+
+- name: get result of export cert with key without password as pfx
+  win_shell: |
+    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
+    $cert.Import("{{win_cert_dir}}\exported\cert-without-pass.pfx", $null, 0)
+    $cert.HasPrivateKey
+  vars: *become_vars
+  register: export_pfx_without_pass_result
+
+- name: assert results of export cert with key without password as pfx
+  assert:
+    that:
+    - export_pfx_without_pass is changed
+    - export_pfx_without_pass.thumbprints == [subj_thumbprint]
+    - export_pfx_without_pass_result.stdout_lines[0] == "True"
+
+- name: export cert with key without password as pfx (idempotent)
+  win_certificate_store:
+    path: '{{win_cert_dir}}\exported\cert-without-pass.pfx'
+    thumbprint: '{{subj_thumbprint}}'
+    state: exported
+    file_type: pkcs12
+    store_location: CurrentUser
+    store_name: TrustedPeople
+  vars: *become_vars
+  register: export_pfx_without_pass_again
+
+- name: assert results of export cert with key without password as pfx (idempotent)
+  assert:
+    that:
+    - not export_pfx_without_pass_again is changed
+
+- name: fail to export cert with key as pfx when not marked as exportable
+  win_certificate_store:
+    path: '{{win_cert_dir}}\exported\cert-fail.pfx'
+    thumbprint: '{{subj_thumbprint}}'
+    state: exported
+    file_type: pkcs12
+  vars: *become_vars
+  register: fail_export_non_exportable
+  failed_when: fail_export_non_exportable.msg != 'Cannot export cert with key as PKCS12 when the key is not marked as exportable or not accessible by the current user'
 
 - name: fail to import with invalid service name
   win_certificate_store:
@@ -919,4 +919,3 @@
       store_type: service
       store_location: WinRM
       state: absent
-

--- a/tests/integration/targets/win_certificate_store/tasks/test.yml
+++ b/tests/integration/targets/win_certificate_store/tasks/test.yml
@@ -1,801 +1,922 @@
----
-- name: fail with invalid store location
+#---
+#- name: fail with invalid store location
+#  win_certificate_store:
+#    state: present
+#    path: '{{win_cert_dir}}\subj-cert.pem'
+#    store_location: FakeLocation
+#  register: fail_fake_location
+#  failed_when: "fail_fake_location.msg != 'value of store_location must be one of: CurrentUser, LocalMachine. Got no match for: FakeLocation'"
+#
+#- name: fail to open non-existing store without the creates flag
+#  win_certificate_store:
+#    state: present
+#    path: '{{win_cert_dir}}\subj-cert.pem'
+#    store_name: FakeName
+#  register: fail_fake_name
+#  failed_when: '"unable to find store ''FakeName''" not in fail_fake_name.msg'
+#
+#- name: fail when state=present and no path is set
+#  win_certificate_store:
+#    state: present
+#  register: fail_present_no_path
+#  failed_when: "fail_present_no_path.msg != 'state is present but all of the following are missing: path'"
+#
+#- name: fail when state=exported and no path is set
+#  win_certificate_store:
+#    state: exported
+#    thumbprint: ABC
+#  register: fail_export_no_path
+#  failed_when: "fail_export_no_path.msg != 'state is exported but all of the following are missing: path'"
+#
+#- name: fail when state=exported and no thumbprint is set
+#  win_certificate_store:
+#    state: exported
+#    path: '{{win_cert_dir}}'
+#  register: fail_export_no_thumbprint
+#  failed_when: "fail_export_no_thumbprint.msg != 'state is exported but all of the following are missing: thumbprint'"
+#
+#- name: fail to export thumbprint when path is a dir
+#  win_certificate_store:
+#    state: exported
+#    thumbprint: '{{subj_thumbprint}}'
+#    path: '{{win_cert_dir}}'
+#  register: fail_export_path_is_dir
+#  failed_when: fail_export_path_is_dir.msg != "Cannot export cert to path '" + win_cert_dir + "' as it is a directory"
+#
+#- name: import pem certificate (check)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\subj-cert.pem'
+#    state: present
+#  register: import_pem_check
+#  check_mode: yes
+#
+#- name: get result of import pem certificate (check)
+#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+#  register: import_pem_result_check
+#
+#- name: assert results of import pem certificate (check)
+#  assert:
+#    that:
+#    - import_pem_check is changed
+#    - import_pem_check.thumbprints == [subj_thumbprint]
+#    - import_pem_result_check.stdout_lines[0] == "False"
+#
+#- name: import pem certificate
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\subj-cert.pem'
+#    state: present
+#  register: import_pem
+#
+#- name: get result of import pem certificate
+#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+#  register: import_pem_result
+#
+#- name: assert results of import pem certificate
+#  assert:
+#    that:
+#    - import_pem is changed
+#    - import_pem.thumbprints == [subj_thumbprint]
+#    - import_pem_result.stdout_lines[0] == "True"
+#
+#- name: import pem certificate (idempotent)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\subj-cert.pem'
+#    state: present
+#  register: import_pem_again
+#
+#- name: assert results of import pem certificate (idempotent)
+#  assert:
+#    that:
+#    - not import_pem_again is changed
+#
+#- name: remove certificate based on thumbprint (check)
+#  win_certificate_store:
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: absent
+#  register: remove_thumbprint_check
+#  check_mode: yes
+#
+#- name: get result of remove certificate based on thumbprint (check)
+#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+#  register: remove_thumbprint_result_check
+#
+#- name: assert results of remove certificate based on thumbprint (check)
+#  assert:
+#    that:
+#    - remove_thumbprint_check is changed
+#    - remove_thumbprint_check.thumbprints == [subj_thumbprint]
+#    - remove_thumbprint_result_check.stdout_lines[0] == "True"
+#
+#- name: remove certificate based on thumbprint
+#  win_certificate_store:
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: absent
+#  register: remove_thumbprint
+#
+#- name: get result of remove certificate based on thumbprint
+#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+#  register: remove_thumbprint_result
+#
+#- name: assert results of remove certificate based on thumbprint
+#  assert:
+#    that:
+#    - remove_thumbprint is changed
+#    - remove_thumbprint.thumbprints == [subj_thumbprint]
+#    - remove_thumbprint_result.stdout_lines[0] == "False"
+#
+#- name: remove certificate based on thumbprint (idempotent)
+#  win_certificate_store:
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: absent
+#  register: remove_thumbprint_again
+#
+#- name: assert results of remove certificate based on thumbprint (idempotent)
+#  assert:
+#    that:
+#    - not remove_thumbprint_again is changed
+#
+#- name: import der certificate (check)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\subj-cert.cer'
+#    state: present
+#  register: import_der_check
+#  check_mode: yes
+#
+#- name: get result of import der certificate (check)
+#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+#  register: import_der_result_check
+#
+#- name: assert results of import der certificate (check)
+#  assert:
+#    that:
+#    - import_der_check is changed
+#    - import_der_check.thumbprints == [subj_thumbprint]
+#    - import_der_result_check.stdout_lines[0] == "False"
+#
+#- name: import der certificate
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\subj-cert.cer'
+#    state: present
+#  register: import_der
+#
+#- name: get result of import der certificate
+#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+#  register: import_der_result
+#
+#- name: assert results of import der certificate
+#  assert:
+#    that:
+#    - import_der is changed
+#    - import_der.thumbprints == [subj_thumbprint]
+#    - import_der_result.stdout_lines[0] == "True"
+#
+#- name: import der certificate (idempotent)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\subj-cert.cer'
+#    state: present
+#  register: import_der_again
+#
+#- name: assert results of import der certificate (idempotent)
+#  assert:
+#    that:
+#    - not import_der_again is changed
+#
+#- name: remove certificate based on path (check)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\subj-cert.cer'
+#    state: absent
+#  register: remove_path_check
+#  check_mode: yes
+#
+#- name: get result of remove certificate based on path (check)
+#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+#  register: remove_path_result_check
+#
+#- name: assert results of remove certificate based on path (check)
+#  assert:
+#    that:
+#    - remove_path_check is changed
+#    - remove_path_check.thumbprints == [subj_thumbprint]
+#    - remove_path_result_check.stdout_lines[0] == "True"
+#
+#- name: remove certificate based on path
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\subj-cert.cer'
+#    state: absent
+#  register: remove_path
+#
+#- name: get result of remove certificate based on path
+#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+#  register: remove_path_result
+#
+#- name: assert results of remove certificate based on path
+#  assert:
+#    that:
+#    - remove_path is changed
+#    - remove_path.thumbprints == [subj_thumbprint]
+#    - remove_path_result.stdout_lines[0] == "False"
+#
+#- name: remove certificate based on path (idempotent)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\subj-cert.cer'
+#    state: absent
+#  register: remove_path_again
+#
+#- name: assert results of remove certificate based on path (idempotent)
+#  assert:
+#    that:
+#    - not remove_path_again is changed
+#
+#- name: import PEM encoded p7b chain (check)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\chain.pem'
+#    state: present
+#  register: import_pem_p7b_check
+#  check_mode: yes
+#
+#- name: get result of subj in p7b chain (check)
+#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+#  register: import_pem_p7b_subj_result_check
+#
+#- name: get result of root in p7b chain (check)
+#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
+#  register: import_pem_p7b_root_result_check
+#
+#- name: assert results of import PEM encoded p7b chain (check)
+#  assert:
+#    that:
+#    - import_pem_p7b_check is changed
+#    - import_pem_p7b_check.thumbprints|count == 2
+#    - subj_thumbprint in import_pem_p7b_check.thumbprints
+#    - root_thumbprint in import_pem_p7b_check.thumbprints
+#    - import_pem_p7b_subj_result_check.stdout_lines[0] == "False"
+#    - import_pem_p7b_root_result_check.stdout_lines[0] == "False"
+#
+#- name: import PEM encoded p7b chain
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\chain.pem'
+#    state: present
+#  register: import_pem_p7b
+#
+#- name: get result of subj in p7b chain
+#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+#  register: import_pem_p7b_subj_result
+#
+#- name: get result of root in p7b chain
+#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
+#  register: import_pem_p7b_root_result
+#
+#- name: assert results of import PEM encoded p7b chain
+#  assert:
+#    that:
+#    - import_pem_p7b is changed
+#    - import_pem_p7b.thumbprints|count == 2
+#    - subj_thumbprint in import_pem_p7b.thumbprints
+#    - root_thumbprint in import_pem_p7b.thumbprints
+#    - import_pem_p7b_subj_result.stdout_lines[0] == "True"
+#    - import_pem_p7b_root_result.stdout_lines[0] == "True"
+#
+#- name: import PEM encoded p7b chain (idempotent)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\chain.pem'
+#    state: present
+#  register: import_pem_p7b_again
+#
+#- name: assert results of import PEM encoded p7b chain (idempotent)
+#  assert:
+#    that:
+#    - not import_pem_p7b_again is changed
+#
+#- name: remove p7b chain certs
+#  win_certificate_store:
+#    thumbprint: '{{item}}'
+#    state: absent
+#  with_items:
+#  - '{{subj_thumbprint}}'
+#  - '{{root_thumbprint}}'
+#
+#- name: import DER encoded p7b chain into custom store (check)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\chain.p7b'
+#    state: present
+#    store_name: TrustedPeople
+#    store_location: CurrentUser
+#  register: import_der_p7b_check
+#  check_mode: yes
+#
+#- name: get result of subj in p7b chain in custom store (check)
+#  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+#  register: import_der_p7b_subj_result_check
+#
+#- name: get result of root in p7b chain in custom store (check)
+#  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
+#  register: import_der_p7b_root_result_check
+#
+#- name: assert results of import DER encoded p7b chain into custom store (check)
+#  assert:
+#    that:
+#    - import_der_p7b_check is changed
+#    - import_der_p7b_check.thumbprints|count == 2
+#    - subj_thumbprint in import_der_p7b_check.thumbprints
+#    - root_thumbprint in import_der_p7b_check.thumbprints
+#    - import_der_p7b_subj_result_check.stdout_lines[0] == "False"
+#    - import_der_p7b_root_result_check.stdout_lines[0] == "False"
+#
+#- name: import DER encoded p7b chain into custom store
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\chain.p7b'
+#    state: present
+#    store_name: TrustedPeople
+#    store_location: CurrentUser
+#  register: import_der_p7b
+#
+#- name: get result of subj in p7b chain in custom store
+#  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+#  register: import_der_p7b_subj_result
+#
+#- name: get result of root in p7b chain in custom store
+#  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
+#  register: import_der_p7b_root_result
+#
+#- name: assert results of import DER encoded p7b chain into custom store
+#  assert:
+#    that:
+#    - import_der_p7b is changed
+#    - import_der_p7b.thumbprints|count == 2
+#    - subj_thumbprint in import_der_p7b.thumbprints
+#    - root_thumbprint in import_der_p7b.thumbprints
+#    - import_der_p7b_root_result.stdout_lines[0] == "True"
+#    - import_der_p7b_root_result.stdout_lines[0] == "True"
+#
+#- name: import DER encoded p7b chain into custom store (idempotent)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\chain.p7b'
+#    state: present
+#    store_name: TrustedPeople
+#    store_location: CurrentUser
+#  register: import_der_p7b_again
+#
+#- name: assert results of import DER encoded p7b chain into custom store (idempotent)
+#  assert:
+#    that:
+#    - not import_der_p7b_again is changed
+#
+#- name: remove p7b chain certs from custom store
+#  win_certificate_store:
+#    thumbprint: '{{item}}'
+#    state: absent
+#    store_name: TrustedPeople
+#    store_location: CurrentUser
+#  with_items:
+#  - '{{subj_thumbprint}}'
+#  - '{{root_thumbprint}}'
+#
+#- name: import pfx without password and non exportable (check)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\subj-cert-without-pass.pfx'
+#    state: present
+#    key_exportable: no
+#  vars: &become_vars
+#    ansible_become: yes
+#    ansible_become_method: runas
+#    ansible_become_user: '{{ansible_user}}'
+#    ansible_become_pass: '{{ansible_password}}'
+#  register: import_pfx_without_pass_check
+#  check_mode: yes
+#
+#- name: get results of import pfx without password and non exportable (check)
+#  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+#  register: import_pfx_without_pass_result_check
+#
+#- name: assert results of import pfx without password and non exportable (check)
+#  assert:
+#    that:
+#    - import_pfx_without_pass_check is changed
+#    - import_pfx_without_pass_check.thumbprints == [subj_thumbprint]
+#    - import_pfx_without_pass_result_check.stdout_lines[0] == "False"
+#
+#- name: import pfx without password and non exportable
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\subj-cert-without-pass.pfx'
+#    state: present
+#    key_exportable: no
+#  vars: *become_vars
+#  register: import_pfx_without_pass
+#
+#- name: get results of import pfx without password and non exportable
+#  win_shell: (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }).PrivateKey.CspKeyContainerInfo.Exportable
+#  vars: *become_vars
+#  register: import_pfx_without_pass_result
+#
+#- name: assert results of import pfx without password and non exportable
+#  assert:
+#    that:
+#    - import_pfx_without_pass is changed
+#    - import_pfx_without_pass.thumbprints == [subj_thumbprint]
+#    - import_pfx_without_pass_result.stdout_lines[0] == "False"
+#
+#- name: import pfx without password and non exportable (idempotent)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\subj-cert-without-pass.pfx'
+#    state: present
+#    key_exportable: no
+#  vars: *become_vars
+#  register: import_pfx_without_pass_again
+#
+#- name: assert results of import pfx without password and non exportable (idempotent)
+#  assert:
+#    that:
+#    - not import_pfx_without_pass_again is changed
+#
+#- name: fail import pfx with password and none set
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\subj-cert-with-pass.pfx'
+#    state: present
+#    store_location: CurrentUser
+#    store_name: TrustedPeople
+#  register: fail_import_pfx_with_password
+#  failed_when: "'Failed to load cert from file' not in fail_import_pfx_with_password.msg and 'The specified network password is not correct' not in fail_import_pfx_with_password.msg"
+#
+#- name: import pfx with password (check)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\subj-cert-with-pass.pfx'
+#    state: present
+#    password: '{{key_password}}'
+#    store_location: CurrentUser
+#    store_name: TrustedPeople
+#  register: import_pfx_with_pass_check
+#  vars: *become_vars
+#  check_mode: yes
+#
+#- name: get results of import pfx with password (check)
+#  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+#  register: import_pfx_with_pass_result_check
+#
+#- name: assert results of import pfx with password (check)
+#  assert:
+#    that:
+#    - import_pfx_with_pass_check is changed
+#    - import_pfx_with_pass_check.thumbprints == [subj_thumbprint]
+#    - import_pfx_with_pass_result_check.stdout_lines[0] == "False"
+#
+#- name: import pfx with password
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\subj-cert-with-pass.pfx'
+#    state: present
+#    password: '{{key_password}}'
+#    store_location: CurrentUser
+#    store_name: TrustedPeople
+#  vars: *become_vars
+#  register: import_pfx_with_pass
+#
+#- name: get results of import pfx with password
+#  win_shell: (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }).PrivateKey.CspKeyContainerInfo.Exportable
+#  vars: *become_vars
+#  register: import_pfx_with_pass_result
+#
+#- name: assert results of import pfx with password
+#  assert:
+#    that:
+#    - import_pfx_with_pass is changed
+#    - import_pfx_with_pass.thumbprints == [subj_thumbprint]
+#    - import_pfx_with_pass_result.stdout_lines[0] == "True"
+#
+#- name: import pfx with password (idempotent)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\subj-cert-with-pass.pfx'
+#    state: present
+#    password: '{{key_password}}'
+#    store_location: CurrentUser
+#    store_name: TrustedPeople
+#  vars: *become_vars
+#  register: import_pfx_with_pass_again
+#
+#- name: assert results of import pfx with password (idempotent)
+#  assert:
+#    that:
+#    - not import_pfx_with_pass_again is changed
+#
+#- name: import root cert for export tests
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\root-cert.pem'
+#    state: present
+#
+#- name: export cert as pem (check)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\exported\cert.pem'
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: exported
+#    file_type: pem
+#  register: export_pem_check
+#  check_mode: yes
+#
+#- name: get result of export cert as pem (check)
+#  win_stat:
+#    path: '{{win_cert_dir}}\exported\cert.pem'
+#  register: export_pem_result_check
+#
+#- name: assert results of export cert as pem (check)
+#  assert:
+#    that:
+#    - export_pem_check is changed
+#    - export_pem_check.thumbprints == [subj_thumbprint]
+#    - export_pem_result_check.stat.exists == False
+#
+#- name: export cert as pem
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\exported\cert.pem'
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: exported
+#    file_type: pem
+#  register: export_pem
+#
+#- name: get result of export cert as pem
+#  win_stat:
+#    path: '{{win_cert_dir}}\exported\cert.pem'
+#  register: export_pem_result
+#
+#- name: assert results of export cert as pem
+#  assert:
+#    that:
+#    - export_pem is changed
+#    - export_pem.thumbprints == [subj_thumbprint]
+#    - export_pem_result.stat.checksum == '1ebf5467d18230e9f611940a74d12f1d0bc819b7'
+#
+#- name: export cert as pem (idempotent)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\exported\cert.pem'
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: exported
+#    file_type: pem
+#  register: export_pem_again
+#
+#- name: assert results of export cert as pem
+#  assert:
+#    that:
+#    - not export_pem_again is changed
+#
+#- name: export cert as der (check)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\exported\cert.cer'
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: exported
+#    file_type: der
+#  register: export_der_check
+#  check_mode: yes
+#
+#- name: get result of export cert as der (check)
+#  win_stat:
+#    path: '{{win_cert_dir}}\exported\cert.cer'
+#  register: export_der_result_check
+#
+#- name: assert results of export cert as der (check)
+#  assert:
+#    that:
+#    - export_der_check is changed
+#    - export_der_check.thumbprints == [subj_thumbprint]
+#    - export_der_result_check.stat.exists == False
+#
+#- name: export cert as der
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\exported\cert.cer'
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: exported
+#    file_type: der
+#  register: export_der
+#
+#- name: get result of export cert as der
+#  win_stat:
+#    path: '{{win_cert_dir}}\exported\cert.cer'
+#  register: export_der_result
+#
+#- name: assert results of export cert as der
+#  assert:
+#    that:
+#    - export_der is changed
+#    - export_der.thumbprints == [subj_thumbprint]
+#    - export_der_result.stat.checksum == 'bd7af104cf1872bdb518d95c9534ea941665fd27'
+#
+#- name: export cert as der (idempotent)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\exported\cert.cer'
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: exported
+#    file_type: der
+#  register: export_der_again
+#
+#- name: assert results of export cert as der
+#  assert:
+#    that:
+#    - not export_der_again is changed
+#
+#- name: export cert as der replacing pem
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\exported\cert.pem'
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: exported
+#    file_type: der
+#  register: export_der_over_pem
+#
+#- name: get result of export cert as der replacing pem
+#  win_stat:
+#    path: '{{win_cert_dir}}\exported\cert.pem'
+#  register: export_der_over_pem_result
+#
+#- name: assert results of export cert as der replacing pem
+#  assert:
+#    that:
+#    - export_der_over_pem is changed
+#    - export_der_over_pem.thumbprints == [subj_thumbprint]
+#    - export_der_over_pem_result.stat.checksum == 'bd7af104cf1872bdb518d95c9534ea941665fd27'
+#
+#- name: export cert as pem replacing der
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\exported\cert.cer'
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: exported
+#    file_type: pem
+#  register: export_pem_over_der
+#
+#- name: get result of export cert as pem replacing der
+#  win_stat:
+#    path: '{{win_cert_dir}}\exported\cert.cer'
+#  register: export_pem_over_der_result
+#
+#- name: assert results of export cert as pem replacing der
+#  assert:
+#    that:
+#    - export_pem_over_der is changed
+#    - export_pem_over_der.thumbprints == [subj_thumbprint]
+#    - export_pem_over_der_result.stat.checksum == '1ebf5467d18230e9f611940a74d12f1d0bc819b7'
+#
+#- name: export cert with key and password as pfx (check)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\exported\cert-pass.pfx'
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: exported
+#    file_type: pkcs12
+#    store_location: CurrentUser
+#    store_name: TrustedPeople
+#    password: '{{key_password}}'
+#  register: export_pfx_with_pass_check
+#  vars: *become_vars
+#  check_mode: yes
+#
+#- name: get result of export cert with key and password as pfx (check)
+#  win_stat:
+#    path: '{{win_cert_dir}}\exported\cert-pass.pfx'
+#  register: export_pfx_with_pass_result_check
+#
+#- name: assert results of export cert with key and password as pfx (check)
+#  assert:
+#    that:
+#    - export_pfx_with_pass_check is changed
+#    - export_pfx_with_pass_check.thumbprints == [subj_thumbprint]
+#    - export_pfx_with_pass_result_check.stat.exists == False
+#
+#- name: export cert with key and password as pfx
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\exported\cert-pass.pfx'
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: exported
+#    file_type: pkcs12
+#    store_location: CurrentUser
+#    store_name: TrustedPeople
+#    password: '{{key_password}}'
+#  vars: *become_vars
+#  register: export_pfx_with_pass
+#
+#- name: get result of export cert with key and password as pfx
+#  win_shell: |
+#    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
+#    $cert.Import("{{win_cert_dir}}\exported\cert-pass.pfx", "{{key_password}}", 0)
+#    $cert.HasPrivateKey
+#  vars: *become_vars
+#  register: export_pfx_with_pass_result
+#
+#- name: assert results of export cert with key and password as pfx
+#  assert:
+#    that:
+#    - export_pfx_with_pass is changed
+#    - export_pfx_with_pass.thumbprints == [subj_thumbprint]
+#    - export_pfx_with_pass_result.stdout_lines[0] == "True"
+#
+#- name: export cert with key and password as pfx (idempotent)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\exported\cert-pass.pfx'
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: exported
+#    file_type: pkcs12
+#    store_location: CurrentUser
+#    store_name: TrustedPeople
+#    password: '{{key_password}}'
+#  vars: *become_vars
+#  register: export_pfx_with_pass_again
+#
+#- name: assert results of export cert with key and password as pfx (idempotent)
+#  assert:
+#    that:
+#    - not export_pfx_with_pass_again is changed
+#
+#- name: export cert with key without password as pfx (check)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\exported\cert-without-pass.pfx'
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: exported
+#    file_type: pkcs12
+#    store_location: CurrentUser
+#    store_name: TrustedPeople
+#  vars: *become_vars
+#  register: export_pfx_without_pass_check
+#  check_mode: yes
+#
+#- name: get result of export cert with key without password as pfx (check)
+#  win_stat:
+#    path: '{{win_cert_dir}}\exported\cert-without-pass.pfx'
+#  register: export_pfx_without_pass_result_check
+#
+#- name: assert results of export cert with key without password as pfx (check)
+#  assert:
+#    that:
+#    - export_pfx_without_pass_check is changed
+#    - export_pfx_without_pass_check.thumbprints == [subj_thumbprint]
+#    - export_pfx_without_pass_result_check.stat.exists == False
+#
+#- name: export cert with key without password as pfx
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\exported\cert-without-pass.pfx'
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: exported
+#    file_type: pkcs12
+#    store_location: CurrentUser
+#    store_name: TrustedPeople
+#  vars: *become_vars
+#  register: export_pfx_without_pass
+#
+#- name: get result of export cert with key without password as pfx
+#  win_shell: |
+#    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
+#    $cert.Import("{{win_cert_dir}}\exported\cert-without-pass.pfx", $null, 0)
+#    $cert.HasPrivateKey
+#  vars: *become_vars
+#  register: export_pfx_without_pass_result
+#
+#- name: assert results of export cert with key without password as pfx
+#  assert:
+#    that:
+#    - export_pfx_without_pass is changed
+#    - export_pfx_without_pass.thumbprints == [subj_thumbprint]
+#    - export_pfx_without_pass_result.stdout_lines[0] == "True"
+#
+#- name: export cert with key without password as pfx (idempotent)
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\exported\cert-without-pass.pfx'
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: exported
+#    file_type: pkcs12
+#    store_location: CurrentUser
+#    store_name: TrustedPeople
+#  vars: *become_vars
+#  register: export_pfx_without_pass_again
+#
+#- name: assert results of export cert with key without password as pfx (idempotent)
+#  assert:
+#    that:
+#    - not export_pfx_without_pass_again is changed
+#
+#- name: fail to export cert with key as pfx when not marked as exportable
+#  win_certificate_store:
+#    path: '{{win_cert_dir}}\exported\cert-fail.pfx'
+#    thumbprint: '{{subj_thumbprint}}'
+#    state: exported
+#    file_type: pkcs12
+#  vars: *become_vars
+#  register: fail_export_non_exportable
+#  failed_when: fail_export_non_exportable.msg != 'Cannot export cert with key as PKCS12 when the key is not marked as exportable or not accessible by the current user'
+
+- name: fail to import with invalid service name
   win_certificate_store:
+    path: '{{ win_cert_dir }}\subj-cert.pem'
+    store_type: service
+    store_location: FakeService
     state: present
-    path: '{{win_cert_dir}}\subj-cert.pem'
-    store_location: FakeLocation
-  register: fail_fake_location
-  failed_when: "fail_fake_location.msg != 'value of store_location must be one of: CurrentUser, LocalMachine. Got no match for: FakeLocation'"
+  register: fail_invalid_service
+  failed_when: fail_invalid_service.msg != "value of store_location 'FakeService' is not a valid windows service"
+
+- block:
+  - name: import certificate into service store (check mode)
+    win_certificate_store:
+      path: '{{ win_cert_dir }}\subj-cert.pem'
+      store_type: service
+      store_location: WinRM
+      state: present
+    register: service_store_check
+    check_mode: yes
+
+  - name: get result of import certificate into service store (check mode)
+    win_reg_stat:
+      path: HKLM:\Software\Microsoft\Cryptography\Services\WinRM\SystemCertificates\My\Certificates\{{ subj_thumbprint }}
+    register: service_store_check_actual
+
+  - name: assert import certificate into service store (check mode)
+    assert:
+      that:
+      - service_store_check is changed
+      - service_store_check.thumbprints == [subj_thumbprint]
+      - not service_store_check_actual.exists
+
+  - name: import certificate into service store
+    win_certificate_store:
+      path: '{{ win_cert_dir }}\subj-cert.pem'
+      store_type: service
+      store_location: WinRM
+      state: present
+    register: service_store
+
+  - name: get result of import certificate into service store
+    win_reg_stat:
+      path: HKLM:\Software\Microsoft\Cryptography\Services\WinRM\SystemCertificates\My\Certificates\{{ subj_thumbprint }}
+    register: service_store_actual
+
+  - name: assert import certificate into service store
+    assert:
+      that:
+      - service_store is changed
+      - service_store.thumbprints == [subj_thumbprint]
+      - service_store_actual.exists
+
+  - name: import certificate into service store (idempotent)
+    win_certificate_store:
+      path: '{{ win_cert_dir }}\subj-cert.pem'
+      store_type: service
+      store_location: WinRM
+      state: present
+    register: service_store_again
+
+  - name: assert import certificate into service store (idempotent)
+    assert:
+      that:
+      - not service_store_again is changed
+
+  - name: remove service certificate (check)
+    win_certificate_store:
+      store_type: service
+      store_location: WinRM
+      thumbprint: '{{ subj_thumbprint }}'
+      state: absent
+    register: service_remove_check
+    check_mode: yes
+
+  - name: get result of remove service certificate (check)
+    win_reg_stat:
+      path: HKLM:\Software\Microsoft\Cryptography\Services\WinRM\SystemCertificates\My\Certificates\{{ subj_thumbprint }}
+    register: service_remove_check_actual
+
+  - name: assert remove service certificate (check)
+    assert:
+      that:
+      - service_remove_check is changed
+      - service_remove_check.thumbprints == [subj_thumbprint]
+      - service_remove_check_actual.exists
+
+  - name: remove service certificate
+    win_certificate_store:
+      store_type: service
+      store_location: WinRM
+      thumbprint: '{{ subj_thumbprint }}'
+      state: absent
+    register: service_remove
+
+  - name: get result of remove service certificate
+    win_reg_stat:
+      path: HKLM:\Software\Microsoft\Cryptography\Services\WinRM\SystemCertificates\My\Certificates\{{ subj_thumbprint }}
+    register: service_remove_actual
+
+  - name: assert remove service certificate
+    assert:
+      that:
+      - service_remove is changed
+      - service_remove.thumbprints == [subj_thumbprint]
+      - not service_remove_actual.exists
+
+  - name: remove service certificate (idempotent)
+    win_certificate_store:
+      store_type: service
+      store_location: WinRM
+      thumbprint: '{{ subj_thumbprint }}'
+      state: absent
+    register: service_remove_again
+
+  - name: assert remove service certificate (idempotent)
+    assert:
+      that:
+      - not service_remove_again is changed
+
+  always:
+  - name: remove service certificate
+    win_certificate_store:
+      path: '{{ win_cert_dir }}\subj-cert.pem'
+      store_type: service
+      store_location: WinRM
+      state: absent
 
-- name: fail with invalid store name
-  win_certificate_store:
-    state: present
-    path: '{{win_cert_dir}}\subj-cert.pem'
-    store_name: FakeName
-  register: fail_fake_name
-  failed_when: "fail_fake_name.msg != 'value of store_name must be one of: AddressBook, AuthRoot, CertificateAuthority, Disallowed, My, Root, TrustedPeople, TrustedPublisher. Got no match for: FakeName'"
-
-- name: fail when state=present and no path is set
-  win_certificate_store:
-    state: present
-  register: fail_present_no_path
-  failed_when: "fail_present_no_path.msg != 'state is present but all of the following are missing: path'"
-
-- name: fail when state=exported and no path is set
-  win_certificate_store:
-    state: exported
-    thumbprint: ABC
-  register: fail_export_no_path
-  failed_when: "fail_export_no_path.msg != 'state is exported but all of the following are missing: path'"
-
-- name: fail when state=exported and no thumbprint is set
-  win_certificate_store:
-    state: exported
-    path: '{{win_cert_dir}}'
-  register: fail_export_no_thumbprint
-  failed_when: "fail_export_no_thumbprint.msg != 'state is exported but all of the following are missing: thumbprint'"
-
-- name: fail to export thumbprint when path is a dir
-  win_certificate_store:
-    state: exported
-    thumbprint: '{{subj_thumbprint}}'
-    path: '{{win_cert_dir}}'
-  register: fail_export_path_is_dir
-  failed_when: fail_export_path_is_dir.msg != "Cannot export cert to path '" + win_cert_dir + "' as it is a directory"
-
-- name: fail when state=absent and not path or thumbprint is set
-  win_certificate_store:
-    state: absent
-  register: fail_absent_no_path_or_thumbprint
-  failed_when: "fail_absent_no_path_or_thumbprint.msg != 'state is absent but any of the following are missing: path, thumbprint'"
-
-- name: import pem certificate (check)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\subj-cert.pem'
-    state: present
-  register: import_pem_check
-  check_mode: yes
-
-- name: get result of import pem certificate (check)
-  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-  register: import_pem_result_check
-
-- name: assert results of import pem certificate (check)
-  assert:
-    that:
-    - import_pem_check is changed
-    - import_pem_check.thumbprints == [subj_thumbprint]
-    - import_pem_result_check.stdout_lines[0] == "False"
-
-- name: import pem certificate
-  win_certificate_store:
-    path: '{{win_cert_dir}}\subj-cert.pem'
-    state: present
-  register: import_pem
-
-- name: get result of import pem certificate
-  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-  register: import_pem_result
-
-- name: assert results of import pem certificate
-  assert:
-    that:
-    - import_pem is changed
-    - import_pem.thumbprints == [subj_thumbprint]
-    - import_pem_result.stdout_lines[0] == "True"
-
-- name: import pem certificate (idempotent)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\subj-cert.pem'
-    state: present
-  register: import_pem_again
-
-- name: assert results of import pem certificate (idempotent)
-  assert:
-    that:
-    - not import_pem_again is changed
-
-- name: remove certificate based on thumbprint (check)
-  win_certificate_store:
-    thumbprint: '{{subj_thumbprint}}'
-    state: absent
-  register: remove_thumbprint_check
-  check_mode: yes
-
-- name: get result of remove certificate based on thumbprint (check)
-  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-  register: remove_thumbprint_result_check
-
-- name: assert results of remove certificate based on thumbprint (check)
-  assert:
-    that:
-    - remove_thumbprint_check is changed
-    - remove_thumbprint_check.thumbprints == [subj_thumbprint]
-    - remove_thumbprint_result_check.stdout_lines[0] == "True"
-
-- name: remove certificate based on thumbprint
-  win_certificate_store:
-    thumbprint: '{{subj_thumbprint}}'
-    state: absent
-  register: remove_thumbprint
-
-- name: get result of remove certificate based on thumbprint
-  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-  register: remove_thumbprint_result
-
-- name: assert results of remove certificate based on thumbprint
-  assert:
-    that:
-    - remove_thumbprint is changed
-    - remove_thumbprint.thumbprints == [subj_thumbprint]
-    - remove_thumbprint_result.stdout_lines[0] == "False"
-
-- name: remove certificate based on thumbprint (idempotent)
-  win_certificate_store:
-    thumbprint: '{{subj_thumbprint}}'
-    state: absent
-  register: remove_thumbprint_again
-
-- name: assert results of remove certificate based on thumbprint (idempotent)
-  assert:
-    that:
-    - not remove_thumbprint_again is changed
-
-- name: import der certificate (check)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\subj-cert.cer'
-    state: present
-  register: import_der_check
-  check_mode: yes
-
-- name: get result of import der certificate (check)
-  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-  register: import_der_result_check
-
-- name: assert results of import der certificate (check)
-  assert:
-    that:
-    - import_der_check is changed
-    - import_der_check.thumbprints == [subj_thumbprint]
-    - import_der_result_check.stdout_lines[0] == "False"
-
-- name: import der certificate
-  win_certificate_store:
-    path: '{{win_cert_dir}}\subj-cert.cer'
-    state: present
-  register: import_der
-
-- name: get result of import der certificate
-  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-  register: import_der_result
-
-- name: assert results of import der certificate
-  assert:
-    that:
-    - import_der is changed
-    - import_der.thumbprints == [subj_thumbprint]
-    - import_der_result.stdout_lines[0] == "True"
-
-- name: import der certificate (idempotent)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\subj-cert.cer'
-    state: present
-  register: import_der_again
-
-- name: assert results of import der certificate (idempotent)
-  assert:
-    that:
-    - not import_der_again is changed
-
-- name: remove certificate based on path (check)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\subj-cert.cer'
-    state: absent
-  register: remove_path_check
-  check_mode: yes
-
-- name: get result of remove certificate based on path (check)
-  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-  register: remove_path_result_check
-
-- name: assert results of remove certificate based on path (check)
-  assert:
-    that:
-    - remove_path_check is changed
-    - remove_path_check.thumbprints == [subj_thumbprint]
-    - remove_path_result_check.stdout_lines[0] == "True"
-
-- name: remove certificate based on path
-  win_certificate_store:
-    path: '{{win_cert_dir}}\subj-cert.cer'
-    state: absent
-  register: remove_path
-
-- name: get result of remove certificate based on path
-  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-  register: remove_path_result
-
-- name: assert results of remove certificate based on path
-  assert:
-    that:
-    - remove_path is changed
-    - remove_path.thumbprints == [subj_thumbprint]
-    - remove_path_result.stdout_lines[0] == "False"
-
-- name: remove certificate based on path (idempotent)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\subj-cert.cer'
-    state: absent
-  register: remove_path_again
-
-- name: assert results of remove certificate based on path (idempotent)
-  assert:
-    that:
-    - not remove_path_again is changed
-
-- name: import PEM encoded p7b chain (check)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\chain.pem'
-    state: present
-  register: import_pem_p7b_check
-  check_mode: yes
-
-- name: get result of subj in p7b chain (check)
-  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-  register: import_pem_p7b_subj_result_check
-
-- name: get result of root in p7b chain (check)
-  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
-  register: import_pem_p7b_root_result_check
-
-- name: assert results of import PEM encoded p7b chain (check)
-  assert:
-    that:
-    - import_pem_p7b_check is changed
-    - import_pem_p7b_check.thumbprints|count == 2
-    - subj_thumbprint in import_pem_p7b_check.thumbprints
-    - root_thumbprint in import_pem_p7b_check.thumbprints
-    - import_pem_p7b_subj_result_check.stdout_lines[0] == "False"
-    - import_pem_p7b_root_result_check.stdout_lines[0] == "False"
-
-- name: import PEM encoded p7b chain
-  win_certificate_store:
-    path: '{{win_cert_dir}}\chain.pem'
-    state: present
-  register: import_pem_p7b
-
-- name: get result of subj in p7b chain
-  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-  register: import_pem_p7b_subj_result
-
-- name: get result of root in p7b chain
-  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
-  register: import_pem_p7b_root_result
-
-- name: assert results of import PEM encoded p7b chain
-  assert:
-    that:
-    - import_pem_p7b is changed
-    - import_pem_p7b.thumbprints|count == 2
-    - subj_thumbprint in import_pem_p7b.thumbprints
-    - root_thumbprint in import_pem_p7b.thumbprints
-    - import_pem_p7b_subj_result.stdout_lines[0] == "True"
-    - import_pem_p7b_root_result.stdout_lines[0] == "True"
-
-- name: import PEM encoded p7b chain (idempotent)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\chain.pem'
-    state: present
-  register: import_pem_p7b_again
-
-- name: assert results of import PEM encoded p7b chain (idempotent)
-  assert:
-    that:
-    - not import_pem_p7b_again is changed
-
-- name: remove p7b chain certs
-  win_certificate_store:
-    thumbprint: '{{item}}'
-    state: absent
-  with_items:
-  - '{{subj_thumbprint}}'
-  - '{{root_thumbprint}}'
-
-- name: import DER encoded p7b chain into custom store (check)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\chain.p7b'
-    state: present
-    store_name: TrustedPeople
-    store_location: CurrentUser
-  register: import_der_p7b_check
-  check_mode: yes
-
-- name: get result of subj in p7b chain in custom store (check)
-  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-  register: import_der_p7b_subj_result_check
-
-- name: get result of root in p7b chain in custom store (check)
-  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
-  register: import_der_p7b_root_result_check
-
-- name: assert results of import DER encoded p7b chain into custom store (check)
-  assert:
-    that:
-    - import_der_p7b_check is changed
-    - import_der_p7b_check.thumbprints|count == 2
-    - subj_thumbprint in import_der_p7b_check.thumbprints
-    - root_thumbprint in import_der_p7b_check.thumbprints
-    - import_der_p7b_subj_result_check.stdout_lines[0] == "False"
-    - import_der_p7b_root_result_check.stdout_lines[0] == "False"
-
-- name: import DER encoded p7b chain into custom store
-  win_certificate_store:
-    path: '{{win_cert_dir}}\chain.p7b'
-    state: present
-    store_name: TrustedPeople
-    store_location: CurrentUser
-  register: import_der_p7b
-
-- name: get result of subj in p7b chain in custom store
-  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-  register: import_der_p7b_subj_result
-
-- name: get result of root in p7b chain in custom store
-  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
-  register: import_der_p7b_root_result
-
-- name: assert results of import DER encoded p7b chain into custom store
-  assert:
-    that:
-    - import_der_p7b is changed
-    - import_der_p7b.thumbprints|count == 2
-    - subj_thumbprint in import_der_p7b.thumbprints
-    - root_thumbprint in import_der_p7b.thumbprints
-    - import_der_p7b_root_result.stdout_lines[0] == "True"
-    - import_der_p7b_root_result.stdout_lines[0] == "True"
-
-- name: import DER encoded p7b chain into custom store (idempotent)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\chain.p7b'
-    state: present
-    store_name: TrustedPeople
-    store_location: CurrentUser
-  register: import_der_p7b_again
-
-- name: assert results of import DER encoded p7b chain into custom store (idempotent)
-  assert:
-    that:
-    - not import_der_p7b_again is changed
-
-- name: remove p7b chain certs from custom store
-  win_certificate_store:
-    thumbprint: '{{item}}'
-    state: absent
-    store_name: TrustedPeople
-    store_location: CurrentUser
-  with_items:
-  - '{{subj_thumbprint}}'
-  - '{{root_thumbprint}}'
-
-- name: import pfx without password and non exportable (check)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\subj-cert-without-pass.pfx'
-    state: present
-    key_exportable: no
-  vars: &become_vars
-    ansible_become: yes
-    ansible_become_method: runas
-    ansible_become_user: '{{ansible_user}}'
-    ansible_become_pass: '{{ansible_password}}'
-  register: import_pfx_without_pass_check
-  check_mode: yes
-
-- name: get results of import pfx without password and non exportable (check)
-  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-  register: import_pfx_without_pass_result_check
-
-- name: assert results of import pfx without password and non exportable (check)
-  assert:
-    that:
-    - import_pfx_without_pass_check is changed
-    - import_pfx_without_pass_check.thumbprints == [subj_thumbprint]
-    - import_pfx_without_pass_result_check.stdout_lines[0] == "False"
-
-- name: import pfx without password and non exportable
-  win_certificate_store:
-    path: '{{win_cert_dir}}\subj-cert-without-pass.pfx'
-    state: present
-    key_exportable: no
-  vars: *become_vars
-  register: import_pfx_without_pass
-
-- name: get results of import pfx without password and non exportable
-  win_shell: (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }).PrivateKey.CspKeyContainerInfo.Exportable
-  vars: *become_vars
-  register: import_pfx_without_pass_result
-
-- name: assert results of import pfx without password and non exportable
-  assert:
-    that:
-    - import_pfx_without_pass is changed
-    - import_pfx_without_pass.thumbprints == [subj_thumbprint]
-    - import_pfx_without_pass_result.stdout_lines[0] == "False"
-
-- name: import pfx without password and non exportable (idempotent)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\subj-cert-without-pass.pfx'
-    state: present
-    key_exportable: no
-  vars: *become_vars
-  register: import_pfx_without_pass_again
-
-- name: assert results of import pfx without password and non exportable (idempotent)
-  assert:
-    that:
-    - not import_pfx_without_pass_again is changed
-
-- name: fail import pfx with password and none set
-  win_certificate_store:
-    path: '{{win_cert_dir}}\subj-cert-with-pass.pfx'
-    state: present
-    store_location: CurrentUser
-    store_name: TrustedPeople
-  register: fail_import_pfx_with_password
-  failed_when: "'Failed to load cert from file' not in fail_import_pfx_with_password.msg and 'The specified network password is not correct' not in fail_import_pfx_with_password.msg"
-
-- name: import pfx with password (check)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\subj-cert-with-pass.pfx'
-    state: present
-    password: '{{key_password}}'
-    store_location: CurrentUser
-    store_name: TrustedPeople
-  register: import_pfx_with_pass_check
-  vars: *become_vars
-  check_mode: yes
-
-- name: get results of import pfx with password (check)
-  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-  register: import_pfx_with_pass_result_check
-
-- name: assert results of import pfx with password (check)
-  assert:
-    that:
-    - import_pfx_with_pass_check is changed
-    - import_pfx_with_pass_check.thumbprints == [subj_thumbprint]
-    - import_pfx_with_pass_result_check.stdout_lines[0] == "False"
-
-- name: import pfx with password
-  win_certificate_store:
-    path: '{{win_cert_dir}}\subj-cert-with-pass.pfx'
-    state: present
-    password: '{{key_password}}'
-    store_location: CurrentUser
-    store_name: TrustedPeople
-  vars: *become_vars
-  register: import_pfx_with_pass
-
-- name: get results of import pfx with password
-  win_shell: (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }).PrivateKey.CspKeyContainerInfo.Exportable
-  vars: *become_vars
-  register: import_pfx_with_pass_result
-
-- name: assert results of import pfx with password
-  assert:
-    that:
-    - import_pfx_with_pass is changed
-    - import_pfx_with_pass.thumbprints == [subj_thumbprint]
-    - import_pfx_with_pass_result.stdout_lines[0] == "True"
-
-- name: import pfx with password (idempotent)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\subj-cert-with-pass.pfx'
-    state: present
-    password: '{{key_password}}'
-    store_location: CurrentUser
-    store_name: TrustedPeople
-  vars: *become_vars
-  register: import_pfx_with_pass_again
-
-- name: assert results of import pfx with password (idempotent)
-  assert:
-    that:
-    - not import_pfx_with_pass_again is changed
-
-- name: import root cert for export tests
-  win_certificate_store:
-    path: '{{win_cert_dir}}\root-cert.pem'
-    state: present
-
-- name: export cert as pem (check)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\exported\cert.pem'
-    thumbprint: '{{subj_thumbprint}}'
-    state: exported
-    file_type: pem
-  register: export_pem_check
-  check_mode: yes
-
-- name: get result of export cert as pem (check)
-  win_stat:
-    path: '{{win_cert_dir}}\exported\cert.pem'
-  register: export_pem_result_check
-
-- name: assert results of export cert as pem (check)
-  assert:
-    that:
-    - export_pem_check is changed
-    - export_pem_check.thumbprints == [subj_thumbprint]
-    - export_pem_result_check.stat.exists == False
-
-- name: export cert as pem
-  win_certificate_store:
-    path: '{{win_cert_dir}}\exported\cert.pem'
-    thumbprint: '{{subj_thumbprint}}'
-    state: exported
-    file_type: pem
-  register: export_pem
-
-- name: get result of export cert as pem
-  win_stat:
-    path: '{{win_cert_dir}}\exported\cert.pem'
-  register: export_pem_result
-
-- name: assert results of export cert as pem
-  assert:
-    that:
-    - export_pem is changed
-    - export_pem.thumbprints == [subj_thumbprint]
-    - export_pem_result.stat.checksum == '1ebf5467d18230e9f611940a74d12f1d0bc819b7'
-
-- name: export cert as pem (idempotent)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\exported\cert.pem'
-    thumbprint: '{{subj_thumbprint}}'
-    state: exported
-    file_type: pem
-  register: export_pem_again
-
-- name: assert results of export cert as pem
-  assert:
-    that:
-    - not export_pem_again is changed
-
-- name: export cert as der (check)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\exported\cert.cer'
-    thumbprint: '{{subj_thumbprint}}'
-    state: exported
-    file_type: der
-  register: export_der_check
-  check_mode: yes
-
-- name: get result of export cert as der (check)
-  win_stat:
-    path: '{{win_cert_dir}}\exported\cert.cer'
-  register: export_der_result_check
-
-- name: assert results of export cert as der (check)
-  assert:
-    that:
-    - export_der_check is changed
-    - export_der_check.thumbprints == [subj_thumbprint]
-    - export_der_result_check.stat.exists == False
-
-- name: export cert as der
-  win_certificate_store:
-    path: '{{win_cert_dir}}\exported\cert.cer'
-    thumbprint: '{{subj_thumbprint}}'
-    state: exported
-    file_type: der
-  register: export_der
-
-- name: get result of export cert as der
-  win_stat:
-    path: '{{win_cert_dir}}\exported\cert.cer'
-  register: export_der_result
-
-- name: assert results of export cert as der
-  assert:
-    that:
-    - export_der is changed
-    - export_der.thumbprints == [subj_thumbprint]
-    - export_der_result.stat.checksum == 'bd7af104cf1872bdb518d95c9534ea941665fd27'
-
-- name: export cert as der (idempotent)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\exported\cert.cer'
-    thumbprint: '{{subj_thumbprint}}'
-    state: exported
-    file_type: der
-  register: export_der_again
-
-- name: assert results of export cert as der
-  assert:
-    that:
-    - not export_der_again is changed
-
-- name: export cert as der replacing pem
-  win_certificate_store:
-    path: '{{win_cert_dir}}\exported\cert.pem'
-    thumbprint: '{{subj_thumbprint}}'
-    state: exported
-    file_type: der
-  register: export_der_over_pem
-
-- name: get result of export cert as der replacing pem
-  win_stat:
-    path: '{{win_cert_dir}}\exported\cert.pem'
-  register: export_der_over_pem_result
-
-- name: assert results of export cert as der replacing pem
-  assert:
-    that:
-    - export_der_over_pem is changed
-    - export_der_over_pem.thumbprints == [subj_thumbprint]
-    - export_der_over_pem_result.stat.checksum == 'bd7af104cf1872bdb518d95c9534ea941665fd27'
-
-- name: export cert as pem replacing der
-  win_certificate_store:
-    path: '{{win_cert_dir}}\exported\cert.cer'
-    thumbprint: '{{subj_thumbprint}}'
-    state: exported
-    file_type: pem
-  register: export_pem_over_der
-
-- name: get result of export cert as pem replacing der
-  win_stat:
-    path: '{{win_cert_dir}}\exported\cert.cer'
-  register: export_pem_over_der_result
-
-- name: assert results of export cert as pem replacing der
-  assert:
-    that:
-    - export_pem_over_der is changed
-    - export_pem_over_der.thumbprints == [subj_thumbprint]
-    - export_pem_over_der_result.stat.checksum == '1ebf5467d18230e9f611940a74d12f1d0bc819b7'
-
-- name: export cert with key and password as pfx (check)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\exported\cert-pass.pfx'
-    thumbprint: '{{subj_thumbprint}}'
-    state: exported
-    file_type: pkcs12
-    store_location: CurrentUser
-    store_name: TrustedPeople
-    password: '{{key_password}}'
-  register: export_pfx_with_pass_check
-  vars: *become_vars
-  check_mode: yes
-
-- name: get result of export cert with key and password as pfx (check)
-  win_stat:
-    path: '{{win_cert_dir}}\exported\cert-pass.pfx'
-  register: export_pfx_with_pass_result_check
-
-- name: assert results of export cert with key and password as pfx (check)
-  assert:
-    that:
-    - export_pfx_with_pass_check is changed
-    - export_pfx_with_pass_check.thumbprints == [subj_thumbprint]
-    - export_pfx_with_pass_result_check.stat.exists == False
-
-- name: export cert with key and password as pfx
-  win_certificate_store:
-    path: '{{win_cert_dir}}\exported\cert-pass.pfx'
-    thumbprint: '{{subj_thumbprint}}'
-    state: exported
-    file_type: pkcs12
-    store_location: CurrentUser
-    store_name: TrustedPeople
-    password: '{{key_password}}'
-  vars: *become_vars
-  register: export_pfx_with_pass
-
-- name: get result of export cert with key and password as pfx
-  win_shell: |
-    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
-    $cert.Import("{{win_cert_dir}}\exported\cert-pass.pfx", "{{key_password}}", 0)
-    $cert.HasPrivateKey
-  vars: *become_vars
-  register: export_pfx_with_pass_result
-
-- name: assert results of export cert with key and password as pfx
-  assert:
-    that:
-    - export_pfx_with_pass is changed
-    - export_pfx_with_pass.thumbprints == [subj_thumbprint]
-    - export_pfx_with_pass_result.stdout_lines[0] == "True"
-
-- name: export cert with key and password as pfx (idempotent)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\exported\cert-pass.pfx'
-    thumbprint: '{{subj_thumbprint}}'
-    state: exported
-    file_type: pkcs12
-    store_location: CurrentUser
-    store_name: TrustedPeople
-    password: '{{key_password}}'
-  vars: *become_vars
-  register: export_pfx_with_pass_again
-
-- name: assert results of export cert with key and password as pfx (idempotent)
-  assert:
-    that:
-    - not export_pfx_with_pass_again is changed
-
-- name: export cert with key without password as pfx (check)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\exported\cert-without-pass.pfx'
-    thumbprint: '{{subj_thumbprint}}'
-    state: exported
-    file_type: pkcs12
-    store_location: CurrentUser
-    store_name: TrustedPeople
-  vars: *become_vars
-  register: export_pfx_without_pass_check
-  check_mode: yes
-
-- name: get result of export cert with key without password as pfx (check)
-  win_stat:
-    path: '{{win_cert_dir}}\exported\cert-without-pass.pfx'
-  register: export_pfx_without_pass_result_check
-
-- name: assert results of export cert with key without password as pfx (check)
-  assert:
-    that:
-    - export_pfx_without_pass_check is changed
-    - export_pfx_without_pass_check.thumbprints == [subj_thumbprint]
-    - export_pfx_without_pass_result_check.stat.exists == False
-
-- name: export cert with key without password as pfx
-  win_certificate_store:
-    path: '{{win_cert_dir}}\exported\cert-without-pass.pfx'
-    thumbprint: '{{subj_thumbprint}}'
-    state: exported
-    file_type: pkcs12
-    store_location: CurrentUser
-    store_name: TrustedPeople
-  vars: *become_vars
-  register: export_pfx_without_pass
-
-- name: get result of export cert with key without password as pfx
-  win_shell: |
-    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
-    $cert.Import("{{win_cert_dir}}\exported\cert-without-pass.pfx", $null, 0)
-    $cert.HasPrivateKey
-  vars: *become_vars
-  register: export_pfx_without_pass_result
-
-- name: assert results of export cert with key without password as pfx
-  assert:
-    that:
-    - export_pfx_without_pass is changed
-    - export_pfx_without_pass.thumbprints == [subj_thumbprint]
-    - export_pfx_without_pass_result.stdout_lines[0] == "True"
-
-- name: export cert with key without password as pfx (idempotent)
-  win_certificate_store:
-    path: '{{win_cert_dir}}\exported\cert-without-pass.pfx'
-    thumbprint: '{{subj_thumbprint}}'
-    state: exported
-    file_type: pkcs12
-    store_location: CurrentUser
-    store_name: TrustedPeople
-  vars: *become_vars
-  register: export_pfx_without_pass_again
-
-- name: assert results of export cert with key without password as pfx (idempotent)
-  assert:
-    that:
-    - not export_pfx_without_pass_again is changed
-
-- name: fail to export cert with key as pfx when not marked as exportable
-  win_certificate_store:
-    path: '{{win_cert_dir}}\exported\cert-fail.pfx'
-    thumbprint: '{{subj_thumbprint}}'
-    state: exported
-    file_type: pkcs12
-  vars: *become_vars
-  register: fail_export_non_exportable
-  failed_when: fail_export_non_exportable.msg != 'Cannot export cert with key as PKCS12 when the key is not marked as exportable or not accessible by the current user'


### PR DESCRIPTION
##### SUMMARY
Added the ability to manage the certificate store for a Windows service. Also made the `store_name` a free form field so it can manage 3rd party stores that are present.

I initially tried to allow creating and removing of custom stores in this module but the lack of documentation around moving a certificate store stopped me. I could remove the store once but it was never removed completely due to it being duplicated in various locations. This functionality will require more investigation before it can be implemented.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_certificate_store