### PR TITLE
win_dns_client - Handle null chars in raw registry dns servers value

### DIFF
--- a/changelogs/fragments/win_dns_client-null-chars.yml
+++ b/changelogs/fragments/win_dns_client-null-chars.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_dns_client - Fix failure to lookup registry DNS servers when it contains null characters

--- a/plugins/modules/win_dns_client.ps1
+++ b/plugins/modules/win_dns_client.ps1
@@ -222,7 +222,11 @@ Function Get-RegistryNameServerInfo {
                 }
 
                 if (($ns = Get-OptionalProperty -InputObject $iprop -Name $items.StaticNameServer)) {
-                    $famInfo.EffectiveNameServers = $famInfo.StaticNameServers = $ns -split '[,;\ ]'
+                    # The raw string value may have null bytes at the end of the string so needs to be trimmed out.
+                    # This seems to only happen when Set-DnsClientServerAddress was used to set both IPv4 and IPv6
+                    # DNS servers at the same time.
+                    # $famInfo.EffectiveNameServers = $famInfo.StaticNameServers = $ns.Trim([char]0) -split '[,;\ ]'
+                    $famInfo.EffectiveNameServers = $famInfo.StaticNameServers = $ns.Trim([char]0) -split '[,;\ ]'
                     $famInfo.UsingDhcp = $false
                     $famInfo.NameServerBadFormat = $ns -match '[;\ ]'
                 }
@@ -381,7 +385,7 @@ Try {
 Catch {
     $excep = $_
 
-    Write-DebugLog "Exception: $($excep | out-string)"
+    Write-DebugLog "Exception: $($excep | Out-String)"
 
     Throw
 }

--- a/tests/integration/targets/win_dns_client/tasks/main.yml
+++ b/tests/integration/targets/win_dns_client/tasks/main.yml
@@ -201,12 +201,14 @@
     win_dns_client:
       adapter_names: '{{ network_adapter_name }}'
       dns_servers:
+      - 192.168.34.7
+      - 192.168.34.8
       - 2001:db8::1
       - 2001:db8::2
     register: set_ipv6
 
   - name: get result of set IPv6 DNS address
-    win_shell: (Get-DnsClientServerAddress -InterfaceAlias '{{ network_adapter_name }}' -AddressFAmily IPv6).ServerAddresses
+    win_shell: (Get-DnsClientServerAddress -InterfaceAlias '{{ network_adapter_name }}').ServerAddresses
     changed_when: no
     register: set_ipv6_actual
 
@@ -214,4 +216,19 @@
     assert:
       that:
       - set_ipv6 is changed
-      - set_ipv6_actual.stdout_lines == ['2001:db8::1', '2001:db8::2']
+      - set_ipv6_actual.stdout_lines == ['192.168.34.7', '192.168.34.8', '2001:db8::1', '2001:db8::2']
+
+  - name: set IPv6 DNS address (idempotent)
+    win_dns_client:
+      adapter_names: '{{ network_adapter_name }}'
+      dns_servers:
+      - 192.168.34.7
+      - 192.168.34.8
+      - 2001:db8::1
+      - 2001:db8::2
+    register: set_ipv6_again
+
+  - name: assert set IPv6 DNS address (idempotent)
+    assert:
+      that:
+      - not set_ipv6_again is changed


### PR DESCRIPTION
##### SUMMARY
If `Set-DnsClientServerAddress` was used to set both IPv4 and IPv6 DNS servers at the same time, the raw registry value will contain null chars. This causes problems on subsequent runs because the code will try to parse `'{ip}\0\0\0\0'` into a `IPAddress` object which fails with

```json
{
    "changed": false,
    "msg": "Unhandled exception while executing module: Cannot convert value \"8.8.8.8\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0000\" to type \"System.Net.IPAddress\". Error: \"An invalid IP address was specified.\""
}
```

The code here trims the raw value for any null chars so the cast later one works. To replicate this you can run the following to get the host in the same state.

```powershell
$adapter = Get-NetAdapter -Name 'INSERT ADAPTER NAME HERE'

$dnsServers = @(
    [System.Net.IPAddress]'8.8.4.4'
    [System.Net.IPAddress]'8.8.8.8'
    [System.Net.IPAddress]'2001:4860:4860::8888'
    [System.Net.IPAddress]'2001:4860:4860::8844'
)
Set-DnsClientServerAddress -InterfaceIndex $adapter.InterfaceIndex -ServerAddresses $dnsServers
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_dns_client
