### PR TITLE
win_updates - fix execution policy restrictions

### DIFF
--- a/changelogs/fragments/win_updates-execution-policy.yml
+++ b/changelogs/fragments/win_updates-execution-policy.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_updates - Fixed issue when attempting to run ``task.ps1`` with a host that has a restrictive execution policy set through GPO


### PR DESCRIPTION
##### SUMMARY
If a host has a restrictive execution policy set through GPO then the `win_updates` module will fail to start `task.ps1` which is run through the task scheduler. By having the new process read the file manually and invoke it using a scriptblock it can avoid this restriction and run like normal.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_updates