### PR TITLE
win_updates - fix incorrect return value

### DIFF
--- a/changelogs/fragments/win_updates-return.yml
+++ b/changelogs/fragments/win_updates-return.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- >-
+  win_updates - Fix return value for ``updates`` and ``filtered_updates`` to match original stucture -
+  https://github.com/ansible-collections/ansible.windows/issues/307

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -777,11 +777,11 @@ class ActionModule(ActionBase):
             result['found_update_count'] = 0
             result['failed_update_count'] = 0
             result['installed_update_count'] = 0
-            result['updates'] = []
-            result['filtered_updates'] = []
+            result['updates'] = {}
+            result['filtered_updates'] = {}
             for update_id in self._selected_updates:
                 update_info = self._get_update_info(update_id)
-                result['updates'].append(update_info)
+                result['updates'][update_id] = update_info
                 result['found_update_count'] += 1
 
                 if 'failure_hresult_code' in update_info:
@@ -804,7 +804,7 @@ class ActionModule(ActionBase):
 
                 update_info['filtered_reasons'] = reasons
 
-                result['filtered_updates'].append(update_info)
+                result['filtered_updates'][update_id] = update_info
 
         if self._invocation and 'invocation' not in result:
             result['invocation'] = self._invocation

--- a/plugins/modules/win_updates.ps1
+++ b/plugins/modules/win_updates.ps1
@@ -1563,8 +1563,8 @@ if ($invokeSplat.Wait) {
     $module.Result.found_update_count = 0
     $module.Result.failed_update_count = 0
     $module.Result.installed_update_count = 0
-    $module.Result.updates = [System.Collections.Generic.List[Hashtable]]@()
-    $module.Result.filtered_updates = [System.Collections.Generic.List[Hashtable]]@()
+    $module.Result.updates = @{}
+    $module.Result.filtered_updates = @{}
 
     $updates = @{}
     Get-Content -LiteralPath $outputPath | ForEach-Object -Process {
@@ -1643,7 +1643,7 @@ if ($invokeSplat.Wait) {
         $info = $updateKvp.Value
 
         if ($info.Contains('filtered_reasons')) {
-            $module.Result.filtered_updates.Add($info)
+            $module.Result.filtered_updates[$info.id] = $info
             continue
         }
 
@@ -1654,7 +1654,7 @@ if ($invokeSplat.Wait) {
         elseif ($info.installed) {
             $module.Result.installed_update_count += 1
         }
-        $module.Result.updates.Add($info)
+        $module.Result.updates[$info.id] = $info
     }
 }
 else {

--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -204,9 +204,11 @@ reboot_required:
     sample: true
 
 updates:
-    description: List of updates that were found/installed.
+    description:
+    - Updates that were found/installed.
+    - The key for each update is the C(id) of the update.
     returned: success
-    type: complex
+    type: dict
     sample:
     contains:
         title:
@@ -255,11 +257,11 @@ updates:
             version_added: 1.7.0
 
 filtered_updates:
-    description: List of updates that were found but were filtered based on
+    description: Updates that were found but were filtered based on
       I(blacklist), I(whitelist) or I(category_names). The return value is in
       the same form as I(updates), along with I(filtered_reason).
     returned: success
-    type: complex
+    type: dict
     sample: see the updates return value
     contains:
         filtered_reason:

--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -132,7 +132,7 @@ notes:
 - More information about PowerShell and how it handles RegEx strings can be
   found at U(https://technet.microsoft.com/en-us/library/2007.11.powershell.aspx).
 - The current module doesn't support Systems Center Configuration Manager (SCCM).
-  See L(https://github.com/ansible-collections/ansible.windows/issues/194)
+  See U(https://github.com/ansible-collections/ansible.windows/issues/194)
 seealso:
 - module: chocolatey.chocolatey.win_chocolatey
 - module: ansible.windows.win_feature

--- a/tests/integration/targets/win_updates/tasks/main.yml
+++ b/tests/integration/targets/win_updates/tasks/main.yml
@@ -83,9 +83,9 @@
     - search_sync.found_update_count == search_sync.updates|length
     - search_async.found_update_count == search_async.updates|length
     - search_become.found_update_count == search_become.updates|length
-    - search_sync.filtered_updates == []
-    - search_async.filtered_updates == []
-    - search_become.filtered_updates == []
+    - search_sync.filtered_updates == {}
+    - search_async.filtered_updates == {}
+    - search_become.filtered_updates == {}
 
 - name: search updates - check mode
   win_updates:
@@ -146,8 +146,8 @@
       - search_async.installed_update_count == 0
       - search_sync.found_update_count == search_sync.updates|length
       - search_async.found_update_count == search_async.updates|length
-      - search_sync.filtered_updates == []
-      - search_async.filtered_updates == []
+      - search_sync.filtered_updates == {}
+      - search_async.filtered_updates == {}
 
   always:
   - name: remove explicit deny batch logon right

--- a/tests/unit/plugins/action/test_win_updates.py
+++ b/tests/unit/plugins/action/test_win_updates.py
@@ -187,8 +187,8 @@ def test_failed_to_start_module(monkeypatch):
     assert actual['found_update_count'] == 0
     assert actual['failed_update_count'] == 0
     assert actual['installed_update_count'] == 0
-    assert actual['filtered_updates'] == []
-    assert actual['updates'] == []
+    assert actual['filtered_updates'] == {}
+    assert actual['updates'] == {}
 
 
 def test_failure_with_poll_script(monkeypatch):
@@ -203,8 +203,8 @@ def test_failure_with_poll_script(monkeypatch):
     assert actual['found_update_count'] == 0
     assert actual['failed_update_count'] == 0
     assert actual['installed_update_count'] == 0
-    assert actual['filtered_updates'] == []
-    assert actual['updates'] == []
+    assert actual['filtered_updates'] == {}
+    assert actual['updates'] == {}
 
 
 def test_poll_script_invalid_json_output(monkeypatch):
@@ -219,8 +219,8 @@ def test_poll_script_invalid_json_output(monkeypatch):
     assert actual['found_update_count'] == 0
     assert actual['failed_update_count'] == 0
     assert actual['installed_update_count'] == 0
-    assert actual['filtered_updates'] == []
-    assert actual['updates'] == []
+    assert actual['filtered_updates'] == {}
+    assert actual['updates'] == {}
 
 
 def test_install_with_multiple_reboots(monkeypatch):
@@ -241,10 +241,11 @@ def test_install_with_multiple_reboots(monkeypatch):
     assert actual['found_update_count'] == 8
     assert actual['failed_update_count'] == 0
     assert actual['installed_update_count'] == 8
-    assert actual['filtered_updates'] == []
+    assert actual['filtered_updates'] == {}
     assert len(actual['updates']) == 8
 
-    for u in actual['updates']:
+    for u_id, u in actual['updates'].items():
+        assert u['id'] == u_id
         assert u['id'] in UPDATE_INFO
         u_info = UPDATE_INFO[u['id']]
         assert u['title'] == u_info['title']
@@ -271,7 +272,8 @@ def test_install_without_reboot(monkeypatch):
     assert actual['installed_update_count'] == 3
 
     assert len(actual['filtered_updates']) == 3
-    for u in actual['filtered_updates']:
+    for u_id, u in actual['filtered_updates'].items():
+        assert u['id'] == u_id
         assert u['id'] in UPDATE_INFO
         u_info = UPDATE_INFO[u['id']]
         assert u['title'] == u_info['title']
@@ -288,7 +290,8 @@ def test_install_without_reboot(monkeypatch):
             assert u['filtered_reasons'] == ['category_names']
 
     assert len(actual['updates']) == 3
-    for u in actual['updates']:
+    for u_id, u in actual['updates'].items():
+        assert u['id'] == u_id
         assert u['id'] in UPDATE_INFO
         u_info = UPDATE_INFO[u['id']]
         assert u['title'] == u_info['title']
@@ -314,10 +317,11 @@ def test_install_with_initial_reboot_required(monkeypatch):
     assert actual['found_update_count'] == 6
     assert actual['failed_update_count'] == 0
     assert actual['installed_update_count'] == 5  # 1 found update was already installed at the beginning
-    assert actual['filtered_updates'] == []
+    assert actual['filtered_updates'] == {}
 
     assert len(actual['updates']) == 6
-    for u in actual['updates']:
+    for u_id, u in actual['updates'].items():
+        assert u['id'] == u_id
         assert u['id'] in UPDATE_INFO
         u_info = UPDATE_INFO[u['id']]
         assert u['title'] == u_info['title']
@@ -350,10 +354,11 @@ def test_install_with_reboot_fail(monkeypatch):
     assert actual['found_update_count'] == 6
     assert actual['failed_update_count'] == 0
     assert actual['installed_update_count'] == 0
-    assert actual['filtered_updates'] == []
+    assert actual['filtered_updates'] == {}
 
     assert len(actual['updates']) == 6
-    for u in actual['updates']:
+    for u_id, u in actual['updates'].items():
+        assert u['id'] == u_id
         assert u['id'] in UPDATE_INFO
         u_info = UPDATE_INFO[u['id']]
         assert u['title'] == u_info['title']
@@ -381,10 +386,11 @@ def test_install_with_reboot_check_mode(monkeypatch):
     assert actual['found_update_count'] == 6
     assert actual['failed_update_count'] == 0
     assert actual['installed_update_count'] == 0
-    assert actual['filtered_updates'] == []
+    assert actual['filtered_updates'] == {}
 
     assert len(actual['updates']) == 6
-    for u in actual['updates']:
+    for u_id, u in actual['updates'].items():
+        assert u['id'] == u_id
         assert u['id'] in UPDATE_INFO
         u_info = UPDATE_INFO[u['id']]
         assert u['title'] == u_info['title']
@@ -414,8 +420,8 @@ def test_install_reboot_with_two_failures(monkeypatch):
     assert actual['found_update_count'] == 0
     assert actual['failed_update_count'] == 0
     assert actual['installed_update_count'] == 0
-    assert actual['filtered_updates'] == []
-    assert actual['updates'] == []
+    assert actual['filtered_updates'] == {}
+    assert actual['updates'] == {}
 
 
 def test_install_with_initial_reboot_required_but_no_reboot(monkeypatch):
@@ -435,10 +441,11 @@ def test_install_with_initial_reboot_required_but_no_reboot(monkeypatch):
     assert actual['found_update_count'] == 5
     assert actual['failed_update_count'] == 0
     assert actual['installed_update_count'] == 0
-    assert actual['filtered_updates'] == []
+    assert actual['filtered_updates'] == {}
 
     assert len(actual['updates']) == 5
-    for u in actual['updates']:
+    for u_id, u in actual['updates'].items():
+        assert u['id'] == u_id
         assert u['id'] in UPDATE_INFO
         u_info = UPDATE_INFO[u['id']]
         assert u['title'] == u_info['title']
@@ -455,7 +462,8 @@ def test_install_non_integer_kb_values(monkeypatch):
     })
 
     assert len(actual['filtered_updates']) == 3
-    for u in actual['filtered_updates']:
+    for u_id, u in actual['filtered_updates'].items():
+        assert u['id'] == u_id
         if u['id'] == 'f26a0046-1e1a-4305-8743-19c92c3095a5':
             assert u['kb'] == ['']
 
@@ -469,7 +477,8 @@ def test_install_non_integer_kb_values(monkeypatch):
             assert False, ("Unknown update in filtered updates %s" % u['id'])
 
     assert len(actual['updates']) == 3
-    for u in actual['updates']:
+    for u_id, u in actual['updates'].items():
+        assert u['id'] == u_id
         if u['id'] == '74819184-828b-4f97-bb4b-089a0c58e366':
             assert u['kb'] == ['']
 
@@ -502,7 +511,8 @@ def test_fail_install(monkeypatch):
     assert actual['installed_update_count'] == 1
 
     assert len(actual['filtered_updates']) == 4
-    for u in actual['filtered_updates']:
+    for u_id, u in actual['filtered_updates'].items():
+        assert u['id'] == u_id
         assert u['id'] in UPDATE_INFO
         u_info = UPDATE_INFO[u['id']]
         assert u['title'] == u_info['title']
@@ -518,7 +528,8 @@ def test_fail_install(monkeypatch):
             assert u['filtered_reasons'] == ['accept_list', 'category_names']
 
     assert len(actual['updates']) == 2
-    for u in actual['updates']:
+    for u_id, u in actual['updates'].items():
+        assert u['id'] == u_id
         assert u['id'] in UPDATE_INFO
         u_info = UPDATE_INFO[u['id']]
         assert u['title'] == u_info['title']


### PR DESCRIPTION
##### SUMMARY
The `win_updates` refactor in `1.7.0` changed the return value of `updates` and `filtered_updates` from a dict to a list. To ease the transition to the collection from users of Ansible 2.9 or ealier this update reverts the changing of these values back to what it was before.

This is technically a breaking change but it's to rectify something that shouldn't have changed in the first place.

Fixes https://github.com/ansible-collections/ansible.windows/issues/307

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_updates