### PR TITLE
Add metadata for ansible-builder

### DIFF
--- a/meta/ee-bindep.txt
+++ b/meta/ee-bindep.txt
@@ -1,0 +1,8 @@
+# This is used for ansible-builder and should not be used by other tools
+gcc [platform:rpm compile]
+krb5-devel [platform:rpm compile]
+krb5-workstation [platform:rpm]  # Used by winrm as it calls kinit during runtime
+python38-cryptography [platform:rpm]
+python38-devel [platform:rpm compile]
+python38-requests [platform:rpm]  # Uses a requests that trust the system cert store rather than certifi
+

--- a/meta/ee-requirements.txt
+++ b/meta/ee-requirements.txt
@@ -1,0 +1,4 @@
+# This is used for ansible-builder and should not be used by other tools
+pypsrp[kerberos,credssp]
+pywinrm[kerberos,credssp]
+

--- a/meta/execution-environment.yml
+++ b/meta/execution-environment.yml
@@ -1,0 +1,5 @@
+dependencies:
+  python: meta/ee-requirements.txt
+  system: meta/ee-bindep.txt
+version: 1
+


### PR DESCRIPTION
##### SUMMARY
Adds metadata required by ansible-builder to create an image with all the main dependencies required for Windows on Ansible. These files should not be used by any other tool.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-builder