### PR TITLE
Updated certificate store name for intermediate CA

### DIFF
--- a/docs/ansible.windows.win_certificate_store_module.rst
+++ b/docs/ansible.windows.win_certificate_store_module.rst
@@ -196,7 +196,7 @@ Parameters
                         <div>The store name to use when importing a certificate or searching for a certificate.</div>
                         <div><code>AddressBook</code>: The X.509 certificate store for other users</div>
                         <div><code>AuthRoot</code>: The X.509 certificate store for third-party certificate authorities (CAs)</div>
-                        <div><code>CertificateAuthority</code>: The X.509 certificate store for intermediate certificate authorities (CAs)</div>
+                        <div><code>CA</code>: The X.509 certificate store for intermediate certificate authorities (CAs)</div>
                         <div><code>Disallowed</code>: The X.509 certificate store for revoked certificates</div>
                         <div><code>My</code>: The X.509 certificate store for personal certificates</div>
                         <div><code>Root</code>: The X.509 certificate store for trusted root certificate authorities (CAs)</div>


### PR DESCRIPTION
##### SUMMARY

Module `ansible.windows.win_certificate_store` documentation stated Windows certificate store name (`store_name: "CertificateAuthority"`) for intermediate certificate authorities.

Importing a certificate to store name `CertificateAuthority` raises error message `unable to find store ''CertificateAuthority'': (CertOpenStore failed (The system cannot find the file specified, Win32ErrorCode 2 - 0x00000002))`.

Using store name `CA` allowed me to import a certificate to certificate store for intermediate certificate authorities.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

Module `ansible.windows.win_certificate_store`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
