### PR TITLE
Add support to apply ACL to Junctions 

### DIFF
--- a/changelogs/fragments/win_acl_follow.yml
+++ b/changelogs/fragments/win_acl_follow.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - win_acl Let the ability to follow the symlinks and junctions before applying ACLs to change the target instead of the link
+- win_acl - Added the ``follow`` parameter with will follow the symlinks and junctions before applying ACLs to change the target instead of the link

--- a/changelogs/fragments/win_acl_follow.yml
+++ b/changelogs/fragments/win_acl_follow.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - win_acl Let the ability to follow the symlinks and junctions before applying ACLs to change the target instead of the link

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -94,7 +94,7 @@ $follow_links = $True
 $path = Resolve-Path $path
 Do {
     $PathDetails = Get-ItemProperty -LiteralPath $path
-    if ($PathDetails.Target.GetType().Name -eq "String[]" -and $follow_links) {
+    if ($PathDetails.Target -and $PathDetails.Target.GetType().Name -eq "String[]" -and $follow_links) {
         $path = "\\?\$($PathDetails.Target.Get(0))"
     }
 } While($PathDetails.LinkType)

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -109,7 +109,8 @@ $path = Resolve-Path -LiteralPath $path
 while ($follow) {
     try {
         $link_info = Get-Link -Path $path
-    } catch {
+    }
+    catch {
         $link_info = $null
     }
 

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -97,7 +97,7 @@ Do {
     if ($PathDetails.Target -and $PathDetails.Target.GetType().Name -eq "String[]" -and $follow_links) {
         $path = "\\?\$($PathDetails.Target.Get(0))"
     }
-} While($PathDetails.LinkType)
+} While ($PathDetails.LinkType)
 
 # We mount the HKCR, HKU, and HKCC registry hives so PS can access them.
 # Network paths have no qualifiers so we use -EA SilentlyContinue to ignore that

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -91,7 +91,6 @@ $inherit = Get-AnsibleParam -obj $params -name "inherit" -type "str"
 $propagation = Get-AnsibleParam -obj $params -name "propagation" -type "str" -default "None" -validateset "InheritOnly", "None", "NoPropagateInherit"
 $follow_links = $True
 
-# OL Fix to change permissions following links
 $path = Resolve-Path $path
 Do {
     $PathDetails = Get-ItemProperty -LiteralPath $path

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -91,7 +91,7 @@ $inherit = Get-AnsibleParam -obj $params -name "inherit" -type "str"
 $propagation = Get-AnsibleParam -obj $params -name "propagation" -type "str" -default "None" -validateset "InheritOnly", "None", "NoPropagateInherit"
 $follow_links = $True
 
-$path = Resolve-Path $path
+$path = Resolve-Path -LiteralPath $path
 Do {
     $PathDetails = Get-ItemProperty -LiteralPath $path
     if ($PathDetails.Target -and $PathDetails.Target.GetType().Name -eq "String[]" -and $follow_links) {

--- a/plugins/modules/win_acl.py
+++ b/plugins/modules/win_acl.py
@@ -67,9 +67,10 @@ options:
     default: "None"
   follow:
     description:
-    - Follow the symlinks and junctions to apply the ACLs to the target instead of the link
+    - Follow the symlinks and junctions to apply the ACLs to the target instead of the link.
     type: bool
-    default: true
+    default: false
+    version_added: 1.12.0
 notes:
 - If adding ACL's for AppPool identities, the Windows Feature "Web-Scripting-Tools" must be enabled.
 seealso:

--- a/plugins/modules/win_acl.py
+++ b/plugins/modules/win_acl.py
@@ -65,6 +65,11 @@ options:
     type: str
     choices: [ InheritOnly, None, NoPropagateInherit ]
     default: "None"
+  follow:
+    description:
+    - Follow the symlinks and junctions to apply the ACLs to the target instead of the link
+    type: bool
+    default: true
 notes:
 - If adding ACL's for AppPool identities, the Windows Feature "Web-Scripting-Tools" must be enabled.
 seealso:

--- a/tests/integration/targets/win_acl/tasks/main.yml
+++ b/tests/integration/targets/win_acl/tasks/main.yml
@@ -17,6 +17,23 @@
   - present
 
 - block:
+  - name: create test dir for link target
+    win_file:
+      path: '{{ test_acl_path }}\target'
+      state: directory
+
+  - name: create symlinks in test dir
+    win_powershell:
+      script: |
+        param (
+            [string]$Path
+        )
+
+        cmd.exe /c mklink /J "$Path\junction" "$Path\target"
+        cmd.exe /c mklink /D "$Path\symlink" "$Path\junction"
+      parameters:
+        Path: '{{ test_acl_path }}'
+
   - name: run tests
     include_tasks: tests.yml
 

--- a/tests/integration/targets/win_acl/tasks/tests.yml
+++ b/tests/integration/targets/win_acl/tasks/tests.yml
@@ -213,6 +213,76 @@
     - remove_right is changed
     - remove_right_actual.stdout_lines == ["[", "", "]"]
 
+- name: add right to symlink without follow
+  win_acl:
+    path: '{{ test_acl_path }}\symlink'
+    type: allow
+    user: Guests
+    rights: Write
+  register: allow_not_follow
+
+- name: get result of add right to symlink without follow on symlink
+  win_shell: '$path = ''{{ test_acl_path }}\symlink''; {{ test_ace_cmd }}'
+  register: allow_not_follow_symlink
+
+- name: get result of add right to symlink without follow on symlink
+  win_shell: '$path = ''{{ test_acl_path }}\target''; {{ test_ace_cmd }}'
+  register: allow_not_follow_target
+
+- name: assert add write rights to Guest - network
+  assert:
+    that:
+    - allow_not_follow is changed
+    - (allow_not_follow_symlink.stdout|from_json)|count == 1
+    - (allow_not_follow_symlink.stdout|from_json)[0].identity == 'BUILTIN\Guests'
+    - (allow_not_follow_symlink.stdout|from_json)[0].inheritance_flags == 'ContainerInherit, ObjectInherit'
+    - (allow_not_follow_symlink.stdout|from_json)[0].propagation_flags == 'None'
+    - (allow_not_follow_symlink.stdout|from_json)[0].rights == 'Write, Synchronize'
+    - (allow_not_follow_symlink.stdout|from_json)[0].type == 'Allow'
+    - (allow_not_follow_target.stdout|from_json)|count == 0
+
+- name: remove write rights on symlink
+  win_acl:
+    path: '{{ test_acl_path }}\symlink'
+    type: allow
+    user: Guests
+    rights: Write
+    state: absent
+
+- name: add right to symlink with follow
+  win_acl:
+    path: '{{ test_acl_path }}\symlink'
+    type: allow
+    user: Guests
+    rights: Write
+    follow: true
+  register: allow_follow
+
+- name: get result of add right to symlink without follow on symlink
+  win_shell: '$path = ''{{ test_acl_path }}\symlink''; {{ test_ace_cmd }}'
+  register: allow_follow_symlink
+
+- name: get result of add right to junction without follow on symlink
+  win_shell: '$path = ''{{ test_acl_path }}\junction''; {{ test_ace_cmd }}'
+  register: allow_follow_junction
+
+- name: get result of add right to symlink without follow on symlink
+  win_shell: '$path = ''{{ test_acl_path }}\target''; {{ test_ace_cmd }}'
+  register: allow_follow_target
+
+- name: assert add write rights to Guest - network
+  assert:
+    that:
+    - allow_not_follow is changed
+    - (allow_follow_symlink.stdout|from_json)|count == 0
+    - (allow_follow_junction.stdout|from_json)|count == 0
+    - (allow_follow_target.stdout|from_json)|count == 1
+    - (allow_follow_target.stdout|from_json)[0].identity == 'BUILTIN\Guests'
+    - (allow_follow_target.stdout|from_json)[0].inheritance_flags == 'ContainerInherit, ObjectInherit'
+    - (allow_follow_target.stdout|from_json)[0].propagation_flags == 'None'
+    - (allow_follow_target.stdout|from_json)[0].rights == 'Write, Synchronize'
+    - (allow_follow_target.stdout|from_json)[0].type == 'Allow'
+
 - name: add write rights to Guest - registry
   win_acl:
     path: '{{ test_acl_reg_path }}'


### PR DESCRIPTION
##### SUMMARY
Currently applying ACLs on a SymLink or Junction just applies the ACLs to the "link" not to the target.
There was no way to follow links, what seems to be the first intent when you set ACLs

I didn't added a new official variable for now, I let you decide if it's necessary or not.