### PR TITLE
win_user_right - update docs on user domain prefix

### DIFF
--- a/plugins/modules/win_user_right.py
+++ b/plugins/modules/win_user_right.py
@@ -26,6 +26,9 @@ options:
       domain users/groups.
     - For local users/groups it can be in the form user-group, .\user-group,
       SERVERNAME\user-group where SERVERNAME is the name of the remote server.
+    - It is highly recommended to use the C(.\) or C(SERVERNAME\) prefix to
+      avoid any ambiguity with domain account names or errors trying to lookup
+      an account on a domain controller.
     - You can also add special local accounts like SYSTEM and others.
     - Can be set to an empty list with I(action=set) to remove all accounts
       from the right.


### PR DESCRIPTION
##### SUMMARY
Further clarifies the recommendation to use the `.\account` or `SERVERNAME\account` format when dealing with local users and groups.

Fixes https://github.com/ansible-collections/ansible.windows/issues/316

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
win_user_right