### PR TITLE
Fix typo

### DIFF
--- a/docs/ansible.windows.win_regedit_module.rst
+++ b/docs/ansible.windows.win_regedit_module.rst
@@ -289,7 +289,7 @@ Examples
         path: HKLM:\ANSIBLE\Control Panel\Mouse
         name: MouseTrails
         data: 10
-        type: str
+        type: string
         state: present
         hive: C:\Users\Default\NTUSER.dat
 


### PR DESCRIPTION
`str` should be `string`, otherwise this error will occur:

```
value of type must be one of: none, binary, dword, expandstring, multistring, string, qword. Got no match for: str
```

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
