### PR TITLE
win_updates - Update the documentation block

### DIFF
--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -11,6 +11,9 @@ module: win_updates
 short_description: Download and install Windows updates
 description:
     - Searches, downloads, and installs Windows updates synchronously by automating the Windows Update client.
+notes:
+    - The current module doesn't support Systems Center Configuration Manager (SCCM).
+    - See L(https://github.com/ansible-collections/ansible.windows/issues/194)
 options:
     blacklist:
         description:
@@ -51,13 +54,11 @@ options:
         - Defines the Windows Update source catalog.
         - C(default) Use the default search source. For many systems default is
           set to the Microsoft Windows Update catalog. Systems participating in
-          Windows Server Update Services (WSUS), Systems Center Configuration
-          Manager (SCCM), or similar corporate update server environments may
+          Windows Server Update Services (WSUS), or similar corporate update server environments may
           default to those managed update sources instead of the Windows Update
           catalog.
         - C(managed_server) Use a managed server catalog. For environments
-          utilizing Windows Server Update Services (WSUS), Systems Center
-          Configuration Manager (SCCM), or similar corporate update servers, this
+          utilizing Windows Server Update Services (WSUS), or similar corporate update servers, this
           option selects the defined corporate update source.
         - C(windows_update) Use the Microsoft Windows Update catalog.
         type: str

--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -11,9 +11,6 @@ module: win_updates
 short_description: Download and install Windows updates
 description:
     - Searches, downloads, and installs Windows updates synchronously by automating the Windows Update client.
-notes:
-    - The current module doesn't support Systems Center Configuration Manager (SCCM).
-    - See L(https://github.com/ansible-collections/ansible.windows/issues/194)
 options:
     blacklist:
         description:
@@ -112,6 +109,8 @@ notes:
   Check the examples for ways to mitigate this.
 - More information about PowerShell and how it handles RegEx strings can be
   found at U(https://technet.microsoft.com/en-us/library/2007.11.powershell.aspx).
+- The current module doesn't support Systems Center Configuration Manager (SCCM).
+  See L(https://github.com/ansible-collections/ansible.windows/issues/194)
 seealso:
 - module: chocolatey.chocolatey.win_chocolatey
 - module: ansible.windows.win_feature

--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -54,11 +54,11 @@ options:
         - Defines the Windows Update source catalog.
         - C(default) Use the default search source. For many systems default is
           set to the Microsoft Windows Update catalog. Systems participating in
-          Windows Server Update Services (WSUS), or similar corporate update server environments may
+          Windows Server Update Services (WSUS) or similar corporate update server environments may
           default to those managed update sources instead of the Windows Update
           catalog.
         - C(managed_server) Use a managed server catalog. For environments
-          utilizing Windows Server Update Services (WSUS), or similar corporate update servers, this
+          utilizing Windows Server Update Services (WSUS) or similar corporate update servers, this
           option selects the defined corporate update source.
         - C(windows_update) Use the Microsoft Windows Update catalog.
         type: str


### PR DESCRIPTION
##### SUMMARY

I get it that the win_updates module doesn't support SCCM.  
So this PR will remove SCCM from the documentation block, and add about SCCM doesn't support to notes.

see: https://github.com/ansible-collections/ansible.windows/issues/194

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

win_updates

##### ADDITIONAL INFORMATION

```
```