### PR TITLE
Fixed Direcotry typo in examples

### DIFF
--- a/plugins/modules/win_powershell.py
+++ b/plugins/modules/win_powershell.py
@@ -123,7 +123,7 @@ EXAMPLES = r'''
           $Force
       )
 
-      New-Item -Path $Path -ItemType Direcotry -Force:$Force
+      New-Item -Path $Path -ItemType Directory -Force:$Force
     parameters:
       Path: C:\temp
       Force: true


### PR DESCRIPTION
##### SUMMARY

Example PowerShell code in win_powershell.py has "New-Item -Path $Path -ItemType Direcotry -Force:$Force" which will throw an error

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

win_powershell

##### ADDITIONAL INFORMATION

