### PR TITLE
Fix issues when copying folder with remote_dest

### DIFF
--- a/plugins/modules/win_copy.ps1
+++ b/plugins/modules/win_copy.ps1
@@ -330,9 +330,9 @@ if ($copy_mode -eq "query") {
             }
         } else {
             # copying the folder and it's contents to dest
-            $dest = Join-Path -Path $dest -ChildPath (Get-Item -LiteralPath $src -Force).Name
-            $result.dest = $dest
-            $diff = Copy-Folder -source $src -dest $dest
+            $remote_dest = Join-Path -Path $dest -ChildPath (Get-Item -LiteralPath $src -Force).Name
+            $result.dest = $remote_dest
+            $diff = Copy-Folder -source $src -dest $remote_dest
         }
     } else {
         # we are just copying a single file to dest


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
In case of remote_dest, handle variables for folder copy the same way as file copy, so that Get-FileSize is executed at the proper level.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_copy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Set up a playbook that will copy a folder into C:\ with remote_src enabled
```yaml
- name: Copy Tools Folder
  win_copy: 
    src: \\fileserver\sharedfolder\Tools
    dest: C:\
    remote_src: yes
```
The error looks as below. It tries to go into some symbolic links under `C:\Document and Settings\<some user>\AppData\Local`: `ApplicationData` links back into `AppData\Local` and leads into an infinite loop.

The issue is that the name of the folder that is being copied is not appended in $remote_dest so `Get-FileSize` is run on `C:\` instead of `C:\subfolder`.

We could confirm that this bug is absent when running a version of ansible.windows before the PR #5 was merged.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
 TASK [copy_task : Copy Tools Folder] ************************
 task path: /tmp/workspace/ansible/roles/tasks/some_tasks.yml:69
 Tuesday 26 October 2021  12:40:33 +0000 (0:01:32.132)       0:18:58.912 ******* 
 Tuesday 26 October 2021  12:40:33 +0000 (0:01:32.132)       0:18:58.911 ******* 
 redirecting (type: action) ansible.builtin.win_copy to ansible.windows.win_copy
 redirecting (type: action) ansible.builtin.win_copy to ansible.windows.win_copy
 Using module file /usr/local/lib/python3.8/dist-packages/ansible_collections/ansible/windows/plugins/modules/win_copy.ps1
 Pipelining is enabled.
 <target-server> ESTABLISH WINRM CONNECTION FOR USER: USER on PORT 5985 TO target-server
 EXEC (via pipeline wrapper)
 The full traceback is:
 Could not find a part of the path 'C:\Documents and Settings\.NET v2.0\AppData\Local\Application Data\Application Data\Application Data\Application Data\Application Data\Application Data\Application Data\Application Data\Application Data\Application Data\Application Data\Application Data\Application Data'.
 At line:135 char:18
 + ...    $size = (Get-ChildItem -Literalpath $file.FullName -Recurse -Force ...
 +                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     + CategoryInfo          : ReadError: (C:\Documents an...pplication Data:String) [Get-ChildItem], DirectoryNotFoundException
     + FullyQualifiedErrorId : DirIOError,Microsoft.PowerShell.Commands.GetChildItemCommand
 
 ScriptStackTrace:
 at Get-FileSize, <No file>: line 135
 at <ScriptBlock>, <No file>: line 367
 
 System.IO.DirectoryNotFoundException: Could not find a part of the path 'C:\Documents and Settings\.NET v2.0\AppData\Local\Application Data\Application Data\Application Data\Application Data\Application Data\Application Data\Application Data\Application Data\Application Data\Application Data\Application Data\Application Data\Application Data'.
    at System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
    at System.IO.FileSystemEnumerableIterator`1.CommonInit()
    at System.IO.FileSystemEnumerableIterator`1..ctor(String path, String originalUserPath, String searchPattern, SearchOption searchOption, SearchResultHandler`1 resultHandler, Boolean checkHost)
    at System.IO.DirectoryInfo.EnumerateDirectories()
    at Microsoft.PowerShell.Commands.FileSystemProvider.Dir(DirectoryInfo directory, Boolean recurse, UInt32 depth, Boolean nameOnly, ReturnContainers returnContainers)
 fatal: [target-server]: FAILED! => {
     "changed": false,
     "dest": "C:\\",
     "msg": "Unhandled exception while executing module: Could not find a part of the path 'C:\\Documents and Settings\\.NET v2.0\\AppData\\Local\\Application Data\\Application Data\\Application Data\\Application Data\\Application Data\\Application Data\\Application Data\\Application Data\\Application Data\\Application Data\\Application Data\\Application Data\\Application Data'.",
     "src": "\\\\fileserver\\sharedfolder\\Tools"
 }
```
