### PR TITLE
Fix for "Failed to validate the user's credentials"

### DIFF
--- a/changelogs/fragments/win_user-domain.yml
+++ b/changelogs/fragments/win_user-domain.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_user - Set validate user logic to always check local database

--- a/plugins/modules/win_user.ps1
+++ b/plugins/modules/win_user.ps1
@@ -183,7 +183,7 @@ Function Test-LocalCredential {
     )
 
     try {
-        $handle = [Ansible.AccessToken.TokenUtil]::LogonUser($Username, $null, $Password, "Network", "Default")
+        $handle = [Ansible.AccessToken.TokenUtil]::LogonUser($Username, ".", $Password, "Network", "Default")
         $handle.Dispose()
         $isValid = $true
     } catch [Ansible.AccessToken.Win32Exception] {


### PR DESCRIPTION
I get an error in the win_user module when creating a local user on servers in AD: "Failed to validate the user's credentials: Failed to logon username (Incorrect function, Win32ErrorCode 1 - 0x00000001)". This commit fixes this problem.

##### SUMMARY

I am getting an error in the win_user module when creating a local user on servers in AD: "Failed to validate user credentials: Could not login with username (invalid function, Win32ErrorCode 1 - 0x00000001)"

This error is sent by the [Ansible.AccessToken.TokenUtil] :: LogonUser function. This function calls LogonUserW from the Windows API. Description of this function is here https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-logonuserw
And in this description for the lpszDomain parameter it says:

lpszDomain

A pointer to a null-terminated string that specifies the name of the domain or server whose account database contains the lpszUsername account. If this parameter is NULL, the user name must be specified in UPN format. If this parameter is ".", the function validates the account by using only the local account database.

In the current version, the module sends $null in the given parameter. LogonUserW then expects a UPN in lpszUsername, that is, username@domain and not username. I suggest changing this to "." and get the behavior "function checks account using only local accounts database" where only username without @domain can be checked.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_user

##### ADDITIONAL INFORMATION
