### PR TITLE
win_reboot - fix last_error raising

### DIFF
--- a/changelogs/fragments/reboot_error_outside_block.yml
+++ b/changelogs/fragments/reboot_error_outside_block.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_reboot - Fix local variable referenced before assignment issue - https://github.com/ansible-collections/ansible.windows/issues/276

--- a/plugins/plugin_utils/_reboot.py
+++ b/plugins/plugin_utils/_reboot.py
@@ -295,6 +295,7 @@ def _do_until_success_or_condition(task_action, connection, host_context, action
     fail_count = 0
     max_fail_sleep = 12
     reset_required = False
+    last_error = None
 
     while fail_count == 0 or condition(fail_count):
         try:
@@ -310,6 +311,8 @@ def _do_until_success_or_condition(task_action, connection, host_context, action
                 return res
 
         except Exception as e:
+            last_error = e
+
             if not isinstance(e, _TestCommandFailure):
                 # The error may be due to a connection problem, just reset the connection just in case
                 reset_required = True
@@ -337,7 +340,8 @@ def _do_until_success_or_condition(task_action, connection, host_context, action
             fail_count += 1
             time.sleep(fail_sleep)
 
-    raise e
+    if last_error:
+        raise last_error
 
 
 def _execute_command(task_action, connection, command):  # type: (str, ConnectionBase, str) -> Tuple[int, str, str]


### PR DESCRIPTION
##### SUMMARY
Small fix for last_error raising in reboot util (python 3 compatibility)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
_reboot.py

##### ADDITIONAL INFORMATION
Original variable `e` is deleted outside the except block
https://stackoverflow.com/questions/24271752/except-clause-deletes-local-variable

Here's a simple example that reproduces the problem:
```python
def main():
    try:
        raise Exception("msg")
    except Exception as e:
        print(e)

    raise e


main()
```
