### PR TITLE
win_dsc - fix locale problems

### DIFF
--- a/changelogs/fragments/win_dsc-locale.yml
+++ b/changelogs/fragments/win_dsc-locale.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_dsc - Fix import errors when running against host that wasn't installed with the ``en-US`` locale - https://github.com/ansible-collections/ansible.windows/issues/83


### PR DESCRIPTION
##### SUMMARY
The `PSDesiredStateConfiguration` fails to import when the UI culture doesn't match the installed UI culture. This works around this issue as best as possible by temporarily changing the current UI back and also not treat ever error as fatal.

Even if `$ErrorActionPreference = 'Continue'` masks a real fatal error (it shouldn't), the subsequent call to `Get-DscResource` will attempt to re-import it under the existing strict preference causing the same failure as today.

Fixes https://github.com/ansible-collections/ansible.windows/issues/83

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_dsc