### PR TITLE
Update module documentation explicitly stating that it behaves as a r…

### DIFF
--- a/plugins/modules/win_reboot.py
+++ b/plugins/modules/win_reboot.py
@@ -8,7 +8,7 @@ DOCUMENTATION = r'''
 module: win_reboot
 short_description: Reboot a windows machine
 description:
-- Reboot a Windows machine, wait for it to go down, come back up, and respond to commands.
+- Unconditionally reboot a Windows machine, wait for it to go down, come back up, and respond to commands.
 - For non-Windows targets, use the M(ansible.builtin.reboot) module instead.
 options:
   pre_reboot_delay:
@@ -63,6 +63,7 @@ notes:
 - The connection user must have the C(SeRemoteShutdownPrivilege) privilege enabled, see
   U(https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/force-shutdown-from-a-remote-system)
   for more information.
+- This module is equivalent to using the /f forced option for reboot on a windows host
 seealso:
 - module: ansible.builtin.reboot
 author:


### PR DESCRIPTION
…eboot with the /f forced option

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update the win_reboot module documentation to explicitly state it is equivalent to using `shutdown /r /f` see related issue.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_reboot.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See [related issue 336](https://github.com/ansible-collections/ansible.windows/issues/336) 
