### PR TITLE
win_user - fix state query msg value

### DIFF
--- a/changelogs/fragments/290-win_user-state-query.yml
+++ b/changelogs/fragments/290-win_user-state-query.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- >-
+  win_user - Fix ``msg`` return value when setting ``state: query``

--- a/plugins/modules/win_user.ps1
+++ b/plugins/modules/win_user.ps1
@@ -424,7 +424,7 @@ if ($state -eq 'present') {
     $module.Diff.after = ""
 
 } else {
-    $module.Result.msg = "User '$name' was not found"
+    $module.Result.msg = "Querying user '$name'"
     $module.Result.state = if ($user) { 'present' } else { 'absent' }
     $module.Diff.after = $module.Diff.before
 }

--- a/tests/integration/targets/win_user/tasks/tests.yml
+++ b/tests/integration/targets/win_user/tasks/tests.yml
@@ -94,6 +94,7 @@
   assert:
     that:
       - "win_user_query_result is not changed"
+      - win_user_query_result.msg == "Querying user '" + test_win_user_name + "'"
       - "win_user_query_result.state == 'present'"
       - "win_user_query_result.name == '{{ test_win_user_name }}'"
       - "win_user_query_result.fullname == 'Test user'"


### PR DESCRIPTION
##### SUMMARY
The `msg` return value when using `state: query` reports the user was missing when that may not be the actual case.

Fixes https://github.com/ansible-collections/ansible.windows/issues/290

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_user