### PR TITLE
setup - Add system locale language

### DIFF
--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -1056,7 +1056,7 @@ $factMeta = @(
     @{
         Subsets = 'locale'
         Code = {
-            $system_language = (Get-WmiObject -Class Win32_OperatingSystem).MUILanguages | Select -Index 0
+            $system_language = (Get-CimInstance -ClassName Win32_OperatingSystem).MUILanguages | Select-Object -Index 0
 
             $ansibleFacts.ansible_locale.system_language = $system_language
         }

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -1052,11 +1052,19 @@ $factMeta = @(
             $ansibleFacts.ansible_virtualization_role = 'NA'
             $ansibleFacts.ansible_virtualization_type = 'NA'
         }
+    },
+    @{
+        Subsets = 'locale'
+        Code = {
+            $system_language = (Get-WmiObject -Class Win32_OperatingSystem).MUILanguages | Select -Index 0
+
+            $ansibleFacts.ansible_locale.system_language = $system_language
+        }
     }
 )
 
 $groupedSubsets = @{
-    min = [System.Collections.Generic.List[string]]@('date_time', 'distribution', 'dns', 'env', 'local', 'platform', 'powershell_version', 'user')
+    min = [System.Collections.Generic.List[string]]@('date_time', 'distribution', 'dns', 'env', 'local', 'platform', 'powershell_version', 'user', 'locale')
     network = [System.Collections.Generic.List[string]]@('all_ipv4_addresses', 'all_ipv6_addresses', 'interfaces', 'windows_domain', 'winrm')
     hardware = [System.Collections.Generic.List[string]]@('bios', 'memory', 'processor', 'uptime', 'virtual')
     external = [System.Collections.Generic.List[string]]@('facter')


### PR DESCRIPTION
##### SUMMARY

Based on https://github.com/ansible/ansible/pull/32930, add the system locale language of Windows to the facts of Ansible for the Windows operating system. This helps to resolve different language-related differences under Windows. I've tried to add the system locale language with the constraints mentioned in the pull request. However, some time has passed since the last pull request, so I'm unsure if this solution is appropriated. Feel free to suggest.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

- `setup.ps1` Module