### PR TITLE
win_reboot - Make the code more Python 3 like and increase display verbosity

### DIFF
--- a/changelogs/fragments/win_reboot-msg.yml
+++ b/changelogs/fragments/win_reboot-msg.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_reboot - Display connection messages under 4 v's ``-vvvv`` instead of 3


### PR DESCRIPTION
##### SUMMARY
Remove some of the python 2 compatible code to clean things up and bump the connection level actions to `-vvvv`. This reduces the amount of messages shown during `-vvv` as some of the same information is displayed on the connection plugin instead and is superfluous.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_reboot