### PR TITLE
Fix error when using win_dns_client with an IPv6 dns server

### DIFF
--- a/changelogs/fragments/283-win_dns_client_IPv6_DNS.yml
+++ b/changelogs/fragments/283-win_dns_client_IPv6_DNS.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_dns_client - Fix method used to read IPv6 DNS settings given by DHCP - https://github.com/ansible-collections/ansible.windows/issues/283

--- a/plugins/modules/win_dns_client.ps1
+++ b/plugins/modules/win_dns_client.ps1
@@ -202,15 +202,15 @@ Function Get-RegistryNameServerInfo {
                     $famInfo.EffectiveNameServers = $famInfo.DhcpAssignedNameServers = 
                     # IPv6 are stored as 16 bytes separated REG_BINARY properties in the registry
                     @(if ($ns -is [System.Object[]]) {
-                            for ($i = 0; $i -lt $ns.Length; $i += $items.BinaryLength) {
-                                [byte[]]$ipBytes = $ns[$i..($i + $items.BinaryLength - 1)]
-                (New-Object -TypeName System.Net.IPAddress -ArgumentList @(, $ipBytes)).IPAddressToString
-                            }
+                        for ($i = 0; $i -lt $ns.Length; $i += $items.BinaryLength) {
+                            [byte[]]$ipBytes = $ns[$i..($i + $items.BinaryLength - 1)]
+                            (New-Object -TypeName System.Net.IPAddress -ArgumentList @(, $ipBytes)).IPAddressToString
                         }
-                        # IPv4 are stored as space delimited string properties in the registry
-                        else {
-                            $ns.Split(' ')
-                        })
+                    # IPv4 are stored as space delimited string properties in the registry
+                    } else {
+                        $ns.Split(' ')
+                    })
+
                 }
 
                 if (($ns = Get-OptionalProperty -InputObject $iprop -Name $items.StaticNameServer)) {

--- a/plugins/modules/win_dns_client.ps1
+++ b/plugins/modules/win_dns_client.ps1
@@ -196,18 +196,20 @@ Function Get-RegistryNameServerInfo {
                     NameServerBadFormat = $false
                 }
 
+            if (($ns = Get-OptionalProperty -InputObject $iprop -Name $items.DhcpNameServer)) {
 		# IPv6 are stored as 16 bytes REG_BINARY values. If multiple IPv6 are configured
 		# those ips are contiguous
 		$famInfo.EffectiveNameServers = $famInfo.DhcpAssignedNameServers =
 		@(if ($ns -is [System.Object[]]) {
-		for ($i = 0; $i -lt $ns.Length; $i += $items.BinaryLength) {
-		    [byte[]]$ipBytes = $ns[$i..($i + $items.BinaryLength - 1)]
-		    (New-Object -TypeName System.Net.IPAddress -ArgumentList @(, $ipBytes)).IPAddressToString
-		}
+			for ($i = 0; $i -lt $ns.Length; $i += $items.BinaryLength) {
+				[byte[]]$ipBytes = $ns[$i..($i + $items.BinaryLength - 1)]
+				(New-Object -TypeName System.Net.IPAddress -ArgumentList @(, $ipBytes)).IPAddressToString
+			}
 		# IPv4 are stored as space delimited string properties in the registry
 		} else {
 		    $ns.Split(' ')
 		})
+            }    
 
                 if (($ns = Get-OptionalProperty -InputObject $iprop -Name $items.StaticNameServer)) {
                     $famInfo.EffectiveNameServers = $famInfo.StaticNameServers = $ns -split '[,;\ ]'

--- a/plugins/modules/win_dns_client.ps1
+++ b/plugins/modules/win_dns_client.ps1
@@ -204,12 +204,12 @@ Function Get-RegistryNameServerInfo {
                         for ($i = 0; $i -lt $ns.Length; $i += $items.BinaryLength) {
                             [byte[]]$ipBytes = $ns[$i..($i + $items.BinaryLength - 1)]
                             (New-Object -TypeName System.Net.IPAddress -ArgumentList @(, $ipBytes)).IPAddressToString
-                        }  
+                        }
                     # IPv4 are stored as space delimited string properties in the registry
                     } else {
                         $ns.Split(' ')
                     })
-                }    
+                }
 
                 if (($ns = Get-OptionalProperty -InputObject $iprop -Name $items.StaticNameServer)) {
                     $famInfo.EffectiveNameServers = $famInfo.StaticNameServers = $ns -split '[,;\ ]'

--- a/plugins/modules/win_dns_client.ps1
+++ b/plugins/modules/win_dns_client.ps1
@@ -199,8 +199,9 @@ Function Get-RegistryNameServerInfo {
                 }
 
                 if (($ns = Get-OptionalProperty -InputObject $iprop -Name $items.DhcpNameServer)) {
+                    # IPv6 are stored as 16 bytes REG_BINARY values. If multiple IPv6 are configured
+                    # those ips are contiguous
                     $famInfo.EffectiveNameServers = $famInfo.DhcpAssignedNameServers = 
-                    # IPv6 are stored as 16 bytes separated REG_BINARY properties in the registry
                     @(if ($ns -is [System.Object[]]) {
                         for ($i = 0; $i -lt $ns.Length; $i += $items.BinaryLength) {
                             [byte[]]$ipBytes = $ns[$i..($i + $items.BinaryLength - 1)]

--- a/plugins/modules/win_dns_client.ps1
+++ b/plugins/modules/win_dns_client.ps1
@@ -154,60 +154,75 @@ Function Get-NetAdapterInfo {
 }
 
 Function Get-RegistryNameServerInfo {
-    [CmdletBinding()]
-    Param (
-        [Parameter(ValueFromPipeline=$true,ValueFromPipelineByPropertyName=$true,Mandatory=$true)]
-        [System.Guid]
-        $InterfaceGuid
-    )
+  [CmdletBinding()]
+  Param (
+    [Parameter(ValueFromPipeline = $true, ValueFromPipelineByPropertyName = $true, Mandatory = $true)]
+    [System.Guid]
+    $InterfaceGuid
+  )
 
-    Begin {
-        $protoItems = @{
-            [System.Net.Sockets.AddressFamily]::InterNetwork = @{
-                Interface = 'HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\{{{0}}}'
-                StaticNameServer = 'NameServer'
-                DhcpNameServer = 'DhcpNameServer'
-                EnableDhcp = 'EnableDHCP'
-            }
+  Begin {
+    $protoItems = @{
+            
+      [System.Net.Sockets.AddressFamily]::InterNetwork   = @{
+        Interface        = 'HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\{{{0}}}'
+        StaticNameServer = 'NameServer'
+        DhcpNameServer   = 'DhcpNameServer'
+        EnableDhcp       = 'EnableDHCP'
+        BinaryLength     = 4
+      }
 
-            [System.Net.Sockets.AddressFamily]::InterNetworkV6 = @{
-                Interface = 'HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters\Interfaces\{{{0}}}'
-                StaticNameServer = 'NameServer'
-                DhcpNameServer = 'Dhcpv6DNSServers'
-                EnableDhcp = 'EnableDHCP'
-            }
-        }
+      [System.Net.Sockets.AddressFamily]::InterNetworkV6 = @{
+        Interface        = 'HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters\Interfaces\{{{0}}}'
+        StaticNameServer = 'NameServer'
+        DhcpNameServer   = 'Dhcpv6DNSServers'
+        EnableDhcp       = 'EnableDHCP'
+        BinaryLength     = 16
+      }
     }
+  }
 
-    Process {
-        foreach ($addrFamily in $AddressFamilies.Keys) {
-            $items = $protoItems[$addrFamily]
-            $regPath = $items.Interface -f $InterfaceGuid
+  Process {
+    foreach ($addrFamily in $AddressFamilies.Keys) {
+      $items = $protoItems[$addrFamily]
+      $regPath = $items.Interface -f $InterfaceGuid
 
-            if (($iface = Get-Item -LiteralPath $regPath -ErrorAction Ignore)) {
-                $iprop = $iface | Get-ItemProperty
-                $famInfo = @{
-                    AddressFamily = $addrFamily
-                    UsingDhcp = Get-OptionalProperty -InputObject $iprop -Name $items.EnableDhcp -As bool
-                    EffectiveNameServers = @()
-                    DhcpAssignedNameServers = @()
-                    NameServerBadFormat = $false
-                }
+      if (($iface = Get-Item -LiteralPath $regPath -ErrorAction Ignore)) {
 
-                if (($ns = Get-OptionalProperty -InputObject $iprop -Name $items.DhcpNameServer)) {
-                    $famInfo.EffectiveNameServers = $famInfo.DhcpAssignedNameServers = $ns.Split(' ')
-                }
-
-                if (($ns = Get-OptionalProperty -InputObject $iprop -Name $items.StaticNameServer)) {
-                    $famInfo.EffectiveNameServers = $famInfo.StaticNameServers = $ns -split '[,;\ ]'
-                    $famInfo.UsingDhcp = $false
-                    $famInfo.NameServerBadFormat = $ns -match '[;\ ]'
-                }
-
-                $famInfo
-            }
+        $iprop = $iface | Get-ItemProperty
+        $famInfo = @{
+          AddressFamily           = $addrFamily
+          UsingDhcp               = Get-OptionalProperty -InputObject $iprop -Name $items.EnableDhcp -As bool
+          EffectiveNameServers    = @()
+          DhcpAssignedNameServers = @()
+          NameServerBadFormat     = $false
         }
+
+        if (($ns = Get-OptionalProperty -InputObject $iprop -Name $items.DhcpNameServer)) {
+          $famInfo.EffectiveNameServers = $famInfo.DhcpAssignedNameServers = 
+          # IPv6 are stored as 16 bytes separated REG_BINARY properties in the registry
+          @(if ($ns -is [System.Object[]]) {
+              for ($i = 0; $i -lt $ns.Length; $i += $items.BinaryLength) {
+                [byte[]]$ipBytes = $ns[$i..($i + $items.BinaryLength - 1)]
+                (New-Object -TypeName System.Net.IPAddress -ArgumentList @(, $ipBytes)).IPAddressToString
+              }
+            }
+            # IPv4 are stored as space delimited string properties in the registry
+            else {
+              $ns.Split(' ')
+            })
+        }
+
+        if (($ns = Get-OptionalProperty -InputObject $iprop -Name $items.StaticNameServer)) {
+          $famInfo.EffectiveNameServers = $famInfo.StaticNameServers = $ns -split '[,;\ ]'
+          $famInfo.UsingDhcp = $false
+          $famInfo.NameServerBadFormat = $ns -match '[;\ ]'
+        }
+
+        $famInfo
+      }
     }
+  }
 }
 
 # minimal impl of Set-DnsClientServerAddress for 2008/2008R2

--- a/plugins/modules/win_dns_client.ps1
+++ b/plugins/modules/win_dns_client.ps1
@@ -196,20 +196,20 @@ Function Get-RegistryNameServerInfo {
                     NameServerBadFormat = $false
                 }
 
-            if (($ns = Get-OptionalProperty -InputObject $iprop -Name $items.DhcpNameServer)) {
-		# IPv6 are stored as 16 bytes REG_BINARY values. If multiple IPv6 are configured
-		# those ips are contiguous
-		$famInfo.EffectiveNameServers = $famInfo.DhcpAssignedNameServers =
-		@(if ($ns -is [System.Object[]]) {
-			for ($i = 0; $i -lt $ns.Length; $i += $items.BinaryLength) {
-				[byte[]]$ipBytes = $ns[$i..($i + $items.BinaryLength - 1)]
-				(New-Object -TypeName System.Net.IPAddress -ArgumentList @(, $ipBytes)).IPAddressToString
-			}
-		# IPv4 are stored as space delimited string properties in the registry
-		} else {
-		    $ns.Split(' ')
-		})
-            }    
+                if (($ns = Get-OptionalProperty -InputObject $iprop -Name $items.DhcpNameServer)) {
+                    # IPv6 are stored as 16 bytes REG_BINARY values. If multiple IPv6 are configured
+                    # those ips are contiguous
+                    $famInfo.EffectiveNameServers = $famInfo.DhcpAssignedNameServers =
+                    @(if ($ns -is [System.Object[]]) {
+                        for ($i = 0; $i -lt $ns.Length; $i += $items.BinaryLength) {
+                            [byte[]]$ipBytes = $ns[$i..($i + $items.BinaryLength - 1)]
+                            (New-Object -TypeName System.Net.IPAddress -ArgumentList @(, $ipBytes)).IPAddressToString
+                        }  
+                    # IPv4 are stored as space delimited string properties in the registry
+                    } else {
+                        $ns.Split(' ')
+                    })
+                }    
 
                 if (($ns = Get-OptionalProperty -InputObject $iprop -Name $items.StaticNameServer)) {
                     $famInfo.EffectiveNameServers = $famInfo.StaticNameServers = $ns -split '[,;\ ]'


### PR DESCRIPTION
##### SUMMARY
Fixes #283 
Using win_dns_client failed when an IPv6 interface dns server was configured.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
Bugfix Pull Request


##### COMPONENT NAME
win_dns_client.ps1 module used by win_dns_client.
