### PR TITLE
Change output time format from 12H to 24H.

### DIFF
--- a/changelogs/fragments/win_command-shell-time.yml
+++ b/changelogs/fragments/win_command-shell-time.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- win_command - Use the 24 hour format for the hours of ``start`` and ``end`` - https://github.com/ansible-collections/ansible.windows/issues/303
+- win_shell - Use the 24 hour format for the hours of ``start`` and ``end`` - https://github.com/ansible-collections/ansible.windows/issues/303

--- a/plugins/modules/win_command.ps1
+++ b/plugins/modules/win_command.ps1
@@ -67,8 +67,8 @@ $result.stderr = $command_result.stderr
 $result.rc = $command_result.rc
 
 $end_datetime = [DateTime]::UtcNow
-$result.start = $start_datetime.ToString("yyyy-MM-dd hh:mm:ss.ffffff")
-$result.end = $end_datetime.ToString("yyyy-MM-dd hh:mm:ss.ffffff")
+$result.start = $start_datetime.ToString("yyyy-MM-dd HH:mm:ss.ffffff")
+$result.end = $end_datetime.ToString("yyyy-MM-dd HH:mm:ss.ffffff")
 $result.delta = $($end_datetime - $start_datetime).ToString("h\:mm\:ss\.ffffff")
 
 If ($result.rc -ne 0) {

--- a/plugins/modules/win_shell.ps1
+++ b/plugins/modules/win_shell.ps1
@@ -127,8 +127,8 @@ $result.stderr = Format-Stderr $command_result.stderr
 $result.rc = $command_result.rc
 
 $end_datetime = [DateTime]::UtcNow
-$result.start = $start_datetime.ToString("yyyy-MM-dd hh:mm:ss.ffffff")
-$result.end = $end_datetime.ToString("yyyy-MM-dd hh:mm:ss.ffffff")
+$result.start = $start_datetime.ToString("yyyy-MM-dd HH:mm:ss.ffffff")
+$result.end = $end_datetime.ToString("yyyy-MM-dd HH:mm:ss.ffffff")
 $result.delta = $($end_datetime - $start_datetime).ToString("h\:mm\:ss\.ffffff")
 
 If ($result.rc -ne 0) {


### PR DESCRIPTION
Fix of issue https://github.com/ansible-collections/ansible.windows/issues/303

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changed output time format in modules win_command and win_shell from 12H to 24H

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #303
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_command
win_shell

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
