### PR TITLE
win_reboot - refactor and stabilise

### DIFF
--- a/changelogs/fragments/win_reboot-dep.yml
+++ b/changelogs/fragments/win_reboot-dep.yml
@@ -1,2 +1,0 @@
-removed_features:
-- win_reboot - Removed ``shutdown_timeout`` and ``shutdown_timeout_sec`` which has not done anything since Ansible 2.5.

--- a/changelogs/fragments/win_reboot-dep.yml
+++ b/changelogs/fragments/win_reboot-dep.yml
@@ -1,0 +1,2 @@
+removed_features:
+- win_reboot - Removed ``shutdown_timeout`` and ``shutdown_timeout_sec`` which has not done anything since Ansible 2.5.

--- a/changelogs/fragments/win_reboot-refactor.yml
+++ b/changelogs/fragments/win_reboot-refactor.yml
@@ -1,0 +1,18 @@
+bugfixes:
+- win_reboot - User defined commands are run wrapped as a PowerShell command so they work on all shells - https://github.com/ansible-collections/ansible.windows/issues/36
+- win_reboot - Ensure documented return values are always returned even on a failure
+- win_reboot - Handle more connection failures during the reboot phases
+
+minor_changes:
+- >-
+  win_reboot - Change the default ``test_command`` run after a reboot to wait for more services to start up before the
+  plugin finished. This should better handle waiting until the logon screen appears rather than just when WinRM is
+  first online.
+
+deprecated_features:
+- >-
+  win_reboot - Unreachable hosts can be ignored with ``ignore_errors: True``, this ability will be removed in a future
+  version. Use ``ignore_unreachable: True`` to ignore unreachable hosts instead. - https://github.com/ansible-collections/ansible.windows/issues/62
+
+removed_features:
+- win_reboot - Removed ``shutdown_timeout`` and ``shutdown_timeout_sec`` which has not done anything since Ansible 2.5.

--- a/plugins/action/win_reboot.py
+++ b/plugins/action/win_reboot.py
@@ -92,20 +92,4 @@ class ActionModule(ActionBase):
             result['unreachable'] = False
             result['failed'] = True
 
-        print("Running become test code")
-        from ansible.plugins.loader import become_loader
-        command = {
-            "_raw_params": "(New-Object -ComObject Microsoft.Update.Session).CreateUpdateInstaller().IsBusy"
-        }
-        become = become_loader.get('runas')
-        become.set_options(direct={'become_user': 'SYSTEM', 'become_pass': None})
-        self._connection.set_become_plugin(become)
-        module_res = self._execute_module(
-            module_name='ansible.windows.win_shell',
-            module_args=command,
-            task_vars=task_vars,
-            wrap_async=False
-        )
-        print(module_res)
-
         return result

--- a/plugins/action/win_reboot.py
+++ b/plugins/action/win_reboot.py
@@ -4,93 +4,71 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from datetime import datetime
-
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
+from ansible.module_utils.common.validation import check_type_str, check_type_int
 from ansible.plugins.action import ActionBase
-from ansible.plugins.action.reboot import ActionModule as RebootActionModule
 from ansible.utils.display import Display
+
+from ..plugin_utils._reboot import reboot_action
 
 display = Display()
 
 
-class TimedOutException(Exception):
-    pass
-
-
-class ActionModule(RebootActionModule, ActionBase):
+class ActionModule(ActionBase):
     TRANSFERS_FILES = False
     _VALID_ARGS = frozenset((
-        'connect_timeout', 'connect_timeout_sec', 'msg', 'post_reboot_delay', 'post_reboot_delay_sec', 'pre_reboot_delay', 'pre_reboot_delay_sec',
-        'reboot_timeout', 'reboot_timeout_sec', 'shutdown_timeout', 'shutdown_timeout_sec', 'test_command',
+        'boot_time_command',
+        'connect_timeout',
+        'connect_timeout_sec',
+        'msg',
+        'post_reboot_delay',
+        'post_reboot_delay_sec',
+        'pre_reboot_delay',
+        'pre_reboot_delay_sec',
+        'reboot_timeout',
+        'reboot_timeout_sec',
+        'shutdown_timeout',
+        'shutdown_timeout_sec',
+        'test_command',
     ))
 
-    DEFAULT_BOOT_TIME_COMMAND = "(Get-WmiObject -ClassName Win32_OperatingSystem).LastBootUpTime"
-    DEFAULT_CONNECT_TIMEOUT = 5
-    DEFAULT_PRE_REBOOT_DELAY = 2
-    DEFAULT_SUDOABLE = False
-    DEFAULT_SHUTDOWN_COMMAND_ARGS = '/r /t {delay_sec} /c "{message}"'
+    def run(self, tmp=None, task_vars=None):
+        self._supports_check_mode = True
+        self._supports_async = True
 
-    DEPRECATED_ARGS = {
-        'shutdown_timeout': '2.5',
-        'shutdown_timeout_sec': '2.5',
-    }
+        if self._play_context.check_mode:
+            return {'changed': True, 'elapsed': 0, 'rebooted': True}
 
-    def __init__(self, *args, **kwargs):
-        super(ActionModule, self).__init__(*args, **kwargs)
+        if task_vars is None:
+            task_vars = {}
 
-    def get_distribution(self, task_vars):
-        return {'name': 'windows', 'version': '', 'family': ''}
+        super(ActionModule, self).run(tmp, task_vars)
 
-    def get_shutdown_command(self, task_vars, distribution):
-        return self.DEFAULT_SHUTDOWN_COMMAND
+        parameters = {}
+        for names, check_func in [
+            (['boot_time_command'], check_type_str),
+            (['connect_timeout', 'connect_timeout_sec'], check_type_int),
+            (['msg'], check_type_str),
+            (['post_reboot_delay', 'post_reboot_delay_sec'], check_type_int),
+            (['pre_reboot_delay', 'pre_reboot_delay_sec'], check_type_int),
+            (['reboot_timeout', 'reboot_timeout_sec'], check_type_int),
+            (['test_command'], check_type_str),
+        ]:
+            for name in names:
+                value = self._task.args.get(name, None)
+                if value:
+                    break
+            else:
+                value = None
 
-    def run_test_command(self, distribution, **kwargs):
-        # Need to wrap the test_command in our PowerShell encoded wrapper. This is done to align the command input to a
-        # common shell and to allow the psrp connection plugin to report the correct exit code without manually setting
-        # $LASTEXITCODE for just that plugin.
-        test_command = self._task.args.get('test_command', self.DEFAULT_TEST_COMMAND)
-        kwargs['test_command'] = self._connection._shell._encode_script(test_command)
-        super(ActionModule, self).run_test_command(distribution, **kwargs)
+            # Defaults are applied in reboot_action so skip adding to kwargs if the input wasn't set (None)
+            if value is not None:
+                try:
+                    value = check_func(value)
+                except TypeError as e:
+                    raise AnsibleError("Invalid value given for '%s': %s." % (names[0], to_native(e)))
 
-    def perform_reboot(self, task_vars, distribution):
-        shutdown_command = self.get_shutdown_command(task_vars, distribution)
-        shutdown_command_args = self.get_shutdown_command_args(distribution)
-        reboot_command = self._connection._shell._encode_script('{0} {1}'.format(shutdown_command, shutdown_command_args))
+                parameters[names[0]] = value
 
-        display.vvv("{action}: rebooting server...".format(action=self._task.action))
-        display.debug("{action}: distribution: {dist}".format(action=self._task.action, dist=distribution))
-        display.debug("{action}: rebooting server with command '{command}'".format(action=self._task.action, command=reboot_command))
-
-        result = {}
-        reboot_result = self._low_level_execute_command(reboot_command, sudoable=self.DEFAULT_SUDOABLE)
-        result['start'] = datetime.utcnow()
-
-        # Test for "A system shutdown has already been scheduled. (1190)" and handle it gracefully
-        stdout = reboot_result['stdout']
-        stderr = reboot_result['stderr']
-        if reboot_result['rc'] == 1190 or (reboot_result['rc'] != 0 and "(1190)" in reboot_result['stderr']):
-            display.warning('A scheduled reboot was pre-empted by Ansible.')
-
-            # Try to abort (this may fail if it was already aborted)
-            result1 = self._low_level_execute_command(self._connection._shell._encode_script('shutdown /a'),
-                                                      sudoable=self.DEFAULT_SUDOABLE)
-
-            # Initiate reboot again
-            result2 = self._low_level_execute_command(reboot_command, sudoable=self.DEFAULT_SUDOABLE)
-
-            reboot_result['rc'] = result2['rc']
-            stdout += result1['stdout'] + result2['stdout']
-            stderr += result1['stderr'] + result2['stderr']
-
-        if reboot_result['rc'] != 0:
-            result['failed'] = True
-            result['rebooted'] = False
-            result['msg'] = "Reboot command failed, error was: {stdout} {stderr}".format(
-                stdout=to_native(stdout.strip()),
-                stderr=to_native(stderr.strip()))
-            return result
-
-        result['failed'] = False
-        return result
+        return reboot_action(self._task.action, self._connection, **parameters)

--- a/plugins/filter/quote.py
+++ b/plugins/filter/quote.py
@@ -4,70 +4,15 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import re
-
 from ansible.errors import AnsibleFilterError
 from ansible.module_utils.common.collections import is_sequence
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
-_UNSAFE_C = re.compile(u'[\\s\t"]')
-_UNSAFE_CMD = re.compile(u'[\\s\\(\\)\\^\\|%!"<>&]')
-
-# PowerShell has 5 characters it uses as a single quote, we need to double up on all of them.
-# https://github.com/PowerShell/PowerShell/blob/b7cb335f03fe2992d0cbd61699de9d9aafa1d7c1/src/System.Management.Automation/engine/parser/CharTraits.cs#L265-L272
-# https://github.com/PowerShell/PowerShell/blob/b7cb335f03fe2992d0cbd61699de9d9aafa1d7c1/src/System.Management.Automation/engine/parser/CharTraits.cs#L18-L21
-_UNSAFE_PWSH = re.compile(u"(['\u2018\u2019\u201a\u201b])")
-
-
-def _quote_c(s):
-    # https://docs.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
-    if not s:
-        return u'""'
-
-    if not _UNSAFE_C.search(s):
-        return s
-
-    # Replace any double quotes in an argument with '\"'.
-    s = s.replace('"', '\\"')
-
-    # We need to double up on any '\' chars that preceded a double quote (now '\"').
-    s = re.sub(r'(\\+)\\"', r'\1\1\"', s)
-
-    # Double up '\' at the end of the argument so it doesn't escape out end quote.
-    s = re.sub(r'(\\+)$', r'\1\1', s)
-
-    # Finally wrap the entire argument in double quotes now we've escaped the double quotes within.
-    return u'"{0}"'.format(s)
-
-
-def _quote_cmd(s):
-    # https://docs.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way#a-better-method-of-quoting
-    if not s:
-        return u'""'
-
-    if not _UNSAFE_CMD.search(s):
-        return s
-
-    # Escape the metachars as we are quoting the string to stop cmd from interpreting that metachar. For example
-    # 'file &whoami.exe' would result in 'whoami.exe' being executed and then that output being used as the argument
-    # instead of the literal string.
-    # https://stackoverflow.com/questions/3411771/multiple-character-replace-with-python
-    for c in u'^()%!"<>&|':  # '^' must be the first char that we scan and replace
-        if c in s:
-            # I can't find any docs that explicitly say this but to escape ", it needs to be prefixed with \^.
-            s = s.replace(c, (u"\\^" if c == u'"' else u"^") + c)
-
-    return u'^"{0}^"'.format(s)
-
-
-def _quote_pwsh(s):
-    # https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-5.1
-    if not s:
-        return u"''"
-
-    # We should always quote values in PowerShell as it has conflicting rules where strings can and can't be quoted.
-    # This means we quote the entire arg with single quotes and just double up on the single quote equivalent chars.
-    return u"'{0}'".format(_UNSAFE_PWSH.sub(u'\\1\\1', s))
+from ..plugin_utils._quote import (
+    quote_c,
+    quote_cmd,
+    quote_pwsh,
+)
 
 
 def quote(value, shell=None):
@@ -86,11 +31,11 @@ def quote(value, shell=None):
     :return: The quoted argument(s) from the input.
     """
     if not shell:
-        quote_func = _quote_c
+        quote_func = quote_c
     elif shell == 'cmd':
-        quote_func = _quote_cmd
+        quote_func = quote_cmd
     elif shell == 'powershell':
-        quote_func = _quote_pwsh
+        quote_func = quote_pwsh
     else:
         raise AnsibleFilterError("Invalid shell specified, valid shell are None, 'cmd', or 'powershell'")
 

--- a/plugins/plugin_utils/_quote.py
+++ b/plugins/plugin_utils/_quote.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2021 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Quoting helpers for Windows
+
+This contains code to help with quoting values for use in the variable Windows
+shell. Right now it should only be used in ansible.windows as the interface is
+not final and could be subject to change.
+"""
+
+# FOR INTERNAL COLLECTION USE ONLY
+# The interfaces in this file are meant for use within the ansible.windows collection
+# and may not remain stable to outside uses. Changes may be made in ANY release, even a bugfix release.
+# See also: https://github.com/ansible/community/issues/539#issuecomment-780839686
+# Please open an issue if you have questions about this.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+
+from ansible.module_utils.six import text_type
+
+
+_UNSAFE_C = re.compile(u'[\\s\t"]')
+_UNSAFE_CMD = re.compile(u'[\\s\\(\\)\\^\\|%!"<>&]')
+
+# PowerShell has 5 characters it uses as a single quote, we need to double up on all of them.
+# https://github.com/PowerShell/PowerShell/blob/b7cb335f03fe2992d0cbd61699de9d9aafa1d7c1/src/System.Management.Automation/engine/parser/CharTraits.cs#L265-L272
+# https://github.com/PowerShell/PowerShell/blob/b7cb335f03fe2992d0cbd61699de9d9aafa1d7c1/src/System.Management.Automation/engine/parser/CharTraits.cs#L18-L21
+_UNSAFE_PWSH = re.compile(u"(['\u2018\u2019\u201a\u201b])")
+
+
+def quote_c(s):  # type: (text_type) -> text_type
+    """Quotes a value for the raw Win32 process command line.
+
+    Quotes a value to be safely used by anything that calls the Win32
+    CreateProcess API.
+
+    Args:
+        s: The string to quote.
+
+    Returns:
+        (text_type): The quoted string value.
+    """
+    # https://docs.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way
+    if not s:
+        return u'""'
+
+    if not _UNSAFE_C.search(s):
+        return s
+
+    # Replace any double quotes in an argument with '\"'.
+    s = s.replace('"', '\\"')
+
+    # We need to double up on any '\' chars that preceded a double quote (now '\"').
+    s = re.sub(r'(\\+)\\"', r'\1\1\"', s)
+
+    # Double up '\' at the end of the argument so it doesn't escape out end quote.
+    s = re.sub(r'(\\+)$', r'\1\1', s)
+
+    # Finally wrap the entire argument in double quotes now we've escaped the double quotes within.
+    return u'"{0}"'.format(s)
+
+
+def quote_cmd(s):  # type: (text_type) -> text_type
+    """Quotes a value for cmd.
+
+    Quotes a value to be safely used by a command prompt call.
+
+    Args:
+        s: The string to quote.
+
+    Returns:
+        (text_type): The quoted string value.
+    """
+    # https://docs.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way#a-better-method-of-quoting
+    if not s:
+        return u'""'
+
+    if not _UNSAFE_CMD.search(s):
+        return s
+
+    # Escape the metachars as we are quoting the string to stop cmd from interpreting that metachar. For example
+    # 'file &whoami.exe' would result in 'whoami.exe' being executed and then that output being used as the argument
+    # instead of the literal string.
+    # https://stackoverflow.com/questions/3411771/multiple-character-replace-with-python
+    for c in u'^()%!"<>&|':  # '^' must be the first char that we scan and replace
+        if c in s:
+            # I can't find any docs that explicitly say this but to escape ", it needs to be prefixed with \^.
+            s = s.replace(c, (u"\\^" if c == u'"' else u"^") + c)
+
+    return u'^"{0}^"'.format(s)
+
+
+def quote_pwsh(s):  # type: (text_type) -> text_type
+    """Quotes a value for PowerShell.
+
+    Quotes a value to be safely used by a PowerShell expression. The input
+    string because something that is safely wrapped in single quotes.
+
+    Args:
+        s: The string to quote.
+
+    Returns:
+        (text_type): The quoted string value.
+    """
+    # https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_quoting_rules?view=powershell-5.1
+    if not s:
+        return u"''"
+
+    # We should always quote values in PowerShell as it has conflicting rules where strings can and can't be quoted.
+    # This means we quote the entire arg with single quotes and just double up on the single quote equivalent chars.
+    return u"'{0}'".format(_UNSAFE_PWSH.sub(u'\\1\\1', s))

--- a/plugins/plugin_utils/_reboot.py
+++ b/plugins/plugin_utils/_reboot.py
@@ -1,0 +1,374 @@
+# Copyright: (c) 2021, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Reboot action for Windows hosts
+
+This contains the code to reboot a Windows host for use by other action plugins
+in this collection. Right now it should only be used in ansible.windows as the
+interface is not final and could be subject to change.
+"""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import datetime
+import random
+import time
+import traceback
+
+from ansible.errors import AnsibleConnectionFailure, AnsibleError
+from ansible.module_utils.common.text.converters import to_native, to_text
+from ansible.utils.display import Display
+
+from ansible.plugins.connection import ConnectionBase
+try:
+    from typing import (
+        Any,
+        Callable,
+        Dict,
+        Tuple,
+    )
+except ImportError:
+    # Satisfy Python 2 which doesn't have typing.
+    Any = Callable = Dict = Tuple = None
+
+
+# This is not ideal but the psrp connection plugin doesn't catch all these exceptions as an AnsibleConnectionFailure.
+# Until we can guarantee we are using a version of psrp that handles all this we try to handle those issues.
+try:
+    from requests.exceptions import (
+        ConnectionError as RequestsConnectionError,
+        Timeout as RequestsTimeout,
+    )
+except ImportError:
+    RequestsConnectionError = RequestsTimeout = None
+
+
+_DEFAULT_BOOT_TIME_COMMAND = "(Get-CimInstance -ClassName Win32_OperatingSystem -Property LastBootUpTime)" \
+                             ".LastBootUpTime.ToFileTime()"
+display = Display()
+
+
+class _ReturnResultException(Exception):
+
+    def __init__(self, msg, **result):
+        super(_ReturnResultException, self).__init__(msg)
+        self.result = result
+
+
+def reboot_action(
+        task_action,
+        connection,
+        boot_time_command=_DEFAULT_BOOT_TIME_COMMAND,
+        connection_timeout=5,
+        msg='Reboot initiated by Ansible',
+        post_reboot_delay=0,
+        pre_reboot_delay=2,
+        reboot_timeout=600,
+        test_command='whoami',
+):  # type: (str, ConnectionBase, str, int, str, int, int, int, str) -> Dict
+    """Reboot a Windows Host.
+
+    Used by action plugins in ansible.windows to reboot a Windows host. It
+    takes in the action plugin so it can run the commands on the targeted host
+    and monitor the reboot process. The return dict will have the following
+    keys set:
+
+        changed: Whether a change occurred (reboot was done)
+        elapsed: Seconds elapsed between the reboot and it coming back online
+        failed: Whether a failure occurred
+        rebooted: Whether the host was rebooted
+
+    When failed=True there may be more keys to give some information around
+    the failure like msg, exception. There are other keys that might be
+    returned as well but they are dependent on the failure that occurred.
+
+    Verbosity levels used:
+        2: Message when each reboot step is completed
+        3: Connection plugin operations and their results
+        5: Raw commands run and the results of those commands
+        Debug:
+
+    Args:
+        task_action: The name of the action plugin that is running for logging.
+        connection: The connection plugin to run the reboot again.
+        boot_time_command: The command to run when getting the boot timeout.
+        connection_timeout: Override the connection timeout of the connection
+            plugin when polling the rebooted host.
+        msg: The message to display to interactive users when rebooting the
+            host.
+        post_reboot_delay: Seconds to wait after sending the reboot command
+            before checking to see if it has returned.
+        pre_reboot_delay: Seconds to wait when sending the reboot command.
+        reboot_timeout: Seconds to wait while polling for the host to come
+            back online.
+        test_command: Command to run when the host is back online and
+            determines the machine is ready for management.
+
+    Returns:
+        (Dict[str, Any]): The return result as a dictionary. Use the 'failed'
+            key to determine if there was a failure or not.
+    """
+    result = {
+        'changed': False,
+        'elapsed': 0,
+        'failed': False,
+        'rebooted': False,
+    }
+
+    # Get current boot time
+    try:
+        previous_boot_time = _get_system_boot_time(task_action, connection, boot_time_command)
+    except Exception as e:
+        if isinstance(e, _ReturnResultException):
+            result.update(e.result)
+
+        result['failed'] = True
+        result['msg'] = to_text(e)
+        result['exception'] = traceback.format_exc()
+        return result
+
+    # Get the original connection_timeout option var so it can be reset after
+    original_connection_timeout = None
+    reset_connection_timeout = True
+    try:
+        original_connection_timeout = connection.get_option('connection_timeout')
+        display.vvv("%s: saving original connect_timeout of %s" % (task_action, original_connection_timeout))
+    except KeyError:
+        display.vvv("%s: connect_timeout connection option has not been set" % task_action)
+        reset_connection_timeout = False
+
+    # Initiate reboot
+    reboot_command = 'shutdown.exe /r /t %s /c "%s"' % (pre_reboot_delay, msg)
+    try:
+        _perform_reboot(task_action, connection, reboot_command)
+    except Exception as e:
+        if isinstance(e, _ReturnResultException):
+            result.update(e.result)
+
+        result['failed'] = True
+        result['msg'] = to_text(e)
+        result['exception'] = traceback.format_exc()
+        return result
+
+    start = datetime.datetime.utcnow()
+
+    try:
+        result['rebooted'] = True
+
+        if post_reboot_delay != 0:
+            display.vv("%s: waiting an additional %s seconds" % (task_action, post_reboot_delay))
+            time.sleep(post_reboot_delay)
+
+        # Keep on trying to run the last boot time check until it is successful or the timeout is raised
+        display.vv('%s validating reboot' % task_action)
+        _do_until_success_or_timeout(task_action, connection, 'last boot time check', reboot_timeout,
+                                     _check_boot_time, task_action, connection, previous_boot_time, boot_time_command,
+                                     connection_timeout)
+
+        # Reset the connection plugin connection timeout back to the original
+        if reset_connection_timeout:
+            _set_connection_timeout(task_action, connection, original_connection_timeout)
+
+        # Run test command until ti is successful or a timeout occurs
+        display.vv('%s running post reboot test command' % task_action)
+        _do_until_success_or_timeout(task_action, connection, 'post-reboot test command', reboot_timeout,
+                                     _run_test_command, task_action, connection, test_command)
+
+        display.vv("%s: system successfully rebooted" % task_action)
+
+    except Exception as e:
+        if isinstance(e, _ReturnResultException):
+            result.update(e.result)
+
+        result['failed'] = True
+        result['msg'] = to_text(e)
+        result['exception'] = traceback.format_exc()
+
+    elapsed = datetime.datetime.utcnow() - start
+    result['elapsed'] = elapsed.seconds
+
+    return result
+
+
+def _check_boot_time(task_action, connection, previous_boot_time, boot_time_command, timeout):
+    """Checks the system boot time has been changed or not"""
+    display.vvv("%s: attempting to get system boot time" % task_action)
+
+    # override connection timeout from defaults to custom value
+    if timeout:
+        display.vvvvv("%s: setting connect_timeout to %s" % (task_action, timeout))
+        connection.set_option("connection_timeout", timeout)
+        if not _reset_connection(task_action, connection):
+            display.warning("Connection plugin does not allow the connection timeout to be overridden")
+
+    # try and get boot time
+    current_boot_time = _get_system_boot_time(task_action, connection, boot_time_command)
+    if current_boot_time == previous_boot_time:
+        raise ValueError("boot time has not changed")
+
+
+def _do_until_success_or_timeout(task_action, connection, action_desc, timeout, func, *args, **kwargs):
+    # type: (str, ConnectionBase, str, int, Callable, Any, Any) -> Any
+    """Runs the function multiple times ignoring errors until a timeout occurs"""
+    max_end_time = datetime.datetime.utcnow() + datetime.timedelta(seconds=timeout)
+
+    fail_count = 0
+    max_fail_sleep = 12
+    reset_required = False
+
+    while datetime.datetime.utcnow() < max_end_time:
+        try:
+            if reset_required:
+                # Keep on trying the reset until it succeeds.
+                _reset_connection(task_action, connection)
+                reset_required = False
+
+            else:
+                res = func(*args, **kwargs)
+                display.vvvvv('%s: %s success' % (task_action, action_desc))
+
+                return res
+
+        except Exception as e:
+            # The error may be due to a connection problem, just reset the connection just in case
+            reset_required = True
+
+            # Use exponential backoff with a max timeout, plus a little bit of randomness
+            random_int = random.randint(0, 1000) / 1000
+            fail_sleep = 2 ** fail_count + random_int
+            if fail_sleep > max_fail_sleep:
+                fail_sleep = max_fail_sleep + random_int
+
+            try:
+                error = to_text(e).splitlines()[-1]
+            except IndexError as e:
+                error = to_text(e)
+
+            display.vvvvv("{action}: {desc} fail {e_type} '{err}', retrying in {sleep:.4} seconds...\n{test}".format(
+                action=task_action,
+                desc=action_desc,
+                e_type=type(e).__name__,
+                err=error,
+                sleep=fail_sleep,
+                test=traceback.format_exc(),
+            ))
+
+            fail_count += 1
+            time.sleep(fail_sleep)
+
+    raise Exception('Timed out waiting for %s (timeout=%s)' % (action_desc, timeout))
+
+
+def _execute_command(task_action, connection, command):  # type: (str, ConnectionBase, str) -> Tuple[int, str, str]
+    """Runs a command on the Windows host and returned the result"""
+    display.vvvvv("%s: running command: %s" % (task_action, command))
+
+    # Need to wrap the command in our PowerShell encoded wrapper. This is done to align the command input to a
+    # common shell and to allow the psrp connection plugin to report the correct exit code without manually setting
+    # $LASTEXITCODE for just that plugin.
+    command = connection._shell._encode_script(command)
+
+    try:
+        rc, stdout, stderr = connection.exec_command(command, in_data=None, sudoable=False)
+    except (RequestsConnectionError, RequestsTimeout) as e:
+        # The psrp connection plugin should be doing this but until we can guarantee it does we just convert it here
+        # to ensure AnsibleConnectionFailure refers to actual connection errors.
+        raise AnsibleConnectionFailure("Failed to connect to the host: %s" % to_native(e))
+
+    rc = rc or 0
+    stdout = to_text(stdout, errors='surrogate_or_strict').strip()
+    stderr = to_text(stderr, errors='surrogate_or_strict').strip()
+
+    display.vvvvv("%s: command result - rc: %s, stdout: %s, stderr: %s" % (task_action, rc, stdout, stderr))
+
+    return rc, stdout, stderr
+
+
+def _get_system_boot_time(task_action, connection, boot_time_command):  # type: (str, ConnectionBase, str) -> str
+    """Gets a unique identifier to represent the boot time of the Windows host"""
+    display.vv("%s: getting boot time" % task_action)
+    rc, stdout, stderr = _execute_command(task_action, connection, boot_time_command)
+
+    if rc != 0:
+        msg = "%s: failed to get host boot time info" % task_action
+        raise _ReturnResultException(msg, rc=rc, stdout=stdout, stderr=stderr)
+
+    display.vvv("%s: last boot time: %s" % (task_action, stdout))
+    return stdout
+
+
+def _perform_reboot(task_action, connection, reboot_command, handle_abort=True):
+    # type: (str, ConnectionBase, str, bool) -> None
+    """Runs the reboot command"""
+    display.vv("%s: rebooting server..." % task_action)
+
+    stdout = stderr = None
+    try:
+        rc, stdout, stderr = _execute_command(task_action, connection, reboot_command)
+
+    except AnsibleConnectionFailure as e:
+        # If the connection is closed too quickly due to the system being shutdown, carry on
+        display.vvv('%s: AnsibleConnectionFailure caught and handled: %s' % (task_action, to_text(e)))
+        rc = 0
+
+    # Test for "A system shutdown has already been scheduled. (1190)" and handle it gracefully
+    if handle_abort and (rc == 1190 or (rc != 0 and "(1190)" in stderr)):
+        display.warning('A scheduled reboot was pre-empted by Ansible.')
+
+        # Try to abort (this may fail if it was already aborted)
+        rc, stdout, stderr = _execute_command(task_action, connection, 'shutdown.exe /a')
+        display.vvv("%s: result from trying to abort existing shutdown - rc: %s, stdout: %s, stderr: %s"
+                    % (task_action, rc, stdout, stderr))
+
+        return _perform_reboot(task_action, connection, reboot_command, handle_abort=False)
+
+    if rc != 0:
+        msg = "%s: Reboot command failed" % task_action
+        raise _ReturnResultException(msg, rc=rc, stdout=stdout, stderr=stderr)
+
+
+def _reset_connection(task_action, connection, ignore_errors=False):  # type: (str, ConnectionBase, tru) -> bool
+    """Resets the connection handling any errors and returns a bool stating if it is resettable"""
+    res = True
+    if getattr(_reset_connection, '_skip', False):
+        return res
+
+    display.vvv("%s: resetting connection plugin" % task_action)
+    try:
+        connection.reset()
+
+    except AttributeError:
+        res = False
+        setattr(_reset_connection, '_skip', True)
+
+    except (AnsibleError, RequestsConnectionError, RequestsTimeout) as e:
+        if ignore_errors:
+            return res
+
+        raise AnsibleError(to_native(e))
+
+    return res
+
+
+def _run_test_command(task_action, connection, command):  # type: (str, ConnectionBase, str) -> None
+    """Runs the user specified test command until the host is able to run it properly"""
+    display.vvv("%s: attempting post-reboot test command" % task_action)
+
+    rc, stdout, stderr = _execute_command(task_action, connection, command)
+
+    if rc != 0:
+        msg = "%s: Test command failed - rc: %s, stdout: %s, stderr: %s" % (task_action, rc, stdout, stderr)
+        raise RuntimeError(msg)
+
+
+def _set_connection_timeout(task_action, connection, timeout):  # type: (str, ConnectionBase, int) -> None
+    """Sets the connection plugin connection_timeout option and resets the connection"""
+    current_connection_timeout = connection.get_option('connection_timeout')
+    if timeout == current_connection_timeout:
+        return
+
+    display.vvv("%s: setting connect_timeout %s" % (task_action, timeout))
+    connection.set_option("connection_timeout", timeout)
+
+    _reset_connection(task_action, connection, ignore_errors=True)

--- a/tests/integration/targets/win_reboot/tasks/main.yml
+++ b/tests/integration/targets/win_reboot/tasks/main.yml
@@ -33,7 +33,7 @@
     test_command: 'FAIL'
     reboot_timeout: 120
   register: reboot_fail_test
-  failed_when: "reboot_fail_test.msg != 'Timed out waiting for post-reboot test command (timeout=120)'"
+  failed_when: "reboot_fail_test.msg != 'Timed out waiting for post-reboot test command (timeout=120.0)'"
 
 - name: remove SeRemoteShutdownPrivilege
   win_user_right:
@@ -47,8 +47,8 @@
     win_reboot:
     register: fail_privilege
     failed_when:
-    - "'Reboot command failed, error was:' not in fail_privilege.msg"
-    - "'Access is denied.(5)' not in fail_privilege.msg"
+    - 'fail_privilege.msg != "win_reboot: Reboot command failed"'
+    - "'Access is denied.(5)' not in fail_privilege.stderr"
 
   always:
   - name: reset the SeRemoteShutdownPrivilege
@@ -58,7 +58,7 @@
       action: add
 
 - name: Use invalid parameter
-  reboot:
+  win_reboot:
     foo: bar
   ignore_errors: true
   register: invalid_parameter
@@ -67,4 +67,4 @@
   assert:
     that:
     - invalid_parameter is failed
-    - "invalid_parameter.msg == 'Invalid options for reboot: foo'"
+    - "invalid_parameter.msg == 'Invalid options for win_reboot: foo'"


### PR DESCRIPTION
##### SUMMARY
A refactor of the win_reboot plugin. It changes the following

* Stops relying on `reboot` that is in ansible-base in case that makes an incompatible change
* Move the reboot specific components to an internal plugin util to make it easy for other action plugins to call
* Ensure the correct and documented return values are returned on a failure
* Return stdout/stderr/rc from get last boot time failures as separate keys for easier parsing
* Try to handle connection failures with requests based connections (winrm/psrp) where they don't catch those exceptions properly

Fixes https://github.com/ansible-collections/ansible.windows/issues/27
Fixes https://github.com/ansible-collections/ansible.windows/issues/36
Fixes https://github.com/ansible-collections/ansible.windows/issues/62

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
win_reboot