### PR TITLE
Add stale PR handler

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: Stale pull request handler
+on:
+  schedule:
+  - cron: 0 0 * * *
+
+permissions:
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v4.0.0
+      id: stale
+      with:
+        days-before-stale: -1
+        days-before-pr-stale: 28
+        days-before-pr-close: 14
+        stale-pr-label: stale
+        stale-pr-message: >-
+          This pull request is stale because it has been open for 4 weeks with no activity.
+          Remove stale label or comment or this will be closed in 2 weeks.
+

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,4 +21,3 @@ jobs:
         stale-pr-message: >-
           This pull request is stale because it has been open for 4 weeks with no activity.
           Remove stale label or comment or this will be closed in 2 weeks.
-


### PR DESCRIPTION
##### SUMMARY
Adds a github workflow to mark stale PRs after 4 weeks and close them 2 weeks after that.