### PR TITLE
win_certificate_store - fix CertificateAuthority -> CA

### DIFF
--- a/changelogs/fragments/win_certificate_store-ca.yml
+++ b/changelogs/fragments/win_certificate_store-ca.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- >-
+  win_certificate_store - Make sure `store_name: CertificateAuthority` refers to the `CA` store for backwards
+  compatibility - https://github.com/ansible-collections/ansible.windows/pull/216

--- a/plugins/modules/win_certificate_store.ps1
+++ b/plugins/modules/win_certificate_store.ps1
@@ -326,6 +326,13 @@ $module.Result.thumbprints = @()
 [Security.Cryptography.X509Certificates.OpenFlags]$open_flags = if ($state -eq 'exported') { 'ReadOnly' } else { 'ReadWrite' }
 $open_flags = [int]$open_flags -bor [int][Security.Cryptography.X509Certificates.OpenFlags]::OpenExistingOnly
 
+# We originally opened the store with [X509]::new($name, $location). Now that we call the necessary Win32 APIs we need
+# map any of the StoreName enum values to the proper string name. Luckily that is just CertificateAuthority -> CA.
+# https://github.com/microsoft/referencesource/blob/master/System/security/system/security/cryptography/x509/x509store.cs#L67-L91
+if ($store_name -eq 'CertificateAuthority') {
+    $store_name = 'CA'
+}
+
 $cert_params = @{
     Name = $store_name
 }

--- a/tests/integration/targets/win_certificate_store/tasks/test.yml
+++ b/tests/integration/targets/win_certificate_store/tasks/test.yml
@@ -299,17 +299,17 @@
   win_certificate_store:
     path: '{{win_cert_dir}}\chain.p7b'
     state: present
-    store_name: TrustedPeople
+    store_name: CertificateAuthority
     store_location: CurrentUser
   register: import_der_p7b_check
   check_mode: yes
 
 - name: get result of subj in p7b chain in custom store (check)
-  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\CA | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
   register: import_der_p7b_subj_result_check
 
 - name: get result of root in p7b chain in custom store (check)
-  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
+  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\CA | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
   register: import_der_p7b_root_result_check
 
 - name: assert results of import DER encoded p7b chain into custom store (check)
@@ -326,16 +326,16 @@
   win_certificate_store:
     path: '{{win_cert_dir}}\chain.p7b'
     state: present
-    store_name: TrustedPeople
+    store_name: CertificateAuthority
     store_location: CurrentUser
   register: import_der_p7b
 
 - name: get result of subj in p7b chain in custom store
-  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
+  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\CA | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
   register: import_der_p7b_subj_result
 
 - name: get result of root in p7b chain in custom store
-  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\TrustedPeople | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
+  win_shell: if (Get-ChildItem -Path Cert:\CurrentUser\CA | Where-Object { $_.Thumbprint -eq "{{root_thumbprint}}" }) { $true } else { $false }
   register: import_der_p7b_root_result
 
 - name: assert results of import DER encoded p7b chain into custom store
@@ -352,7 +352,7 @@
   win_certificate_store:
     path: '{{win_cert_dir}}\chain.p7b'
     state: present
-    store_name: TrustedPeople
+    store_name: CertificateAuthority
     store_location: CurrentUser
   register: import_der_p7b_again
 
@@ -365,7 +365,7 @@
   win_certificate_store:
     thumbprint: '{{item}}'
     state: absent
-    store_name: TrustedPeople
+    store_name: CertificateAuthority
     store_location: CurrentUser
   with_items:
   - '{{subj_thumbprint}}'


### PR DESCRIPTION
##### SUMMARY
In the past we used a .NET method that translated `[Security.Cryptography.X509Certificates.StoreName]::CertificateAuthority` to the `CA` store. Now that we open the handle manually and we just pass the string in directly we still need to ensure that `store_name: CertificateAuthority` refers to the `CA` store just like it did before.

Fixes https://github.com/ansible-collections/ansible.windows/pull/216

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_certificate_store