### PR TITLE
Make sure to escape single quotes in win_stat path

### DIFF
--- a/changelogs/fragments/win_stat-share-slash.yml
+++ b/changelogs/fragments/win_stat-share-slash.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- win_stat - Fix up share checks when the share contains the ``'`` character
+- win_find - Fix up share checks when the share contains the ``'`` character

--- a/plugins/modules/win_find.ps1
+++ b/plugins/modules/win_find.ps1
@@ -305,7 +305,7 @@ Function Search-Path {
         }
 
         if ($dir_child.Attributes.HasFlag([System.IO.FileAttributes]::Directory)) {
-            $share_info = Get-CimInstance -ClassName Win32_Share -Filter "Path='$($dir_child.FullName -replace '\\', '\\')'"
+            $share_info = Get-CimInstance -ClassName Win32_Share -Filter "Path='$($dir_child.FullName -replace "(\\|')", '\$1')'"
             if ($null -ne $share_info) {
                 $file_info.isshared = $true
                 $file_info.sharename = $share_info.Name

--- a/plugins/modules/win_stat.ps1
+++ b/plugins/modules/win_stat.ps1
@@ -129,7 +129,7 @@ If ($null -ne $info) {
     # values that are set according to the type of file
     if ($info.Attributes.HasFlag([System.IO.FileAttributes]::Directory)) {
         $stat.isdir = $true
-        $share_info = Get-CimInstance -ClassName Win32_Share -Filter "Path='$($stat.path -replace '\\', '\\' -replace "'", "\'")'"
+        $share_info = Get-CimInstance -ClassName Win32_Share -Filter "Path='$($stat.path -replace "(\\|')", '\$1')'"
         if ($null -ne $share_info) {
             $stat.isshared = $true
             $stat.sharename = $share_info.Name

--- a/plugins/modules/win_stat.ps1
+++ b/plugins/modules/win_stat.ps1
@@ -129,7 +129,7 @@ If ($null -ne $info) {
     # values that are set according to the type of file
     if ($info.Attributes.HasFlag([System.IO.FileAttributes]::Directory)) {
         $stat.isdir = $true
-        $share_info = Get-CimInstance -ClassName Win32_Share -Filter "Path='$($stat.path -replace '\\', '\\')'"
+        $share_info = Get-CimInstance -ClassName Win32_Share -Filter "Path='$($stat.path -replace '\\', '\\' -replace "'", "\'")'"
         if ($null -ne $share_info) {
             $stat.isshared = $true
             $stat.sharename = $share_info.Name


### PR DESCRIPTION
##### SUMMARY
The proposed change addresses a consistent, reproducible error with the win_stat module.
Without this change, it is impossible to have the module work in situations where the path contains single quotes: `'`

This PR simply enforces the recommended syntax for the Get-CimInstance command, as per the documentation:

```
If the value specified contains double quotes (“), single quotes (‘), or a backslash (\), you must escape 
those characters by prefixing them with the backslash (\) character.
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_stat

##### ADDITIONAL INFORMATION

Result before the change:
```
The full traceback is:
Invalid query 
At line:127 char:23
+ ... hare_info = Get-CimInstance -ClassName Win32_Share -Filter "Path='$($ ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Get-CimInstance], CimException
    + FullyQualifiedErrorId : HRESULT 0x80041017,Microsoft.Management.Infrastructure.CimCmdlets.GetCimInstanceCommand

ScriptStackTrace:
at <ScriptBlock>, <No file>: line 127

Microsoft.Management.Infrastructure.CimException: Invalid query 
   at Microsoft.Management.Infrastructure.Internal.Operations.CimAsyncObserverProxyBase`1.ProcessNativeCallback(OperationCallbackProcessingContext callbackProcessingContext, T currentItem, Boolean moreResults, MiResult operationResult, String errorMessage, InstanceHandle errorDetailsHandle)
failed: [redacted_hostname] (item=runtime) => {
    "ansible_loop_var": "installed_dir",
    "changed": false,
    "installed_dir": "runtime",
    "msg": "Unhandled exception while executing module: Invalid query "
}

```
