### PR TITLE
win_updates - fix incorrect API call with overloads

### DIFF
--- a/changelogs/fragments/win_updates-write-log-arg.yml
+++ b/changelogs/fragments/win_updates-write-log-arg.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_updates - Fix broken call when logging a warning about updates with errors - https://github.com/ansible-collections/ansible.windows/issues/411

--- a/plugins/modules/win_updates.ps1
+++ b/plugins/modules/win_updates.ps1
@@ -1314,8 +1314,8 @@ namespace Ansible.Windows.WinUpdates
             $warning = $searchResult.Warnings.Item($i)
 
             $warningContext = [Ansible.Windows.WinUpdates.UpdateExceptionContext]$warning.Context
-            $api.WriteLog("Search warning {0} - Context {1} - HResult 0x{2:X8} - Message: {3}",
-                $i, $warningContext, $warning.HResult, $warning.Message)
+            $api.WriteLog(("Search warning {0} - Context {1} - HResult 0x{2:X8} - Message: {3}" -f
+                    $i, $warningContext, $warning.HResult, $warning.Message))
         }
     }
     elseif ($resCode -ne 'Succeeded') {


### PR DESCRIPTION
##### SUMMARY
The string needs to be formatted with `-f` and not get passed in as an array like `[string]::Format(...)`.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/411

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_updates