### PR TITLE
Fix LIB env var conflicts

### DIFF
--- a/changelogs/fragments/add-type-env.yml
+++ b/changelogs/fragments/add-type-env.yml
@@ -1,0 +1,6 @@
+bugfixes:
+- win_file - Fix conflicts with existing ``LIB`` environment variable
+- win_find - Fix conflicts with existing ``LIB`` environment variable
+- win_stat - Fix conflicts with existing ``LIB`` environment variable
+- win_updates - Fix conflicts with existing ``LIB`` environment variable
+- win_whoami - Fix conflicts with existing ``LIB`` environment variable

--- a/plugins/modules/win_file.ps1
+++ b/plugins/modules/win_file.ps1
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
 
 $ErrorActionPreference = "Stop"
 
@@ -26,7 +27,7 @@ $result = @{
 }
 
 # Used to delete symlinks as powershell cannot delete broken symlinks
-$symlink_util = @"
+Add-CSharpType -TempPath $_remote_tmp -References @'
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
@@ -50,11 +51,7 @@ namespace Ansible.Command {
         }
     }
 }
-"@
-$original_tmp = $env:TMP
-$env:TMP = $_remote_tmp
-Add-Type -TypeDefinition $symlink_util
-$env:TMP = $original_tmp
+'@
 
 # Used to delete directories and files with logic on handling symbolic links
 function Remove-File($file, $checkmode) {

--- a/plugins/modules/win_find.ps1
+++ b/plugins/modules/win_find.ps1
@@ -43,7 +43,11 @@ $module.Result.examined = 0
 $module.Result.files = @()
 $module.Result.matched = 0
 
+# https://github.com/ansible-collections/ansible.windows/issues/297
+$oldLib = $env:LIB
+$env:LIB = $null
 Load-LinkUtils
+$env:LIB = $oldLib
 
 Function Assert-Age {
     Param (

--- a/plugins/modules/win_stat.ps1
+++ b/plugins/modules/win_stat.ps1
@@ -73,7 +73,12 @@ $follow = $module.Params.follow
 
 $module.Result.stat = @{ exists=$false }
 
+# https://github.com/ansible-collections/ansible.windows/issues/297
+$oldLib = $env:LIB
+$env:LIB = $null
 Load-LinkUtils
+$env:LIB = $oldLib
+
 $info, $link_info = Get-FileInfo -Path $path -Follow:$follow
 If ($null -ne $info) {
     $epoch_date = (Get-Date -Year 1970 -Month 1 -Day 1).Date

--- a/tests/integration/targets/win_file/tasks/main.yml
+++ b/tests/integration/targets/win_file/tasks/main.yml
@@ -570,17 +570,17 @@
 
 # Need to use shell to create the file as win_file doesn't support setting attributes
 - name: create hidden file
-  win_shell: $file = New-Item -Path "{{ win_output_dir }}\hidden.txt" -ItemType File; $file.Attributes = "Hidden"
+  win_shell: $file = New-Item -Path "{{ remote_tmp_dir }}\hidden.txt" -ItemType File; $file.Attributes = "Hidden"
 
 - name: delete hidden file
   win_file:
-    path: '{{ win_output_dir }}\hidden.txt'
+    path: '{{ remote_tmp_dir }}\hidden.txt'
     state: absent
   register: delete_hidden
 
 - name: get result of delete hidden file
   win_stat:
-    path: '{{ win_output_dir }}\hidden.txt'
+    path: '{{ remote_tmp_dir }}\hidden.txt'
   register: delete_hidden_actual
 
 - name: assert delete hidden file

--- a/tests/integration/targets/win_stat/defaults/main.yml
+++ b/tests/integration/targets/win_stat/defaults/main.yml
@@ -1,2 +1,3 @@
-win_stat_dir: '{{win_output_dir}}\win_stat'
+win_stat_dir: '{{ remote_tmp_dir }}\win_stat'
+win_stat_underprivileged_dir: C:\ansible\win_stat
 win_stat_user: test-stat

--- a/tests/integration/targets/win_stat/meta/main.yml
+++ b/tests/integration/targets/win_stat/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- setup_remote_tmp_dir

--- a/tests/integration/targets/win_stat/tasks/main.yml
+++ b/tests/integration/targets/win_stat/tasks/main.yml
@@ -5,8 +5,11 @@
 
 - name: remove win_stat testing directories for clean slate
   win_file:
-    path: '{{win_stat_dir}}'
+    path: '{{ item }}'
     state: absent
+  loop:
+  - '{{ win_stat_dir }}'
+  - '{{ win_stat_underprivileged_dir }}'
 
 # while most of the setup can be done with modules, it is quicker to do them
 # all in bulk than with with_items to save each round trip over WinRM
@@ -56,7 +59,9 @@
     cmd.exe /c mklink /D "{{win_stat_dir}}\nested\nested\link-rel" "..\..\link-dest"
     cmd.exe /c mklink /D "{{win_stat_dir}}\outer-link" "{{win_stat_dir}}\nested\nested\link-rel"
 
-    $date = Get-Date -Year 2016 -Month 11 -Day 1 -Hour 7 -Minute 10 -Second 5 -Millisecond 0
+    $date = New-Object -TypeName System.DateTime -ArgumentList @(
+      2016, 11, 1, 7, 10, 5, 0, 'Utc'
+    )
     Get-ChildItem -Path "{{win_stat_dir}}" -Recurse | ForEach-Object {
         $_.CreationTime = $date
         $_.LastAccessTime = $date
@@ -81,6 +86,19 @@
 
     # weird issue, need to access the file in anyway to get the correct date stats
     Test-Path {{win_stat_dir}}\nested\hard-link.ps1
+
+    # Set up underprivileged directory for become test
+    New-Item -Path "{{ win_stat_underprivileged_dir }}" -ItemType Directory
+    New-Item -Path "{{ win_stat_underprivileged_dir }}\link-dest" -ItemType Directory
+    New-Item -Path "{{ win_stat_underprivileged_dir }}\file.ps1" -ItemType File
+    [System.IO.File]::WriteAllText("{{ win_stat_underprivileged_dir }}\file.ps1", $normal_content)
+    cmd.exe /c mklink /D "{{ win_stat_underprivileged_dir }}\link" "{{ win_stat_underprivileged_dir }}\link-dest"
+
+    Get-ChildItem -Path "{{ win_stat_underprivileged_dir }}" -Recurse | ForEach-Object {
+        $_.CreationTime = $date
+        $_.LastAccessTime = $date
+        $_.LastWriteTime = $date
+    }
 
 # mklink.exe and win_file cannot do this right now so we need a custom module
 - name: create file symlink
@@ -113,3 +131,8 @@
     args:
       executable: cmd.exe
     when: win_stat_user in profile_dir_out.stdout_lines[0]
+
+  - name: remove temp global file
+    win_file:
+      path: '{{ win_stat_underprivileged_dir }}'
+      state: absent

--- a/tests/integration/targets/win_stat/tasks/tests.yml
+++ b/tests/integration/targets/win_stat/tasks/tests.yml
@@ -517,7 +517,7 @@
   register: win_stat_missing
 
 - name: check win_stat missing result
-  assert: 
+  assert:
     that:
       - not win_stat_missing.stat.exists
       - win_stat_missing is not failed
@@ -585,7 +585,7 @@
 - name: test stat with non admin user on a normal file
   vars: *become_vars
   win_stat:
-    path: '{{win_stat_dir}}\nested\file.ps1'
+    path: '{{ win_stat_underprivileged_dir }}\file.ps1'
   register: user_file
 
 - name: asert test stat with non admin user on a normal file
@@ -610,13 +610,13 @@
     - user_file.stat.lastwritetime == 1477984205
     - user_file.stat.nlink == 1
     - user_file.stat.owner == 'BUILTIN\\Administrators'
-    - user_file.stat.path == win_stat_dir + '\\nested\\file.ps1'
+    - user_file.stat.path == win_stat_underprivileged_dir + '\\file.ps1'
     - user_file.stat.size == 3
 
 - name: test stat on a symbolic link as normal user
   vars: *become_vars
   win_stat:
-    path: '{{win_stat_dir}}\link'
+    path: '{{ win_stat_underprivileged_dir }}\link'
   register: user_symlink
 
 - name: assert test stat on a symbolic link as normal user
@@ -637,9 +637,9 @@
     - user_symlink.stat.isshared == False
     - user_symlink.stat.lastaccesstime is defined
     - user_symlink.stat.lastwritetime is defined
-    - user_symlink.stat.lnk_source == win_stat_dir + '\\link-dest'
-    - user_symlink.stat.lnk_target == win_stat_dir + '\\link-dest'
+    - user_symlink.stat.lnk_source == win_stat_underprivileged_dir + '\\link-dest'
+    - user_symlink.stat.lnk_target == win_stat_underprivileged_dir + '\\link-dest'
     - user_symlink.stat.nlink == 1
     - user_symlink.stat.owner == 'BUILTIN\\Administrators'
-    - user_symlink.stat.path == win_stat_dir + '\\link'
+    - user_symlink.stat.path == win_stat_underprivileged_dir + '\\link'
     - user_symlink.stat.checksum is not defined


### PR DESCRIPTION
##### SUMMARY
Calling `Add-Type` with the env var `LIB` set to an invalid PATH breaks the compilation and thus fails the module. This PR changes modules to use `Add-CSharpType` which fixed this problem https://github.com/ansible/ansible/pull/75698. The `win_find` and `win_stat` modules are a bit special because they still call a builtin module_util so they manually unset the env var until the code in Ansible itself has been fixed.

Fixes https://github.com/ansible-collections/ansible.windows/issues/297

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_file
win_find
win_stat
win_updates
win_whoami