### PR TITLE
win_updates - prevent host from sleeping

### DIFF
--- a/changelogs/fragments/win_updates-sleep.yml
+++ b/changelogs/fragments/win_updates-sleep.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- >-
+  win_updates - prevent the host from going to sleep if a low sleep timeout is set -
+  https://github.com/ansible-collections/ansible.windows/issues/310


### PR DESCRIPTION
##### SUMMARY
The module will not tell the host every minute not to go to sleep when running the long async tasks for Windows Updates.

Fixes https://github.com/ansible-collections/ansible.windows/issues/310

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_updates