### PR TITLE
Allows to force reimport a cert if you added a private key with win_certificate_store

### DIFF
--- a/changelogs/fragments/win_certificate_store-privkey-present.yml
+++ b/changelogs/fragments/win_certificate_store-privkey-present.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Allow to reimport a certificate + key if the private key was not present the first time you imported it
+- win_certificate_store - Allow to reimport a certificate + key if the private key was not present the first time you imported it

--- a/changelogs/fragments/win_certificate_store-privkey-present.yml
+++ b/changelogs/fragments/win_certificate_store-privkey-present.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Allow to reimport a certificate + key if the private key was not present the first time you imported it

--- a/tests/integration/targets/win_certificate_store/tasks/test.yml
+++ b/tests/integration/targets/win_certificate_store/tasks/test.yml
@@ -371,6 +371,14 @@
   - '{{subj_thumbprint}}'
   - '{{root_thumbprint}}'
 
+# By importing the cert first we make sure win_certificate_store will reimport
+# a cert with a key present if the imported cert doesn't have the key.
+# https://github.com/ansible-collections/ansible.windows/pull/424
+- name: import cert without key for next test
+  win_certificate_store:
+    path: '{{win_cert_dir}}\subj-cert.pem'
+    state: present
+
 - name: import pfx without password and non exportable (check)
   win_certificate_store:
     path: '{{win_cert_dir}}\subj-cert-without-pass.pfx'
@@ -384,16 +392,11 @@
   register: import_pfx_without_pass_check
   check_mode: yes
 
-- name: get results of import pfx without password and non exportable (check)
-  win_shell: if (Get-ChildItem -Path Cert:\LocalMachine\My | Where-Object { $_.Thumbprint -eq "{{subj_thumbprint}}" }) { $true } else { $false }
-  register: import_pfx_without_pass_result_check
-
 - name: assert results of import pfx without password and non exportable (check)
   assert:
     that:
     - import_pfx_without_pass_check is changed
     - import_pfx_without_pass_check.thumbprints == [subj_thumbprint]
-    - import_pfx_without_pass_result_check.stdout_lines[0] == "False"
 
 - name: import pfx without password and non exportable
   win_certificate_store:


### PR DESCRIPTION
##### SUMMARY
If you try to import a cert in the cert store wich already exists but without a private key associated, you can't because Ansible will detect no change at thumbprint level.
With that change ansible will force reimport if a private key is present during the second import.

We could imagine also force the import, if at the opposite, we remove the private key later. To be discussed.