### PR TITLE
Fix sanity checks

### DIFF
--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,6 +1,4 @@
 plugins/modules/setup.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
 plugins/modules/win_powershell.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
-tests/integration/targets/win_dsc/files/xTestDsc/1.0.0/DSCResources/ANSIBLE_xTestResource/ANSIBLE_xTestResource.psm1 pslint:PSDSCUseIdenticalMandatoryParametersForDSC # Rule is broken in older PSSA versions
-tests/integration/targets/win_dsc/files/xTestDsc/1.0.1/DSCResources/ANSIBLE_xTestResource/ANSIBLE_xTestResource.psm1 pslint:PSDSCUseIdenticalMandatoryParametersForDSC # Rule is broken in older PSSA versions
 tests/utils/shippable/check_matrix.py replace-urlopen
 tests/utils/shippable/timing.py shebang

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -47,7 +47,7 @@ function retry
         echo "@* -> ${result}"
     done
     echo "Command '@*' failed 3 times!"
-    exit -1
+    exit 1
 }
 
 command -v pip


### PR DESCRIPTION
##### SUMMARY
Latest `ansible-test` has bumped the PSSA module version which no longer needs the rule ignores. Also fixes a new sanity check affecting the CI script.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible-test
