### PR TITLE
win_template - Fix ansible internal call that changed slightly in devel

### DIFF
--- a/changelogs/fragments/win_template-dest_path.yml
+++ b/changelogs/fragments/win_template-dest_path.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_template - Fix changed internal API that win_template uses to work with devel again

--- a/plugins/action/win_template.py
+++ b/plugins/action/win_template.py
@@ -123,7 +123,7 @@ class ActionModule(ActionBase):
 
                 # add ansible 'template' vars
                 temp_vars = task_vars.copy()
-                temp_vars.update(generate_ansible_template_vars(source, dest))
+                temp_vars.update(generate_ansible_template_vars(source, dest_path=dest))
 
                 with self._templar.set_temporary_context(searchpath=searchpath, newline_sequence=newline_sequence,
                                                          block_start_string=block_start_string, block_end_string=block_end_string,


### PR DESCRIPTION
##### SUMMARY
The change in Ansible https://github.com/ansible/ansible/pull/73924 added a positional argument in between source and dest_path meaning the call in `win_template` was treating `dest` another another `source` option. Instead we use the kwarg to ensure any future additions won't affect the code here anymore. I checked both stable-2.10 and stable-2.9 to make sure `generate_ansible_template_vars` had the kwarg `dest_path` so this change will still work on those versions.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_template