### PR TITLE
win_reboot - enforce minimum pre reboot time to 2 seconds

### DIFF
--- a/changelogs/fragments/win_reboot-pre-delay.yml
+++ b/changelogs/fragments/win_reboot-pre-delay.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_reboot - Always set a minimum of 2 seconds for ``pre_reboot_delay`` to ensure the plugin can read the result

--- a/plugins/action/win_reboot.py
+++ b/plugins/action/win_reboot.py
@@ -78,6 +78,11 @@ class ActionModule(ActionBase):
                 except TypeError as e:
                     raise AnsibleError("Invalid value given for '%s': %s." % (names[0], to_native(e)))
 
+                # Setting a lower value and kill PowerShell when sending the shutdown command. Just use the defaults
+                # if this is the case.
+                if names[0] == 'pre_reboot_delay' and value < 2:
+                    continue
+
                 parameters[names[0]] = value
 
         result = reboot_host(self._task.action, self._connection, **parameters)

--- a/plugins/modules/win_reboot.py
+++ b/plugins/modules/win_reboot.py
@@ -14,6 +14,7 @@ options:
   pre_reboot_delay:
     description:
     - Seconds to wait before reboot. Passed as a parameter to the reboot command.
+    - The minimum version is C(2) seconds and cannot be set lower.
     type: float
     default: 2
     aliases: [ pre_reboot_delay_sec ]


### PR DESCRIPTION
##### SUMMARY
CI is sometimes seeing a problem with the RPC server not being online when attempting a reboot. This adds a simple retry option in the reboot command if this comes up again.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_reboot