### PR TITLE
add new stable branch and fix up 2.14 santiy ignores

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -54,6 +54,19 @@ stages:
               test: sanity
             - name: Units
               test: units
+  - stage: Ansible_2_13
+    displayName: Ansible 2.13
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: '{0}'
+          testFormat: '2.13/{0}'
+          targets:
+            - name: Sanity
+              test: sanity
+            - name: Units
+              test: units
   - stage: Ansible_2_12
     displayName: Ansible 2.12
     dependsOn: []

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,0 +1,6 @@
+plugins/modules/setup.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
+plugins/modules/win_powershell.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore until all ansible-test branches support custom rules
+tests/integration/targets/win_package/library/win_make_appx.ps1 pslint:PSAvoidLongLines # Cannot ignore until all ansible-test branches support this rule
+tests/utils/shippable/check_matrix.py replace-urlopen
+tests/utils/shippable/timing.py shebang
+tests/integration/targets/win_dsc/files/xTestCompositeDsc/1.0.0/DSCResources/xTestComposite/xTestComposite.schema.psm1 pslint!skip # Pwsh cannot parse DSC to MOF on Linux


### PR DESCRIPTION
##### SUMMARY
Ansible has just bumped versions in the devel branch to 2.14 which requires a new sanity ignore file. This adds that file and ensures we still test with the newly created stable-2.13.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.windows