### PR TITLE
docs win_find_module correct sample for value path

### DIFF
--- a/docs/ansible.windows.win_find_module.rst
+++ b/docs/ansible.windows.win_find_module.rst
@@ -822,7 +822,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                             <div>The full absolute path to the file.</div>
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
-                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BUILTIN\Administrators</div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">C:\temp\file.txt</div>
                 </td>
             </tr>
             <tr>

--- a/docs/ansible.windows.win_find_module.rst
+++ b/docs/ansible.windows.win_find_module.rst
@@ -822,7 +822,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                             <div>The full absolute path to the file.</div>
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
-                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">C:\temp\file.txt</div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">BUILTIN\Administrators</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/modules/win_find.py
+++ b/plugins/modules/win_find.py
@@ -329,7 +329,7 @@ files:
             description: The full absolute path to the file.
             returned: success, path exists
             type: str
-            sample: BUILTIN\Administrators
+            sample: C:\temp\file.txt
         sharename:
             description: The name of share if folder is shared.
             returned: success, path exists, path is a directory and isshared == True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Corrects an error in the documentation for win_find_module where the returned value has an incorrect sample.

Current sample shows what would be the owner of the file, but should show a path to the found file.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_find_module
