### PR TITLE
Simplify unit test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -391,7 +391,3 @@ changelogs/.plugin-cache.yaml
 
 # ansible-test ignores
 tests/integration/inventory*
-
-
-# VSCode
-.vscode/

--- a/.vscode/.env
+++ b/.vscode/.env
@@ -1,3 +1,0 @@
-# Uncomment to set the checkout dir of ansible if running from source
-# ANSIBLE_HOME=/home/username/ansible
-PYTHONPATH=tests/utils/plugins:${PYTHONPATH}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "ms-python.python",
+        "ms-vscode.powershell",
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,30 @@
 {
-    "python.envFile": "${workspaceFolder}/.vscode/.env",
     "python.testing.pytestArgs": [
-        "-p", "pytest_collection_loader",
         "tests/unit",
         "-vv"
     ],
     "python.testing.unittestEnabled": false,
-    "python.testing.nosetestsEnabled": false,
     "python.testing.pytestEnabled": true,
     "python.analysis.extraPaths": [
-        // ansible_collections dir
         "${workspaceFolder}/../../../",
-        // optional - ansible source checkout (points to the lib folder in the checkout)
-        // "/home/<username>/ansible/lib",
-    ]
+    ],
+
+    "powershell.codeFormatting.addWhitespaceAroundPipe": true,
+    "powershell.codeFormatting.alignPropertyValuePairs": false,
+    "powershell.codeFormatting.autoCorrectAliases": true,
+    "powershell.codeFormatting.ignoreOneLineBlock": true,
+    "powershell.codeFormatting.newLineAfterCloseBrace": true,
+    "powershell.codeFormatting.newLineAfterOpenBrace": true,
+    "powershell.codeFormatting.openBraceOnSameLine": true,
+    "powershell.codeFormatting.pipelineIndentationStyle": "IncreaseIndentationForFirstPipeline",
+    "powershell.codeFormatting.whitespaceAfterSeparator": true,
+    "powershell.codeFormatting.whitespaceAroundOperator": true,
+    "powershell.codeFormatting.whitespaceBeforeOpenBrace": true,
+    "powershell.codeFormatting.whitespaceBeforeOpenParen": true,
+    "powershell.codeFormatting.whitespaceBetweenParameters": true,
+    "powershell.codeFormatting.whitespaceInsideBrace": true,
+    "powershell.scriptAnalysis.enable": true,
+    "[powershell]": {
+        "editor.formatOnSave": true,
+    },
 }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -4,10 +4,11 @@ __metaclass__ = type
 
 import os
 import os.path
-import sys
+
+from ansible.utils.collection_loader._collection_finder import _AnsibleCollectionFinder
 
 
-ANSIBLE_COLLECTIONS_PATH = os.path.abspath(os.path.join(__file__, '..', '..', '..', '..', '..', '..'))
+ANSIBLE_COLLECTIONS_PATH = os.path.abspath(os.path.join(__file__, '..', '..', '..', '..', '..'))
 
 
 # this monkeypatch to _pytest.pathlib.resolve_package_path fixes PEP420 resolution for collections in pytest >= 6.0.0
@@ -28,14 +29,6 @@ def pytest_configure():
             return
     except AttributeError:
         pytest_configure.executed = True
-
-    # If ANSIBLE_HOME is set make sure we add it to the PYTHONPATH to ensure it is picked up. Not all env vars are
-    # picked up by vscode (.bashrc is a notable one) so a user can define it manually in their .env file.
-    ansible_home = os.environ.get('ANSIBLE_HOME', None)
-    if ansible_home:
-        sys.path.insert(0, os.path.join(ansible_home, 'lib'))
-
-    from ansible.utils.collection_loader._collection_finder import _AnsibleCollectionFinder
 
     # allow unit tests to import code from collections
 


### PR DESCRIPTION
##### SUMMARY
Now that Ansible from a source checkout can be installed with `pip install -e .` we can simplify the logic in the collection loader plugin used in vscode.

Also adds PowerShell auto formatting to help make it easier to fix sanity problems.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible-test unit