### PR TITLE
win_reboot - handle flaky connection at the start

### DIFF
--- a/changelogs/fragments/win_reboot-flaky-connection.yml
+++ b/changelogs/fragments/win_reboot-flaky-connection.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_reboot - Handle connection failures when getting the first boot time command


### PR DESCRIPTION
##### SUMMARY
A few tasks that require a reboot may leave the connection in a bad state. We try at least 3 times to run the first command when getting the boot timeout to help alleviate this issue. It's not a guaranteed fix as the connection error may happen in the previous task but that requires some more substantial work to implement properly.

Also broadens the scope of request errors that are considered a connection issue after more use in the real world.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_reboot