### PR TITLE
win_updates - Try to recover from search suceeded with errors

### DIFF
--- a/changelogs/fragments/win_updates-search-warnings.yml
+++ b/changelogs/fragments/win_updates-search-warnings.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_updates - Try to display warnings on search suceeded with warnings - https://github.com/ansible-collections/ansible.windows/issues/366


### PR DESCRIPTION
##### SUMMARY
If the search result returned `SuceededWithErrors` then to continue the update task. It also attempts to try and log any warnings in the search result warnings in the log for further debugging.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/366

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_updates