### PR TITLE
Add Verbosity to 'Ansible' object.

### DIFF
--- a/changelogs/fragments/win_powershell.yml
+++ b/changelogs/fragments/win_powershell.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_powershell - Added ``$Ansible.Verbosity`` for scripts to adjust code based on the verbosity Ansible is running as

--- a/plugins/modules/win_powershell.ps1
+++ b/plugins/modules/win_powershell.ps1
@@ -598,6 +598,7 @@ try {
     $ps.Runspace.SessionStateProxy.SetVariable('Ansible', [PSCustomObject]@{
             PSTypeName = 'Ansible.Windows.WinPowerShell.Module'
             CheckMode = $module.CheckMode
+            Verbosity = $module.Verbosity
             Result = @{}
             Changed = $true
             Failed = $false

--- a/plugins/modules/win_powershell.py
+++ b/plugins/modules/win_powershell.py
@@ -95,6 +95,8 @@ notes:
 - C($Ansible.Failed) can be set to C(true) if the script wants to return the failure back to the controller.
 - C($Ansible.Tmpdir) is the path to a temporary directory to use as a scratch location that is cleaned up after the
   module has finished.
+- C($Ansible.Verbosity) reveals Ansible's verbosity level for this play. Allows the script to set VerbosePreference/DebugPreference
+  based on verbosity.
 - Any host/console output like C(Write-Host) or C([Console]::WriteLine) is not considered an output object, they are
   returned as a string in I(host_out) and I(host_err).
 - The module will skip running the script when in check mode unless the script defines
@@ -187,6 +189,20 @@ EXAMPLES = r'''
       else {
           $Ansible.Changed = $true
       }
+
+- name: Define when to enable Verbose/Debug output
+  ansible.windows.win_powershell:
+    script: |
+      if ($Ansible.Verbosity -ge 3) {
+          $VerbosePreference = "Continue"
+      }
+      if ($Ansible.Verbosity -eq 5) {
+          $DebugPreference = "Continue"
+      }
+      Write-Output "Hello World!"
+      Write-Verbose "Hello World!"
+      Write-Debug "Hello World!"
+
 '''
 
 RETURN = r'''

--- a/plugins/modules/win_powershell.py
+++ b/plugins/modules/win_powershell.py
@@ -96,7 +96,7 @@ notes:
 - C($Ansible.Tmpdir) is the path to a temporary directory to use as a scratch location that is cleaned up after the
   module has finished.
 - C($Ansible.Verbosity) reveals Ansible's verbosity level for this play. Allows the script to set VerbosePreference/DebugPreference
-  based on verbosity.
+  based on verbosity. Added in C(1.9.0).
 - Any host/console output like C(Write-Host) or C([Console]::WriteLine) is not considered an output object, they are
   returned as a string in I(host_out) and I(host_err).
 - The module will skip running the script when in check mode unless the script defines


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add $module.Verbosity to 'Ansible' object.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible.windows.win_powershell

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Since $module is not exposed to the script, the script cannot know Ansible's running verbosity. This pull adds the Verbosity from $module to $Ansible and allows a script author to modify their VerbosePreference and/or DebugPreference based on the $Ansible.Verbosity value. This should prove useful to when we need to troubleshoot problems with scripts instead of just win_powershell itself.

``` yaml
---
- name: Define when to enable Verbose/Debug output
  ansible.windows.win_powershell:
    script: |
      if ($Ansible.Verbosity -ge 3) {
          $VerbosePreference = "Continue"
      }
      if ($Ansible.Verbosity -eq 5) {
          $DebugPreference = "Continue"
      }
      Write-Output "Hello World!"
      Write-Verbose "Hello World!"
      Write-Debug "Hello World!"
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
windows_host_before | CHANGED => {
    "changed": true,
    "debug": [],
    "error": [],
    "host_err": "",
    "host_out": "",
    "information": [],
    "invocation": {
        "module_args": {
            "arguments": null,
            "chdir": null,
            "creates": null,
            "depth": 2,
            "error_action": "continue",
            "executable": null,
            "parameters": null,
            "removes": null,
            "script": "if ($Ansible.Verbosity -ge 3) {\r\n    $VerbosePreference = \"Continue\"\r\n}\r\nif ($Ansible.Verbosity -eq 5) {\r\n    $DebugPreference = \"Continue\"\r\n}\r\nWrite-Output \"Hello World!\"\r\nWrite-Verbose \"Hello World!\"\r\nWrite-Debug \"Hello World!\""
        }
    },
    "output": [
        "Hello World!"
    ],
    "result": {},
    "verbose": [],
    "warning": []
}

windows_host_after | CHANGED => {
    "changed": true,
    "debug": [
        "Hello World!"
    ],
    "error": [],
    "host_err": "",
    "host_out": "VERBOSE: Hello World!\r\nDEBUG: Hello World!\r\n",
    "information": [],
    "invocation": {
        "module_args": {
            "arguments": null,
            "chdir": null,
            "creates": null,
            "depth": 2,
            "error_action": "continue",
            "executable": null,
            "parameters": null,
            "removes": null,
            "script": "if ($Ansible.Verbosity -ge 3) {\r\n    $VerbosePreference = \"Continue\"\r\n}\r\nif ($Ansible.Verbosity -eq 5) {\r\n    $DebugPreference = \"Continue\"\r\n}\r\nWrite-Output \"Hello World!\"\r\nWrite-Verbose \"Hello World!\"\r\nWrite-Debug \"Hello World!\""
        }
    },
    "output": [
        "Hello World!"
    ],
    "result": {},
    "verbose": [
        "Hello World!"
    ],
    "warning": []
}
}```
