### PR TITLE
Do not download http target before checking for state when product_id…

### DIFF
--- a/plugins/modules/win_package.ps1
+++ b/plugins/modules/win_package.ps1
@@ -1431,7 +1431,7 @@ try {
     }
 
     # If the path is a URL or UNC with credentials and no ID is set then create a temp copy for idempotency checks.
-    if ($pathType -and -not $Id) {
+    if ($pathType -and -not $getParams.Id) {
         $tempFile = switch ($pathType) {
             url { Get-UrlFile -Module $module -Url $path }
             unc { Copy-ItemWithCredential -Path $path -Destination $module.Tmpdir -Credential $credential }


### PR DESCRIPTION
… is defined

##### SUMMARY
When win_package/product_id is defined - do not download package blob from HTTP location before making check if package is installed already.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_package.ps1

##### ADDITIONAL INFORMATION
Scope mess.