### PR TITLE
win_command - fix exe lookup when located twice in PATH

### DIFF
--- a/changelogs/fragments/win_command-PATH.yml
+++ b/changelogs/fragments/win_command-PATH.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_command - Fix bug that stopped win_command from finding executables that are located more than once in ``PATH`` - https://github.com/ansible-collections/ansible.windows/issues/403

--- a/plugins/module_utils/Process.psm1
+++ b/plugins/module_utils/Process.psm1
@@ -24,9 +24,9 @@ Function Resolve-ExecutablePath {
 
     # See the if path is resolvable using the normal PATH logic. Also resolves absolute paths and relative paths if
     # they exist.
-    $command = Get-Command -Name $FilePath -CommandType Application -ErrorAction SilentlyContinue
+    $command = @(Get-Command -Name $FilePath -CommandType Application -ErrorAction SilentlyContinue)
     if ($command) {
-        $command.Path
+        $command[0].Path
         return
     }
 
@@ -239,7 +239,7 @@ Function Start-AnsibleWindowsProcess {
     }
 }
 
-$export_members = @{
+$exportMembers = @{
     Function = 'ConvertFrom-EscapedArgument', 'ConvertTo-EscapedArgument', 'Resolve-ExecutablePath', 'Start-AnsibleWindowsProcess'
 }
-Export-ModuleMember @export_members
+Export-ModuleMember @exportMembers

--- a/tests/integration/targets/module_utils_Process/library/process_pwsh_tests.ps1
+++ b/tests/integration/targets/module_utils_Process/library/process_pwsh_tests.ps1
@@ -285,8 +285,8 @@ exit 1
             New-Item -Path $path2 -ItemType Directory | Out-Null
             $env:PATH = "$path1;$path2"
 
-            Copy-Item C:\Windows\System32\whoami.exe $path1
-            Copy-Item C:\Windows\System32\whoami.exe $path2
+            Copy-Item -LiteralPath C:\Windows\System32\whoami.exe -Destination $path1
+            Copy-Item -LiteralPath C:\Windows\System32\whoami.exe -Destination $path2
 
             $actual = Start-AnsibleWindowsProcess -CommandLine 'whoami'
             $actual.ExitCode | Assert-Equal -Expected 0

--- a/tests/integration/targets/module_utils_Process/library/process_pwsh_tests.ps1
+++ b/tests/integration/targets/module_utils_Process/library/process_pwsh_tests.ps1
@@ -274,6 +274,27 @@ exit 1
         }
         $time.TotalSeconds -ge 2 | Assert-Equal -Expected $true
     }
+
+    "Start-AnsibleWindowsProcess with exe in multiple PATH locations" = {
+        # https://github.com/ansible-collections/ansible.windows/issues/403
+        $originalPath = $env:PATH
+        try {
+            $path1 = Join-Path $module.TmpDir 'path1'
+            New-Item -Path $path1 -ItemType Directory | Out-Null
+            $path2 = Join-Path $module.TmpDir 'path2'
+            New-Item -Path $path2 -ItemType Directory | Out-Null
+            $env:PATH = "$path1;$path2"
+
+            Copy-Item C:\Windows\System32\whoami.exe $path1
+            Copy-Item C:\Windows\System32\whoami.exe $path2
+
+            $actual = Start-AnsibleWindowsProcess -CommandLine 'whoami'
+            $actual.ExitCode | Assert-Equal -Expected 0
+        }
+        finally {
+            $env:PATH = $originalPath
+        }
+    }
 }
 
 # Add argv <-> argc tests

--- a/tests/integration/targets/win_command/tasks/main.yml
+++ b/tests/integration/targets/win_command/tasks/main.yml
@@ -344,3 +344,45 @@
     - cmdout.rc == 0
     - cmdout.cmd == win_printargv_path ~ ' testing'
     - cmdout_argv.args[0] == 'testing'
+
+- name: create 2 dirs to contain the same executable
+  win_file:
+    path: '{{ remote_tmp_dir }}\{{ item }}'
+    state: directory
+  loop:
+  - path1
+  - path2
+
+- name: copy printargv to 2 dirs
+  win_copy:
+    src: '{{ win_printargv_path }}'
+    dest: '{{ remote_tmp_dir }}\{{ item }}\printargv.exe'
+    remote_src: true
+  loop:
+  - path1
+  - path2
+
+- name: run exe that is located in 2 PATH directories
+  win_command: printargv test
+  environment:
+    PATH: '{{ remote_tmp_dir }}\path1;{{ remote_tmp_dir }}\path2'
+  register: cmdout
+
+- name: assert call to run exe that is located in 2 PATH directories
+  assert:
+    that:
+    - cmdout.rc == 0
+
+- name: run exe that is located in 2 PATH directories with argv
+  win_command:
+    argv:
+    - printargv
+    - test
+  environment:
+    PATH: '{{ remote_tmp_dir }}\path1;{{ remote_tmp_dir }}\path2'
+  register: cmdout
+
+- name: assert call to run exe that is located in 2 PATH directories with argv
+  assert:
+    that:
+    - cmdout.rc == 0


### PR DESCRIPTION
##### SUMMARY
The output of `Get-Command` shows all the results of a command if it's located more than once in the `PATH` which caused problems later on when building the exe to run. Change to code to always run with the first result found rather than the failure that happens today.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/403

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_command