### PR TITLE
win_copy - fix error message with controller src lookup

### DIFF
--- a/changelogs/fragments/win_copy-src-err.yml
+++ b/changelogs/fragments/win_copy-src-err.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_copy - Fix error message when failing to find ``src`` on the controller filesystem

--- a/plugins/action/win_copy.py
+++ b/plugins/action/win_copy.py
@@ -442,7 +442,7 @@ class ActionModule(ActionBase):
                 source_full = self._loader.get_real_file(source, decrypt=decrypt)
             except AnsibleFileNotFound as e:
                 result['failed'] = True
-                result['msg'] = "could not find src=%s, %s" % (source_full, to_text(e))
+                result['msg'] = "could not find src=%s, %s" % (source, to_text(e))
                 return result
 
             original_basename = os.path.basename(source)


### PR DESCRIPTION
##### SUMMARY
The `source_full` wasn't defined yet causing an error when `source` was not found on the controller. The error message should contain the original raw value in the msg.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_copy