### PR TITLE
win_group - fixed setting of group description in check_mode runs

### DIFF
--- a/changelogs/fragments/260-description-checkmode.yml
+++ b/changelogs/fragments/260-description-checkmode.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - win_group - fixed ``description`` setting for a group that doesn't exist when running in check_mode (https://github.com/ansible-collections/ansible.windows/pull/260).

--- a/plugins/modules/win_group.ps1
+++ b/plugins/modules/win_group.ps1
@@ -32,8 +32,8 @@ try {
 
         If ($null -ne $description) {
             IF (-not $group.description -or $group.description -ne $description) {
-                $group.description = $description
                 If (-not $check_mode) {
+                    $group.description = $description
                     $group.SetInfo()
                 }
                 $result.changed = $true

--- a/tests/integration/targets/win_group/tasks/main.yml
+++ b/tests/integration/targets/win_group/tasks/main.yml
@@ -34,6 +34,7 @@
 
 - name: set a group description on a missing group in check mode
   win_group:
+    name: "{{test_win_group_name}}"
     description: "{{test_win_group_description}}"
   check_mode: true
   register: win_group_checkmode_description
@@ -43,6 +44,7 @@
   assert:
     that:
       - "win_group_checkmode_description is changed"
+      - "win_group_checkmode_description is not failed"
 
 - name: create test group with invalid state parameter
   win_group:

--- a/tests/integration/targets/win_group/tasks/main.yml
+++ b/tests/integration/targets/win_group/tasks/main.yml
@@ -32,6 +32,18 @@
     that:
       - "win_group_create_noname is failed"
 
+- name: set a group description on a missing group in check mode
+  win_group:
+    description: "{{test_win_group_description}}"
+  check_mode: true
+  register: win_group_checkmode_description
+  ignore_errors: true
+
+- name: check that description setting in check_mode passes if group doesn't exist
+  assert:
+    that:
+      - "win_group_checkmode_description is changed"
+
 - name: create test group with invalid state parameter
   win_group:
     name: "{{test_win_group_name}}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When a group does not exist yet, trying to set the description in check_mode fails because the object does not exist yet.
This change moves the description setting out of check_mode.

Fixes #258 

Includes tests for this issue
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_group.ps1

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
