### PR TITLE
setup - Ignore invalid PATH entries for facter

### DIFF
--- a/changelogs/fragments/setup-invalid-PATH.yml
+++ b/changelogs/fragments/setup-invalid-PATH.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- setup - Ignore invalid ``PATH`` entries when trying to find ``facter.exe`` - https://github.com/ansible-collections/ansible.windows/issues/364

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -667,7 +667,15 @@ $factMeta = @(
                     return $false
                 }
                 $facterPath = Join-Path -Path $_ -ChildPath facter.exe
-                Test-Path -LiteralPath $facterPath
+
+                # https://github.com/ansible-collections/ansible.windows/issues/364
+                # PATH may still contain invalid PATH characters, ignore them
+                try {
+                    Test-Path -LiteralPath $facterPath -ErrorAction SilentlyContinue
+                }
+                catch [ArgumentException] {
+                    $false
+                }
             } | Select-Object -First 1
 
             if ($facterDir) {


### PR DESCRIPTION
##### SUMMARY
Ignores entries in `PATH` that are invalid paths.

Fixes https://github.com/ansible-collections/ansible.windows/issues/364

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup