### PR TITLE
Add more detail about list arguments

### DIFF
--- a/docs/ansible.windows.win_package_module.rst
+++ b/docs/ansible.windows.win_package_module.rst
@@ -51,7 +51,6 @@ Parameters
                         <div>If the package is an MSI do not supply the <code>/qn</code>, <code>/log</code> or <code>/norestart</code> arguments.</div>
                         <div>This is only used for the <code>msi</code>, <code>msp</code>, and <code>registry</code> providers.</div>
                         <div>Can be a list of arguments and the module will escape the arguments as necessary, it is recommended to use a string when dealing with MSI packages due to the unique escaping issues with msiexec.</div>
-                        <div>When using a list of arguments each item in the list is considered to be a single argument. As such, if an argument in the list contains a space then Ansible will quote this to ensure that this is seen by Windows as a single argument. Should this behaviour not be what is required, the argument should be split into two separate list items. See the examples section for more detail.</div>
                 </td>
             </tr>
             <tr>
@@ -674,19 +673,6 @@ Examples
         - /install
         - /passive
         - /norestart
-        
-    - name: Install MSBuild thingy with arguments split to prevent quotes
-      ansible.windows.win_package:
-        path: https://download.visualstudio.microsoft.com/download/pr/9665567e-f580-4acd-85f2-bc94a1db745f/3580c7d8c43782aebab3af6db6e46e0f89752a96336f9518d3a10f407f4048af/vs_BuildTools.exe
-        product_id: '{D1437F51-786A-4F57-A99C-F8E94FBA1BD8}'
-        arguments: 
-        - --norestart
-        - --passive
-        - --wait
-        - --add 
-        - Microsoft.Net.Component.4.6.1.TargetingPack
-        - --add
-        - Microsoft.Net.Component.4.6.TargetingPack
 
     - name: Install Remote Desktop Connection Manager from msi with a permanent log
       ansible.windows.win_package:

--- a/docs/ansible.windows.win_package_module.rst
+++ b/docs/ansible.windows.win_package_module.rst
@@ -51,6 +51,7 @@ Parameters
                         <div>If the package is an MSI do not supply the <code>/qn</code>, <code>/log</code> or <code>/norestart</code> arguments.</div>
                         <div>This is only used for the <code>msi</code>, <code>msp</code>, and <code>registry</code> providers.</div>
                         <div>Can be a list of arguments and the module will escape the arguments as necessary, it is recommended to use a string when dealing with MSI packages due to the unique escaping issues with msiexec.</div>
+                        <div>When using a list of arguments each item in the list is considered to be a single argument. As such, if an argument in the list contains a space then Ansible will quote this to ensure that this is seen by Windows as a single argument. Should this behaviour not be what is required, the argument should be split into two separate list items. See the examples section for more detail.</div>
                 </td>
             </tr>
             <tr>
@@ -673,6 +674,19 @@ Examples
         - /install
         - /passive
         - /norestart
+        
+    - name: Install MSBuild thingy with arguments split to prevent quotes
+      ansible.windows.win_package:
+        path: https://download.visualstudio.microsoft.com/download/pr/9665567e-f580-4acd-85f2-bc94a1db745f/3580c7d8c43782aebab3af6db6e46e0f89752a96336f9518d3a10f407f4048af/vs_BuildTools.exe
+        product_id: '{D1437F51-786A-4F57-A99C-F8E94FBA1BD8}'
+        arguments: 
+        - --norestart
+        - --passive
+        - --wait
+        - --add 
+        - Microsoft.Net.Component.4.6.1.TargetingPack
+        - --add
+        - Microsoft.Net.Component.4.6.TargetingPack
 
     - name: Install Remote Desktop Connection Manager from msi with a permanent log
       ansible.windows.win_package:

--- a/plugins/modules/win_package.py
+++ b/plugins/modules/win_package.py
@@ -238,13 +238,13 @@ EXAMPLES = r'''
 
 - name: Install MSBuild thingy with arguments split to prevent quotes
   ansible.windows.win_package:
-    path: https://download.visualstudio.microsoft.com/download/pr/9665567e-f580-4acd-85f2-bc94a1db745f/3580c7d8c43782aebab3af6db6e46e0f89752a96336f9518d3a10f407f4048af/vs_BuildTools.exe
+    path: https://download.visualstudio.microsoft.com/download/pr/9665567e-f580-4acd-85f2-bc94a1db745f/vs_BuildTools.exe
     product_id: '{D1437F51-786A-4F57-A99C-F8E94FBA1BD8}'
-    arguments: 
+    arguments:
     - --norestart
     - --passive
     - --wait
-    - --add 
+    - --add
     - Microsoft.Net.Component.4.6.1.TargetingPack
     - --add
     - Microsoft.Net.Component.4.6.TargetingPack

--- a/plugins/modules/win_package.py
+++ b/plugins/modules/win_package.py
@@ -26,6 +26,12 @@ options:
     - Can be a list of arguments and the module will escape the arguments as
       necessary, it is recommended to use a string when dealing with MSI
       packages due to the unique escaping issues with msiexec.
+    - When using a list of arguments each item in the list is considered to be
+      a single argument. As such, if an argument in the list contains a space
+      then Ansible will quote this to ensure that this is seen by Windows as
+      a single argument. Should this behaviour not be what is required, the
+      argument should be split into two separate list items. See the examples
+      section for more detail.
     type: raw
   chdir:
     description:
@@ -229,6 +235,19 @@ EXAMPLES = r'''
     - /install
     - /passive
     - /norestart
+
+- name: Install MSBuild thingy with arguments split to prevent quotes
+  ansible.windows.win_package:
+    path: https://download.visualstudio.microsoft.com/download/pr/9665567e-f580-4acd-85f2-bc94a1db745f/3580c7d8c43782aebab3af6db6e46e0f89752a96336f9518d3a10f407f4048af/vs_BuildTools.exe
+    product_id: '{D1437F51-786A-4F57-A99C-F8E94FBA1BD8}'
+    arguments: 
+    - --norestart
+    - --passive
+    - --wait
+    - --add 
+    - Microsoft.Net.Component.4.6.1.TargetingPack
+    - --add
+    - Microsoft.Net.Component.4.6.TargetingPack
 
 - name: Install Remote Desktop Connection Manager from msi with a permanent log
   ansible.windows.win_package:


### PR DESCRIPTION
Including guidance from https://github.com/ansible/ansible/issues/50221#issuecomment-449199876 regarding the handling of list arguments. 

##### SUMMARY
I've spent quite a lot of time trying to figure out an issue regarding the use of list arguments with win_package. This [issue](https://github.com/ansible/ansible/issues/50221#issuecomment-449199876) had some really good advice from @jborean93 on how to properly use list arguments and I thought this would be a useful addition to the documentation just in case anyone else runs into something similar.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible.windows.win_package

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
The following task will fail with a return code of 87.
```- name: Install MSBuild Tools
  win_package:
    path: "https://download.visualstudio.microsoft.com/download/pr/9665567e-f580-4acd-85f2-bc94a1db745f/3580c7d8c43782aebab3af6db6e46e0f89752a96336f9518d3a10f407f4048af/vs_BuildTools.exe"
    product_id: '{D1437F51-786A-4F57-A99C-F8E94FBA1BD8}'
    arguments: 
    - --norestart
    - --passive
    - --wait
    - --add Microsoft.Net.Component.4.6.1.TargetingPack
    - --add Microsoft.Net.Component.4.6.TargetingPack
    - --add Microsoft.Net.Component.4.8.TargetingPack
    - --add Microsoft.Net.Component.4.8.SDK
    - --add Microsoft.VisualStudio.Component.NuGet.BuildTools
    - --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64
    - --add Microsoft.VisualStudio.Component.Windows10SDK.18362
    - --add Microsoft.VisualStudio.Component.TeamOffice.BuildTools
    - --add Microsoft.VisualStudio.Component.Roslyn.Compiler
    - --add Microsoft.VisualStudio.Component.Roslyn.LanguageServices
```

If you follow the guidance and example now added to the documentation the below changes will allow the task to run successfully:

```
- name: Install MSBuild Tools using correct list arguments
  win_package:
    path: "https://download.visualstudio.microsoft.com/download/pr/9665567e-f580-4acd-85f2-bc94a1db745f/3580c7d8c43782aebab3af6db6e46e0f89752a96336f9518d3a10f407f4048af/vs_BuildTools.exe"
    product_id: '{D1437F51-786A-4F57-A99C-F8E94FBA1BD8}'
    arguments: 
    - --norestart
    - --passive
    - --wait
    - --add 
    - Microsoft.Net.Component.4.6.1.TargetingPack
    - --add
    - Microsoft.Net.Component.4.6.TargetingPack
    - --add
    - Microsoft.Net.Component.4.8.TargetingPack
    - --add
    - Microsoft.Net.Component.4.8.SDK
    - --add
    - Microsoft.VisualStudio.Component.NuGet.BuildTools
    - --add
    - Microsoft.VisualStudio.Component.VC.Tools.x86.x64
    - --add
    - Microsoft.VisualStudio.Component.Windows10SDK.18362
    - --add
    - Microsoft.VisualStudio.Component.TeamOffice.BuildTools
    - --add
    - Microsoft.VisualStudio.Component.Roslyn.Compiler
    - --add
    - Microsoft.VisualStudio.Component.Roslyn.LanguageServices
```
