### PR TITLE
win_stat - return time offets from UTC

### DIFF
--- a/changelogs/fragments/win_state-datetime.yml
+++ b/changelogs/fragments/win_state-datetime.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- >-
+  win_state - Fixed the ``creationtime``, ``lastaccesstime``, and ``lastwritetime`` to report the time in UTC.
+  This matches the ``stat`` module's behaviour and what many would expect for a epoch based timestamp -
+  https://github.com/ansible-collections/ansible.windows/issues/240

--- a/plugins/modules/win_stat.ps1
+++ b/plugins/modules/win_stat.ps1
@@ -76,7 +76,7 @@ $module.Result.stat = @{ exists=$false }
 Load-LinkUtils
 $info, $link_info = Get-FileInfo -Path $path -Follow:$follow
 If ($null -ne $info) {
-    $epoch_date = Get-Date -Date "01/01/1970"
+    $epoch_date = (Get-Date -Year 1970 -Month 1 -Day 1).Date
     $attributes = @()
     foreach ($attribute in ($info.Attributes -split ',')) {
         $attributes += $attribute.Trim()
@@ -99,9 +99,9 @@ If ($null -ne $info) {
         # lnk_target = islnk or isjunction Target of the symlink. Note that relative paths remain relative
         # lnk_source = islnk os isjunction Target of the symlink normalized for the remote filesystem
         hlnk_targets = @()
-        creationtime = (ConvertTo-Timestamp -start_date $epoch_date -end_date $info.CreationTime)
-        lastaccesstime = (ConvertTo-Timestamp -start_date $epoch_date -end_date $info.LastAccessTime)
-        lastwritetime = (ConvertTo-Timestamp -start_date $epoch_date -end_date $info.LastWriteTime)
+        creationtime = (ConvertTo-Timestamp -start_date $epoch_date -end_date $info.CreationTimeUtc)
+        lastaccesstime = (ConvertTo-Timestamp -start_date $epoch_date -end_date $info.LastAccessTimeUtc)
+        lastwritetime = (ConvertTo-Timestamp -start_date $epoch_date -end_date $info.LastWriteTimeUtc)
         # size = a file and directory - calculated below
         path = $info.FullName
         filename = $info.Name


### PR DESCRIPTION
##### SUMMARY
Epoch timestamps should be based on UTC and not the local timezone. While this change is technically a breaking change the format of the value doesn't change so it will still be parsed in the same way. It also aligns the module with the behaviour of `stat` and what most people would expect from a epoch based timestamp. Due to these reasons it's being made as a bugfix.

Fixes https://github.com/ansible-collections/ansible.windows/issues/240

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_stat