### PR TITLE
win_updates - handle illegal paths in pipes

### DIFF
--- a/changelogs/fragments/291-win_updates-illegal-pipe-path.yml
+++ b/changelogs/fragments/291-win_updates-illegal-pipe-path.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- >-
+  win_updates - Ignore named pipes with illegal filenames when checking for the task named pipe during bootstrapping
+  - https://github.com/ansible-collections/ansible.windows/issues/291
+- win_updates - Improve error handling when starting background update task


### PR DESCRIPTION
##### SUMMARY
Seems like Windows can have named pipes that .NET (on some versions) consider to be invalid. This breaks the `EnumerateFiles` enumeration when called normally so instead the code will manually iterate this output and handles any exceptions that may pop up.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/291

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_updates