### PR TITLE
win_stat - add get_size to control size calculation

### DIFF
--- a/changelogs/fragments/win_stat-get-size.yml
+++ b/changelogs/fragments/win_stat-get-size.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_stat - Added ``get_size`` to control whether ``win_stat`` will calculate the size of files or directories - https://github.com/ansible-collections/ansible.windows/issues/384

--- a/plugins/modules/win_stat.py
+++ b/plugins/modules/win_stat.py
@@ -24,6 +24,12 @@ options:
             - Whether to return a checksum of the file (default sha1)
         type: bool
         default: yes
+    get_size:
+        description:
+            - Whether to return the size of a file or directory.
+        type: bool
+        default: yes
+        version_added: '1.11.0'
     checksum_algorithm:
         description:
             - Algorithm to determine checksum of file.
@@ -219,7 +225,7 @@ stat:
             sample: file-share
         size:
             description: The size in bytes of a file or folder.
-            returned: success, path exists, file is not a link
+            returned: success, path exists, file is not a link, get_size == True
             type: int
             sample: 1024
 '''

--- a/tests/integration/targets/win_stat/tasks/tests.yml
+++ b/tests/integration/targets/win_stat/tasks/tests.yml
@@ -557,6 +557,30 @@
     - pagefile_stat.stat.exists == True
   when: pagefile_path.stdout_lines|count != 0
 
+- name: get stat of dir without size
+  win_stat:
+    path: '{{ win_stat_dir }}\nested'
+    get_size: False
+  register: win_stat_no_size_dir
+
+- name: assert get stat of dir without size
+  assert:
+    that:
+    - win_stat_no_size_dir.stat.exists
+    - '"size" not in win_stat_no_size_dir.stat'
+
+- name: get stat of file without size
+  win_stat:
+    path: '{{ win_stat_dir }}\nested\file.ps1'
+    get_size: False
+  register: win_stat_no_size_file
+
+- name: assert get stat of file without size
+  assert:
+    that:
+    - win_stat_no_size_file.stat.exists
+    - '"size" not in win_stat_no_size_file.stat'
+
 # Tests with normal user
 - set_fact:
     gen_pw: password123! + {{ lookup('password', '/dev/null chars=ascii_letters,digits length=8') }}


### PR DESCRIPTION
##### SUMMARY
Adds the `get_size` option to `win_stat` to control whether the size will be calculated or not. Defaults to `true` to preserve existing behaviour.

Fixes https://github.com/ansible-collections/ansible.windows/issues/384

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_stat