### PR TITLE
Fix sanity issues

### DIFF
--- a/plugins/modules/win_dns_client.py
+++ b/plugins/modules/win_dns_client.py
@@ -16,6 +16,7 @@ options:
       - Adapter name or list of adapter names for which to manage DNS settings ('*' is supported as a wildcard value).
       - The adapter name used is the connection caption in the Network Control Panel or the InterfaceAlias of C(Get-DnsClientServerAddress).
     type: list
+    elements: str
     required: yes
   dns_servers:
     description:
@@ -24,6 +25,7 @@ options:
         or disable DNS lookup on statically-configured connections.
       - IPv6 DNS servers can only be set on Windows Server 2012 or newer, older hosts can only set IPv4 addresses.
     type: list
+    elements: str
     required: yes
     aliases: [ "ipv4_addresses", "ip_addresses", "addresses" ]
 author:

--- a/plugins/modules/win_feature.py
+++ b/plugins/modules/win_feature.py
@@ -19,6 +19,7 @@ options:
       - Names of roles or features to install as a single feature or a comma-separated list of features.
       - To list all available features use the PowerShell command C(Get-WindowsFeature).
     type: list
+    elements: str
     required: yes
   state:
     description:

--- a/plugins/modules/win_group_membership.py
+++ b/plugins/modules/win_group_membership.py
@@ -26,6 +26,7 @@ options:
       - Accepts all local, domain and service user types as username,
         favoring domain lookups when in a domain.
     type: list
+    elements: str
     required: yes
   state:
     description:

--- a/plugins/modules/win_path.py
+++ b/plugins/modules/win_path.py
@@ -27,6 +27,7 @@ options:
       - Paths are compared in a case-insensitive fashion, and trailing backslashes are ignored for comparison purposes. However, note that trailing
         backslashes in YAML require quotes.
     type: list
+    elements: str
     required: yes
   state:
     description:

--- a/plugins/modules/win_wait_for.py
+++ b/plugins/modules/win_wait_for.py
@@ -35,6 +35,7 @@ options:
     - The list of hosts or IPs to ignore when looking for active TCP
       connections when C(state=drained).
     type: list
+    elements: str
   host:
     description:
     - A resolvable hostname or IP address to wait for.


### PR DESCRIPTION
##### SUMMARY
Devel introduced a new santiy check to ensure any doc members with `type: list` must also have a `elements: ...` entry to denote the type of each list element.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.windows