### PR TITLE
win_environment path - Notify on environment change

### DIFF
--- a/changelogs/fragments/environment_notify.yml
+++ b/changelogs/fragments/environment_notify.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- win_environment - Trigger ``WM_SETTINGCHANGE`` on a change to notify other host processes of an environment change
+- win_path - Trigger ``WM_SETTINGCHANGE`` on a change to notify other host processes of an environment change
+- win_path - Migrate to newer style module parser that adds features like module invocation under ``-vvv``

--- a/plugins/modules/win_environment.ps1
+++ b/plugins/modules/win_environment.ps1
@@ -5,6 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
 
 $spec = @{
     options = @{
@@ -29,6 +30,10 @@ function Set-EnvironmentVariableState {
     [CmdletBinding(SupportsShouldProcess = $true)]
     [OutputType([hashtable])]
     param(
+        [Parameter(Mandatory = $true)]
+        [Ansible.Basic.AnsibleModule]
+        $Module,
+
         [Parameter(Mandatory = $true)]
         [System.EnvironmentVariableTarget]
         $Level ,
@@ -68,18 +73,82 @@ function Set-EnvironmentVariableState {
         if ($State -eq "present" -and $before_value -ne $Value) {
             if ($PSCmdlet.ShouldProcess($Name, 'Set environment variable')) {
                 [Environment]::SetEnvironmentVariable($Name, $Value, $Level)
+                Register-EnvironmentChange -Module $Module
             }
             $ret.changed = $true
         }
         elseif ($State -eq "absent" -and $null -ne $before_value) {
             if ($PSCmdlet.ShouldProcess($Name, 'Remove environment variable')) {
                 [Environment]::SetEnvironmentVariable($Name, $null, $Level)
+                Register-EnvironmentChange -Module $Module
             }
             $ret.changed = $true
         }
 
         $ret
     }
+}
+
+Function Register-EnvironmentChange {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [Ansible.Basic.AnsibleModule]
+        $Module
+    )
+
+    Add-CSharpType -AnsibleModule $Module -References @'
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+
+namespace Ansible.Windows.WinEnvironment
+{
+    public class Native
+    {
+        [DllImport("User32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern IntPtr SendMessageTimeoutW(
+            IntPtr hWnd,
+            uint Msg,
+            UIntPtr wParam,
+            string lParam,
+            SendMessageFlags fuFlags,
+            uint uTimeout,
+            out UIntPtr lpdwResult);
+
+        public static UIntPtr SendMessageTimeout(IntPtr windowHandle, uint msg, UIntPtr wParam, string lParam,
+            SendMessageFlags flags, uint timeout)
+        {
+            UIntPtr result = UIntPtr.Zero;
+            IntPtr funcRes = SendMessageTimeoutW(windowHandle, msg, wParam, lParam, flags, timeout, out result);
+            if (funcRes == IntPtr.Zero)
+                throw new Win32Exception();
+
+            return result;
+        }
+    }
+
+    [Flags()]
+    public enum SendMessageFlags : uint
+    {
+        Normal = 0x0000,
+        Block = 0x0001,
+        AbortIfHung = 0x0002,
+        NoTimeoutIfNotHung = 0x0008,
+        ErrorOnExit = 0x0020,
+    }
+}
+'@
+
+    $HWND_BROADCAST = [IntPtr]0xFFFF;
+    $WM_SETTINGCHANGE = 0x001A;
+    $null = [Ansible.Windows.WinEnvironment.Native]::SendMessageTimeout(
+        $HWND_BROADCAST,
+        $WM_SETTINGCHANGE,
+        [UIntPtr]::Zero,
+        "Environment",
+        "AbortIfHung",
+        5000)
 }
 
 $module.Result.values = @{}
@@ -112,7 +181,7 @@ foreach ($kv in $envvars.GetEnumerator()) {
         $module.FailJson("When state=present, value must be defined and not an empty string, if you wish to remove the envvar, set state=absent")
     }
 
-    $status = $kv | Set-EnvironmentVariableState -Level $level -State $state -WhatIf:$($module.CheckMode)
+    $status = $kv | Set-EnvironmentVariableState -Module $module -Level $level -State $state -WhatIf:$($module.CheckMode)
 
     if ($status.before) {
         $module.Diff.before.$level.$name = $status.before

--- a/plugins/modules/win_path.py
+++ b/plugins/modules/win_path.py
@@ -34,6 +34,7 @@ options:
       - Whether the path elements specified in C(elements) should be present or absent.
     type: str
     choices: [ absent, present ]
+    default: present
   scope:
     description:
       - The level at which the environment variable specified by C(name) should be managed (either for the current user or global machine scope).


### PR DESCRIPTION
##### SUMMARY
Broadcast the `WM_SETTINGCHANGE`message to top level windows when an environment variable has changed. This replicates what Windows does when changing the environment variables through the GUI. While technically a change in behaviour I cannot imagine why this shouldn't be automatically done so I didn't add a new option to toggle this behaviour.

This also updates `win_path` to use the newer module style.

Fixes https://github.com/ansible-collections/ansible.windows/issues/348

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_environment
win_path