### PR TITLE
win_powershell - Do not serialize ETS props of primitive types

### DIFF
--- a/changelogs/fragments/win_powershell-ets-props.yml
+++ b/changelogs/fragments/win_powershell-ets-props.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_powershell - Do not attempt to serialize ETS properties of primitive types - https://github.com/ansible-collections/ansible.windows/issues/360

--- a/plugins/modules/win_powershell.ps1
+++ b/plugins/modules/win_powershell.ps1
@@ -342,14 +342,15 @@ Function Convert-OutputObject {
             }
         }
         elseif ($InputObject -is [string]) {
-            $InputObject
+            # Get the BaseObject to strip out any ETS properties
+            $InputObject.PSObject.BaseObject
         }
         elseif (&$isType -InputObject $InputObject -Type ([switch])) {
             $InputObject.IsPresent
         }
         elseif ($InputObject.GetType().IsValueType) {
             # We want to display just this value and not any properties it has (if any).
-            $InputObject
+            $InputObject.PSObject.BaseObject
         }
         elseif ($Depth -lt 0) {
             # This must occur after the above to ensure ints and other ValueTypes are preserved as is.

--- a/tests/integration/targets/win_powershell/tasks/tests.yml
+++ b/tests/integration/targets/win_powershell/tasks/tests.yml
@@ -844,3 +844,28 @@
     - host_output.host_out == 'host café 💩\r\nsub stdout café 💩\r\nstdout café 💩\r\n'
     - host_output.error == []
     - host_output.output == []
+
+# Primitive types should strip out the ETS props to avoid recursive and deep nesting serializtion
+# problems. This replicates the behaviour of ConvertTo-Json in newer pwsh versions.
+# https://github.com/ansible-collections/ansible.windows/issues/360
+- name: output primitive types that contains heavily nested ETS properties
+  win_powershell:
+    script: |
+       $noteProp = New-Object -TypeName System.Management.Automation.PSNoteProperty -ArgumentList @(
+          'ETSProp', [type]
+       )
+       $str = "foo" | Write-Output
+       $str.PSObject.Properties.Add($noteProp)
+       $str
+
+       $int = 1 | Write-Output
+       $int.PSObject.Properties.Add($noteProp)
+       $int
+  register: primitive_with_ets
+
+- name: assert output primitive types that contain heavily nested ETS properties
+  assert:
+    that:
+    - primitive_with_ets is changed
+    - primitive_with_ets.error == []
+    - primitive_with_ets.output == ["foo", 1]


### PR DESCRIPTION
##### SUMMARY
This PR will avoid serializing extended type system properties added by PowerShell. This replicates the same behaviour as `ConvertTo-Json` on newer version of PowerShell (7+). This is done for the following reasons:

* Keeps the output object type friendly, most people would expect the primitive type for these cases not a dictionary, e.g. `Get-Content` should return a list of strings not list of dicts
* The ETS prop values would also need to be sterialized to avoid the memory problems when serializing recursive property references or heavily nested values

Fixes https://github.com/ansible-collections/ansible.windows/issues/360

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_powershell