### PR TITLE
Raise minimum Ansible version to 2.11

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -93,19 +93,6 @@ stages:
               test: sanity
             - name: Units
               test: units
-  - stage: Ansible_2_10
-    displayName: Ansible 2.10
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: '{0}'
-          testFormat: '2.10/{0}'
-          targets:
-            - name: Sanity
-              test: sanity
-            - name: Units
-              test: units
   - stage: Windows
     displayName: Windows
     dependsOn: []
@@ -130,7 +117,6 @@ stages:
       - Ansible_devel
       - Ansible_2_12
       - Ansible_2_11
-      - Ansible_2_10
       - Windows
     jobs:
       - template: templates/coverage.yml

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The `ansible.windows` collection includes the core plugins supported by Ansible 
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.10**.
+This collection has been tested against following Ansible versions: **>=2.11**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.

--- a/changelogs/fragments/ansible-version-bump.yml
+++ b/changelogs/fragments/ansible-version-bump.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Raise minimum Ansible version to ``2.11`` or newer

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: ansible
 name: windows
-version: 1.10.0
+version: 1.11.0
 readme: README.md
 authors:
 - Jordan Borean @jborean93

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,1 +1,1 @@
-requires_ansible: '>=2.10'
+requires_ansible: '>=2.11'


### PR DESCRIPTION
##### SUMMARY
Raises the minimum ansible version to 2.11 now that 2.10 is end of life

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible.windows