### PR TITLE
win_acl_inheritance - added registry keys support

### DIFF
--- a/changelogs/fragments/win_acl_inheritance-reg-key-sup.yml
+++ b/changelogs/fragments/win_acl_inheritance-reg-key-sup.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_acl_inheritance - support for setting inheritance for registry keys

--- a/plugins/modules/win_acl_inheritance.ps1
+++ b/plugins/modules/win_acl_inheritance.ps1
@@ -1,75 +1,156 @@
 #!powershell
 
+# Copyright: (c) 2022, Oleg Galushko (@inorangestylee)
 # Copyright: (c) 2015, Hans-Joachim Kliemeck <git@kliemeck.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -CSharpUtil Ansible.Basic
 
-$params = Parse-Args $args -supports_check_mode $true
-$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -default $false
-
-$result = @{
-    changed = $false
+$spec = @{
+    options = @{
+        path = @{ type = 'str'; required = $true }
+        reorganize = @{ type = 'bool'; default = $false }
+        state = @{ type = 'str'; default = 'absent'; choices = @('absent', 'present') }
+    }
+    supports_check_mode = $true
 }
 
-$path = Get-AnsibleParam -obj $params "path" -type "path" -failifempty $true
-$state = Get-AnsibleParam -obj $params "state" -type "str" -default "absent" -validateSet "present", "absent" -resultobj $result
-$reorganize = Get-AnsibleParam -obj $params "reorganize" -type "bool" -default $false -resultobj $result
+function Get-AclEx {
+    [CmdletBinding()]
+    [OutputType([System.Security.AccessControl.NativeObjectSecurity])]
+    param(
+        [System.String] $LiteralPath
+    )
 
-If (-Not (Test-Path -LiteralPath $path)) {
-    Fail-Json $result "$path file or directory does not exist on the host"
+    $item = Get-Item -LiteralPath $LiteralPath
+    return $item.GetAccessControl()
 }
 
-Try {
-    $objACL = Get-ACL -LiteralPath $path
-    # AreAccessRulesProtected - $false if inheritance is set ,$true if inheritance is not set
-    $inheritanceDisabled = $objACL.AreAccessRulesProtected
+function Set-AclEx {
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [System.String] $LiteralPath,
+        [System.Security.AccessControl.NativeObjectSecurity] $AclObject
+    )
 
-    If (($state -eq "present") -And $inheritanceDisabled) {
-        # second parameter is ignored if first=$False
-        $objACL.SetAccessRuleProtection($False, $False)
+    $item = Get-Item -LiteralPath $LiteralPath
+    if ($PSCmdlet.ShouldProcess($LiteralPath)) {
+        if ($item.PSProvider.Name -eq 'Registry') {
+            Set-Acl -LiteralPath $LiteralPath -AclObject $AclObject
+        }
+        else {
+            $item.SetAccessControl($AclObject)
+        }
+    }
+    else {
+        Write-Verbose "WhatIf: Performing setting ACL on '$literalPath'"
+    }
+}
 
-        If ($reorganize) {
-            # it wont work without intermediate save, state would be the same
-            Set-ACL -LiteralPath $path -AclObject $objACL -WhatIf:$check_mode
-            $result.changed = $true
-            $objACL = Get-ACL -LiteralPath $path
+function Remove-AclExplicitDuplicate {
+    [CmdletBinding(SupportsShouldProcess)]
+    [OutputType([System.Security.AccessControl.NativeObjectSecurity])]
+    param (
+        [Parameter(Mandatory = $true, ValueFromPipeline = $true)]
+        [System.Security.AccessControl.NativeObjectSecurity] $acl
+    )
 
-            # convert explicit ACE to inherited ACE
-            ForEach ($inheritedRule in $objACL.Access) {
-                If (-not $inheritedRule.IsInherited) {
-                    Continue
-                }
+    Begin {}
 
-                ForEach ($explicitRrule in $objACL.Access) {
-                    If ($explicitRrule.IsInherited) {
-                        Continue
+    Process {
+        $properties = $acl.Access |
+            Get-Member -MemberType Property |
+            Where-Object { $_.Name -ne 'IsInherited' } |
+            Select-Object -ExpandProperty Name
+
+        ForEach ($inheritedRule in $($acl.Access | Where-Object { $_.IsInherited })) {
+            ForEach ($explicitRule in $($acl.Access | Where-Object { -not $_.IsInherited })) {
+                If ($null -eq (Compare-Object -ReferenceObject $explicitRule -DifferenceObject $inheritedRule -Property $properties)) {
+                    if ($PSCmdlet.ShouldProcess($acl)) {
+                        $acl.RemoveAccessRule($explicitRule)
                     }
-
-                    If (
-                        ($inheritedRule.FileSystemRights -eq $explicitRrule.FileSystemRights) -And
-                        ($inheritedRule.AccessControlType -eq $explicitRrule.AccessControlType) -And
-                        ($inheritedRule.IdentityReference -eq $explicitRrule.IdentityReference) -And
-                        ($inheritedRule.InheritanceFlags -eq $explicitRrule.InheritanceFlags) -And
-                        ($inheritedRule.PropagationFlags -eq $explicitRrule.PropagationFlags)
-                    ) {
-                        $objACL.RemoveAccessRule($explicitRrule)
+                    else {
+                        Write-Verbose "WhatIf: Performing remove explicit duplicate rule: $explicitRule"
                     }
                 }
             }
         }
+        return $acl
+    }
 
-        Set-ACL -LiteralPath $path -AclObject $objACL -WhatIf:$check_mode
-        $result.changed = $true
-    }
-    Elseif (($state -eq "absent") -And (-not $inheritanceDisabled)) {
-        $objACL.SetAccessRuleProtection($True, $reorganize)
-        Set-ACL -LiteralPath $path -AclObject $objACL -WhatIf:$check_mode
-        $result.changed = $true
-    }
-}
-Catch {
-    Fail-Json $result "an error occurred when attempting to disable inheritance: $($_.Exception.Message)"
+    End {}
 }
 
-Exit-Json $result
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$path = $module.Params.path
+$reorganize = $module.Params.reorganize
+$state = $module.Params.state
+$check_mode = $module.CheckMode
+
+$module.Result.changed = $false
+
+$pathQualifier = Split-Path -Path $path -Qualifier -ErrorAction SilentlyContinue
+
+if ($pathQualifier -eq 'HKCR:' -and (-not (Test-Path -LiteralPath HKCR:\))) {
+    $null = New-PSDrive -Name HKCR -PSProvider Registry -Root HKEY_CLASSES_ROOT
+}
+if ($pathQualifier -eq 'HKU:' -and (-not (Test-Path -LiteralPath HKU:\))) {
+    $null = New-PSDrive -Name HKU -PSProvider Registry -Root HKEY_USERS
+}
+if ($pathQualifier -eq 'HKCC:' -and (-not (Test-Path -LiteralPath HKCC:\))) {
+    $null = New-PSDrive -Name HKCC -PSProvider Registry -Root HKEY_CURRENT_CONFIG
+}
+
+If (-Not (Test-Path -LiteralPath $path)) {
+    $module.FailJson("$path does not exist")
+}
+
+try {
+    $acl = Get-AclEx -LiteralPath $path
+}
+catch {
+    $module.FailJson($_.ToString())
+}
+
+$module.Diff.before = @{ access_rules_protected = $acl.AreAccessRulesProtected }
+
+If (($state -eq 'present') -and $acl.AreAccessRulesProtected) {
+    try {
+        $acl.SetAccessRuleProtection($false, $false)
+    }
+    catch {
+        $module.FailJson($_.ToString())
+    }
+    if ($reorganize) {
+        Set-AclEx -LiteralPath $path -AclObject $acl -WhatIf:$check_mode
+        $acl = Remove-AclExplicitDuplicate($acl)
+    }
+    Set-AclEx -LiteralPath $path -AclObject $acl -WhatIf:$check_mode
+    $module.Result.changed = $true
+}
+
+if (($state -eq 'absent') -and (-not $acl.AreAccessRulesProtected)) {
+    try {
+        $acl.SetAccessRuleProtection($true, $reorganize)
+    }
+    catch {
+        $module.FailJson($_.ToString())
+    }
+    Set-AclEx -LiteralPath $path -AclObject $acl -WhatIf:$check_mode
+    $module.Result.changed = $true
+}
+
+if (-not $check_mode) {
+    try {
+        $acl = Get-AclEx -LiteralPath $path
+    }
+    catch {
+        $module.FailJson($_.ToString())
+    }
+}
+
+$module.Diff.after = @{ access_rules_protected = $acl.AreAccessRulesProtected }
+$module.Result.access_rules_protected = $acl.AreAccessRulesProtected
+
+$module.ExitJson()

--- a/plugins/modules/win_acl_inheritance.py
+++ b/plugins/modules/win_acl_inheritance.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# Copyright: (c) 2022, Oleg Galushko (@inorangestylee)
 # Copyright: (c) 2015, Hans-Joachim Kliemeck <git@kliemeck.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -14,8 +15,8 @@ options:
   path:
     description:
       - Path to be used for changing inheritance
-    required: yes
-    type: path
+    required: true
+    type: str
   state:
     description:
       - Specify whether to enable I(present) or disable I(absent) ACL inheritance.
@@ -24,17 +25,18 @@ options:
     default: absent
   reorganize:
     description:
-      - For P(state) = I(absent), indicates if the inherited ACE's should be copied from the parent directory.
+      - For P(state) = I(absent), indicates if the inherited ACE's should be copied from the parent.
         This is necessary (in combination with removal) for a simple ACL instead of using multiple ACE deny entries.
-      - For P(state) = I(present), indicates if the inherited ACE's should be deduplicated compared to the parent directory.
+      - For P(state) = I(present), indicates if the inherited ACE's should be deduplicated compared to the parent.
         This removes complexity of the ACL structure.
     type: bool
-    default: no
+    default: false
 seealso:
 - module: ansible.windows.win_acl
 - module: ansible.windows.win_file
 - module: ansible.windows.win_stat
 author:
+- Oleg Galushko (@inorangestylee)
 - Hans-Joachim Kliemeck (@h0nIg)
 '''
 
@@ -48,15 +50,36 @@ EXAMPLES = r'''
   ansible.windows.win_acl_inheritance:
     path: C:\apache
     state: absent
-    reorganize: yes
+    reorganize: true
 
 - name: Enable and remove dedicated ACE's
   ansible.windows.win_acl_inheritance:
     path: C:\apache
     state: present
-    reorganize: yes
+    reorganize: true
+
+- name: Disable registry key inherited ACE's
+  ansible.windows.win_acl_inheritance:
+    path: HKLM:\SOFTWARE\Secrets
+    state: absent
+
+- name: Disable and copy registry key inherited ACE's
+  ansible.windows.win_acl_inheritance:
+    path: HKLM:\SOFTWARE\Secrets
+    state: absent
+    reorganize: true
+
+- name: Enable and remove registry key dedicated ACE's
+  ansible.windows.win_acl_inheritance:
+    path: HKLM:\SOFTWARE\Secrets
+    state: present
+    reorganize: true
 '''
 
 RETURN = r'''
-
+access_rules_protected:
+  description: Are access rules protected from inheritance.
+  returned: success
+  type: bool
+  sample: True
 '''

--- a/plugins/modules/win_acl_inheritance.py
+++ b/plugins/modules/win_acl_inheritance.py
@@ -15,6 +15,7 @@ options:
   path:
     description:
       - Path to be used for changing inheritance
+      - Support for registry keys have been added in C(ansible.windows>=1.11.0)
     required: true
     type: str
   state:
@@ -77,9 +78,5 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-access_rules_protected:
-  description: Are access rules protected from inheritance.
-  returned: success
-  type: bool
-  sample: True
+
 '''

--- a/tests/integration/targets/win_acl_inheritance/defaults/main.yml
+++ b/tests/integration/targets/win_acl_inheritance/defaults/main.yml
@@ -1,1 +1,3 @@
+---
 test_win_acl_inheritance_path: C:\ansible\win_acl_inheritance .ÅÑŚÌβŁÈ [$!@^&test(;)]
+test_win_acl_inheritance_registry_path: HKU:\.DEFAULT\Ansible Test .ÅÑŚÌβŁÈ [$!@^&test(;)]

--- a/tests/integration/targets/win_acl_inheritance/tasks/main.yml
+++ b/tests/integration/targets/win_acl_inheritance/tasks/main.yml
@@ -2,14 +2,13 @@
 # Test setup
 # Use single task to save in CI runtime
 - name: create test folders
-  win_shell: |
+  ansible.windows.win_shell: |
     $ErrorActionPreference = 'Stop'
-
     $tmp_dir = '{{ test_win_acl_inheritance_path }}'
     if (Test-Path -LiteralPath $tmp_dir) {
         Remove-Item -LiteralPath $tmp_dir -Force -Recurse
     }
-    New-Item -Path $tmp_dir -ItemType Directory > $null
+    $null = New-Item -Path $tmp_dir -ItemType Directory
 
     Add-Type -AssemblyName System.DirectoryServices.AccountManagement
     $current_sid = ([System.DirectoryServices.AccountManagement.UserPrincipal]::Current).Sid
@@ -48,7 +47,7 @@
 
     Set-Acl -LiteralPath $tmp_dir -AclObject $sd
 
-    New-Item -Path "$tmp_dir\folder" -ItemType Directory > $null
+    $null = New-Item -Path "$tmp_dir\folder" -ItemType Directory
     Set-Content -LiteralPath "$tmp_dir\folder\file.txt" -Value 'a'
 
     $system_sid.Value
@@ -56,22 +55,89 @@
     $everyone_sid.Value
   register: test_sids  # register the output SID values used for comparison tests below
 
+- name: create test registry key
+  ansible.windows.win_shell: |
+    $ErrorActionPreference = 'Stop'
+    $tmp_dir = '{{ test_win_acl_inheritance_registry_path }}'
+    $regeditHives = @{
+        "HKCR" = "HKEY_CLASSES_ROOT"
+        "HKU" = "HKEY_USERS"
+        "HKCC" = "HKEY_CURRENT_CONFIG"
+    }
+
+    $pathQualifier = Split-Path -Path $tmp_dir -Qualifier -ErrorAction SilentlyContinue
+    $pathQualifier = $pathQualifier.Replace(':','')
+
+    if ($pathQualifier -in $regeditHives.Keys -and (-not (Test-Path -LiteralPath "${pathQualifier}:\"))) {
+        $null = New-PSDrive -Name $pathQualifier -PSProvider 'Registry' -Root $regeditHives.$pathQualifier
+    }
+
+    Push-Location -Path "${pathQualifier}:\"
+    if (Test-Path -LiteralPath $tmp_dir) {
+        Remove-Item -LiteralPath $tmp_dir -Force -Recurse
+    }
+    $null = New-Item -Path $tmp_dir
+
+    Add-Type -AssemblyName System.DirectoryServices.AccountManagement
+    $current_sid = ([System.DirectoryServices.AccountManagement.UserPrincipal]::Current).Sid
+    $system_sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList @([System.Security.Principal.WellKnownSidType]::LocalSystemSid, $null)
+    $everyone_sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList @([System.Security.Principal.WellKnownSidType]::WorldSid, $null)
+
+    $sd = New-Object -TypeName System.Security.AccessControl.RegistrySecurity
+    $sd.SetAccessRuleProtection($true, $false)
+    $sd.AddAccessRule(
+        (New-Object -TypeName System.Security.AccessControl.RegistryAccessRule -ArgumentList @(
+            $system_sid,
+            [System.Security.AccessControl.RegistryRights]::FullControl,
+            [System.Security.AccessControl.InheritanceFlags]"ContainerInherit, ObjectInherit",
+            [System.Security.AccessControl.PropagationFlags]::None,
+            [System.Security.AccessControl.AccessControlType]::Allow
+        ))
+    )
+    $sd.AddAccessRule(
+        (New-Object -TypeName System.Security.AccessControl.RegistryAccessRule -ArgumentList @(
+            $current_sid,
+            [System.Security.AccessControl.RegistryRights]::FullControl,
+            [System.Security.AccessControl.InheritanceFlags]"ContainerInherit, ObjectInherit",
+            [System.Security.AccessControl.PropagationFlags]::None,
+            [System.Security.AccessControl.AccessControlType]::Allow
+        ))
+    )
+    $sd.AddAccessRule(
+        (New-Object -TypeName System.Security.AccessControl.RegistryAccessRule -ArgumentList @(
+            $everyone_sid,
+            [System.Security.AccessControl.RegistryRights]::ReadKey,
+            [System.Security.AccessControl.InheritanceFlags]"ContainerInherit, ObjectInherit",
+            [System.Security.AccessControl.PropagationFlags]::None,
+            [System.Security.AccessControl.AccessControlType]::Allow
+        ))
+    )
+
+    Set-Acl -LiteralPath $tmp_dir -AclObject $sd
+
+    $null = New-Item -Path "$tmp_dir\folder"
+
+    $system_sid.Value
+    $current_sid.Value
+    $everyone_sid.Value
+  register: test_registry_sids  # register the output SID values used for comparison tests below
+
 # Run tests
-- name: remove inheritance check
-  win_acl_inheritance:
+- name: (folder) remove inheritance check
+  ansible.windows.win_acl_inheritance:
     path: '{{ test_win_acl_inheritance_path }}\folder'
     reorganize: True
     state: absent
   register: remove_check
   check_mode: True
 
-- name: get actual remove inheritance check
+- name: (folder) get actual remove inheritance check
   test_get_acl:
     path: '{{ test_win_acl_inheritance_path }}\folder'
   register: actual_remove_check
 
-- name: assert remove inheritance check
-  assert:
+- name: (folder) assert remove inheritance check
+  ansible.builtin.assert:
     that:
     - remove_check is changed
     - actual_remove_check.inherited == True
@@ -79,20 +145,20 @@
     - actual_remove_check.user_details[test_sids.stdout_lines[1]].isinherited == True
     - actual_remove_check.user_details[test_sids.stdout_lines[2]].isinherited == True
 
-- name: remove inheritance
-  win_acl_inheritance:
+- name: (folder) remove inheritance
+  ansible.windows.win_acl_inheritance:
     path: '{{ test_win_acl_inheritance_path }}\folder'
     reorganize: True
     state: absent
   register: remove
 
-- name: get actual remove inheritance
+- name: (folder) get actual remove inheritance
   test_get_acl:
     path: '{{ test_win_acl_inheritance_path }}\folder'
   register: actual_remove
 
-- name: assert remove inheritance
-  assert:
+- name: (folder) assert remove inheritance
+  ansible.builtin.assert:
     that:
     - remove is changed
     - actual_remove.inherited == False
@@ -100,33 +166,33 @@
     - actual_remove.user_details[test_sids.stdout_lines[1]].isinherited == False
     - actual_remove.user_details[test_sids.stdout_lines[2]].isinherited == False
 
-- name: remove inheritance again
-  win_acl_inheritance:
+- name: (folder) remove inheritance again
+  ansible.windows.win_acl_inheritance:
     path: '{{ test_win_acl_inheritance_path }}\folder'
     reorganize: True
     state: absent
   register: remove_again
 
-- name: assert remove inheritance again
-  assert:
+- name: (folder) assert remove inheritance again
+  ansible.builtin.assert:
     that:
     - remove_again is not changed
 
-- name: add inheritance check
-  win_acl_inheritance:
+- name: (folder) add inheritance check
+  ansible.windows.win_acl_inheritance:
     path: '{{ test_win_acl_inheritance_path }}\folder'
     reorganize: True
     state: present
   register: add_check
   check_mode: True
 
-- name: get actual add inheritance check
+- name: (folder) get actual add inheritance check
   test_get_acl:
     path: '{{ test_win_acl_inheritance_path }}\folder'
   register: actual_add_check
 
-- name: assert add inheritance check
-  assert:
+- name: (folder) assert add inheritance check
+  ansible.builtin.assert:
     that:
     - add_check is changed
     - actual_add_check.inherited == False
@@ -134,20 +200,20 @@
     - actual_add_check.user_details[test_sids.stdout_lines[1]].isinherited == False
     - actual_add_check.user_details[test_sids.stdout_lines[2]].isinherited == False
 
-- name: add inheritance
-  win_acl_inheritance:
+- name: (folder) add inheritance
+  ansible.windows.win_acl_inheritance:
     path: '{{ test_win_acl_inheritance_path }}\folder'
     reorganize: True
     state: present
   register: add
 
-- name: get actual add inheritance
+- name: (folder) get actual add inheritance
   test_get_acl:
     path: '{{ test_win_acl_inheritance_path }}\folder'
   register: actual_add
 
-- name: assert add inheritance
-  assert:
+- name: (folder) assert add inheritance
+  ansible.builtin.assert:
     that:
     - add is changed
     - actual_add.inherited == True
@@ -155,20 +221,137 @@
     - actual_add.user_details[test_sids.stdout_lines[1]].isinherited == True
     - actual_add.user_details[test_sids.stdout_lines[2]].isinherited == True
 
-- name: add inheritance again
-  win_acl_inheritance:
+- name: (folder) add inheritance again
+  ansible.windows.win_acl_inheritance:
     path: '{{ test_win_acl_inheritance_path }}\folder'
     reorganize: True
     state: present
   register: add_again
 
-- name: assert add inheritance again
-  assert:
+- name: (folder) assert add inheritance again
+  ansible.builtin.assert:
     that:
     - add_again is not changed
 
+# registry
+
+- name: (registry) remove inheritance check
+  ansible.windows.win_acl_inheritance:
+    path: '{{ test_win_acl_inheritance_registry_path }}\folder'
+    reorganize: True
+    state: absent
+  register: registry_remove_check
+  check_mode: True
+
+- name: (registry) get actual remove inheritance check
+  test_get_acl:
+    path: '{{ test_win_acl_inheritance_registry_path }}\folder'
+  register: actual_registry_remove_check
+
+- name: (registry) assert remove inheritance check
+  ansible.builtin.assert:
+    that:
+    - registry_remove_check is changed
+    - actual_registry_remove_check.inherited == True
+    - actual_registry_remove_check.user_details[test_sids.stdout_lines[0]].isinherited == True
+    - actual_registry_remove_check.user_details[test_sids.stdout_lines[1]].isinherited == True
+    - actual_registry_remove_check.user_details[test_sids.stdout_lines[2]].isinherited == True
+
+- name: (registry) remove inheritance
+  ansible.windows.win_acl_inheritance:
+    path: '{{ test_win_acl_inheritance_registry_path }}\folder'
+    reorganize: True
+    state: absent
+  register: registry_remove
+
+- name: (registry) get actual remove inheritance
+  test_get_acl:
+    path: '{{ test_win_acl_inheritance_registry_path }}\folder'
+  register: actual_registry_remove
+
+- name: (registry) assert remove inheritance
+  ansible.builtin.assert:
+    that:
+    - registry_remove is changed
+    - actual_registry_remove.inherited == False
+    - actual_registry_remove.user_details[test_sids.stdout_lines[0]].isinherited == False
+    - actual_registry_remove.user_details[test_sids.stdout_lines[1]].isinherited == False
+    - actual_registry_remove.user_details[test_sids.stdout_lines[2]].isinherited == False
+
+- name: (registry) remove inheritance again
+  ansible.windows.win_acl_inheritance:
+    path: '{{ test_win_acl_inheritance_registry_path }}\folder'
+    reorganize: True
+    state: absent
+  register: registry_remove_again
+
+- name: (registry) assert remove inheritance again
+  ansible.builtin.assert:
+    that:
+    - registry_remove_again is not changed
+
+- name: (registry) add inheritance check
+  ansible.windows.win_acl_inheritance:
+    path: '{{ test_win_acl_inheritance_registry_path }}\folder'
+    reorganize: True
+    state: present
+  register: registry_add_check
+  check_mode: True
+
+- name: (registry) get actual add inheritance check
+  test_get_acl:
+    path: '{{ test_win_acl_inheritance_registry_path }}\folder'
+  register: actual_registry_add_check
+
+- name: (registry) assert add inheritance check
+  ansible.builtin.assert:
+    that:
+    - registry_add_check is changed
+    - actual_registry_add_check.inherited == False
+    - actual_registry_add_check.user_details[test_sids.stdout_lines[0]].isinherited == False
+    - actual_registry_add_check.user_details[test_sids.stdout_lines[1]].isinherited == False
+    - actual_registry_add_check.user_details[test_sids.stdout_lines[2]].isinherited == False
+
+- name: (registry) add inheritance
+  ansible.windows.win_acl_inheritance:
+    path: '{{ test_win_acl_inheritance_registry_path }}\folder'
+    reorganize: True
+    state: present
+  register: registry_add
+
+- name: (registry) get actual add inheritance
+  test_get_acl:
+    path: '{{ test_win_acl_inheritance_registry_path }}\folder'
+  register: actual_registry_add
+
+- name: (registry) assert add inheritance
+  ansible.builtin.assert:
+    that:
+    - registry_add is changed
+    - actual_registry_add.inherited == True
+    - actual_registry_add.user_details[test_sids.stdout_lines[0]].isinherited == True
+    - actual_registry_add.user_details[test_sids.stdout_lines[1]].isinherited == True
+    - actual_registry_add.user_details[test_sids.stdout_lines[2]].isinherited == True
+
+- name: (registry) add inheritance again
+  ansible.windows.win_acl_inheritance:
+    path: '{{ test_win_acl_inheritance_registry_path }}\folder'
+    reorganize: True
+    state: present
+  register: registry_add_again
+
+- name: (registry) assert add inheritance again
+  ansible.builtin.assert:
+    that:
+    - registry_add_again is not changed
+
 # Test cleanup
 - name: remove test folder
-  win_file:
+  ansible.windows.win_file:
     path: '{{ test_win_acl_inheritance_path }}'
+    state: absent
+
+- name: remove test registry key
+  ansible.windows.win_regedit:
+    path: '{{ test_win_acl_inheritance_registry_path }}'
     state: absent


### PR DESCRIPTION
##### SUMMARY
Unfortunately, this module does not support changing the inheritance of registry keys. There are several reasons for this:

- use of the `path` type for the `path` parameter, which does not work with registry keys. (Has been replaced by `str`)
- use of `LiteralPath` parameter which does not work correctly with registry paths in Powershell 5.1 and was fixed in https://github.com/PowerShell/PowerShell/issues/11566 (was replaced by `Path`).

Changes here:
- registry path support added
- refactored from legacy to modern module style
- 'try-catch' block redesigned to handle errors of specific calls
- redesigned inheritance and explicit rules equality check

*No breaking changes. No need to rewrite playbooks*

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

win_acl_inheritance