### PR TITLE
Fix typo in the example of windows.win_regedit

### DIFF
--- a/plugins/modules/win_regedit.py
+++ b/plugins/modules/win_regedit.py
@@ -179,7 +179,7 @@ EXAMPLES = r'''
     path: HKLM:\ANSIBLE\Control Panel\Mouse
     name: MouseTrails
     data: 10
-    type: str
+    type: string
     state: present
     hive: C:\Users\Default\NTUSER.dat
 '''


### PR DESCRIPTION
##### SUMMARY
`str` should be `string`, otherwise this error will occur:

`value of type must be one of: none, binary, dword, expandstring, multistring, string, qword. Got no match for: str`

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
win_regedit
