### PR TITLE
win_package - skip msix on older hosts

### DIFF
--- a/changelogs/fragments/win_package-msix-legacy.yml
+++ b/changelogs/fragments/win_package-msix-legacy.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_package - Skip ``msix`` provider on older hosts that do not implement the required cmdlets

--- a/plugins/modules/win_package.ps1
+++ b/plugins/modules/win_package.ps1
@@ -590,7 +590,11 @@ Function Get-InstalledStatus {
     }
     else {
         if ($Provider -eq 'auto') {
-            $providerList = [String[]]$providerInfo.Keys
+            # While we only technically support 2012+ this is a fairly small thing to do to ensure this
+            # continues to run on Server 2008 and 2008 R2. This should be removed sometime in the future.
+            # https://github.com/ansible-collections/ansible.windows/issues/362
+            $msixAvailable = [bool](Get-Command -Name Get-AppxPackage -ErrorAction SilentlyContinue)
+            $providerList = [String[]]$providerInfo.Keys | Where-Object { $_ -ne 'msix' -or $msixAvailable }
         }
         else {
             $providerList = @($Provider)


### PR DESCRIPTION
##### SUMMARY
The msix provider only works on Server 2012 or newer. The installed check will only check with the `msix` provider in `auto` if the required cmdlets are present.

Fixes https://github.com/ansible-collections/ansible.windows/issues/362

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.windows