### PR TITLE
win_powershell - support setting diff result in script

### DIFF
--- a/changelogs/fragments/win_powershell-diff.yml
+++ b/changelogs/fragments/win_powershell-diff.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_powershell - Add support for setting diff output with ``$Ansible.Diff`` in the script

--- a/plugins/modules/win_powershell.ps1
+++ b/plugins/modules/win_powershell.ps1
@@ -601,6 +601,7 @@ try {
             CheckMode = $module.CheckMode
             Verbosity = $module.Verbosity
             Result = @{}
+            Diff = @{}
             Changed = $true
             Failed = $false
             Tmpdir = $module.Tmpdir
@@ -776,6 +777,14 @@ $module.Result.host_err = $newStderr.Output.ToString()
 $module.Result.result = Convert-OutputObject -InputObject $result.Result -Depth $module.Params.depth
 $module.Result.changed = $result.Changed
 $module.Result.failed = $module.Result.failed -or $result.Failed
+
+# If the diff was somehow changed to something else we cannot set it to the
+# module output diff so check if it's still a dict.
+if ($result.Diff -is [System.Collections.IDictionary]) {
+    foreach ($kvp in $result.Diff.GetEnumerator()) {
+        $module.Diff[$kvp.Key] = Convert-OutputObject -InputObject $kvp.Value -Depth $module.Params.depth
+    }
+}
 
 # We process the output outselves to flatten anything beyond the depth and deal with certain problematic types with
 # json serialization.

--- a/plugins/modules/win_powershell.py
+++ b/plugins/modules/win_powershell.py
@@ -34,6 +34,7 @@ options:
   depth:
     description:
     - How deep the return values are serialized for C(result), C(output), and C(information[x].message_data).
+    - This also controls the depth of the diff output set by C($Ansible.Diff).
     - Setting this to a higher value can dramatically increase the amount of data that needs to be returned.
     default: 2
     type: int
@@ -87,9 +88,11 @@ notes:
 - C(Type) will contain a dictionary with C(Name), C(FullName), C(AssemblyQualifiedName), C(BaseType) being the type
   name, the type name including the namespace, the full assembly name the type was defined in and the base type it
   derives from.
-- The script has access to the C($Ansible) variable where it can set C(Result), C(Changed), C(Failed), or access
-  C(Tmpdir).
+- The script has access to the C($Ansible) variable where it can set C(Result), C(Changed), C(Failed), C(Diff),
+  or access C(Tmpdir).
 - C($Ansible.Result) is a value that is returned back to the controller as is.
+- C($Ansible.Diff) was added in the C(1.12.0) release of C(ansible.windows) and is a dictionary that is set to the diff
+  result that can be interepreted by Ansible.
 - C($Ansible.Changed) can be set to C(true) or C(false) to reflect whether the module made a change or not. By default
   this is set to C(true).
 - C($Ansible.Failed) can be set to C(true) if the script wants to return the failure back to the controller.

--- a/tests/integration/targets/win_powershell/tasks/tests.yml
+++ b/tests/integration/targets/win_powershell/tasks/tests.yml
@@ -372,7 +372,7 @@
                   Write-Error @errorParams
               }
           }
-          
+
       }
       1..3 | Test-Function
   register: complex_error_record
@@ -539,7 +539,7 @@
       Write-Warning 'warning'
 
   register: extra_streams
-      
+
 - name: assert write debug/verbose/warning streams
   assert:
     that:
@@ -885,3 +885,30 @@
     - err_nested_to.error | length == 1
     # Depth is 2 so it will fully enumerate 2 objects deep and on the 3rd stringify the value
     - "err_nested_to.error[0].target_object == {'1': {'2': {'3': 'System.Collections.Hashtable'}}}"
+
+- name: run script that sets diff output
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: |
+      $Ansible.Diff = @{
+         before = @{
+            foo = 'foo'
+         }
+         after = @{
+            foo = 'bar'
+            nested = @{'1'=@{'2'=@{foo='bar'}}}
+         }
+      }
+
+  register: diff
+  diff: true
+
+- name: assert run script that sets diff output
+  assert:
+    that:
+    - diff is changed
+    - "diff.diff.before == {'foo': 'foo'}"
+    - (diff.diff.after.keys() | sort) == ["foo", "nested"]
+    - diff.diff.after.foo == 'bar'
+    # Depth also controls the diff nesting
+    - "diff.diff.after.nested == {'1': {'2': 'System.Collections.Hashtable'}}"


### PR DESCRIPTION
##### SUMMARY
Adds the `$Ansible.Diff` key which can be a dictionary like object for setting diff output as understood by Ansible. The keys of this Diff dictionary is the same as what any module would use, so keys like `before`, `after`, `prepared` will work.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/426

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_powershell