### PR TITLE
setup - fix processor facts for older SMBIOS versions

### DIFF
--- a/changelogs/fragments/setup-procinfo.yml
+++ b/changelogs/fragments/setup-procinfo.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- setup - Fallback to using the WMI Win32_Processor provider if the SMBIOS version is too old to return processor core counts
+- setup - Fix calculation for ``ansible_processor_threads_per_core`` to reflect the number of threads per core instead of threads per processor
+- setup - Ignore processors that are not enabled in the ``ansible_processor_count`` return value
+- setup - Support core and thread counts greater than 256 in ``ansible_processor_count`` and ``ansible_processor_threads_per_core``


### PR DESCRIPTION
##### SUMMARY
On hosts with older SMBIOS versions (pre 2.5) the core and thread count fields are not present and the current code was just reading the random bytes after this type structure. This caused the processor count to be returned as random values. Instead have a fallback to the slower CIM/WMI method for older hosts.

The `ansible_processor_threads_per_core` was also being set to the number of threads per processor/CPU and not per core. This fixes the logic to return the correct value as it has been in the past.

It will also ignore any processor entries that are not populated and are not set as enabled.

Finally this also takes into account the `Core Count 2` and `Thread Count 2` fields on the SMBIOS processor information if present. This is a new field added by SMBIOS 3.0 to be able to return core counts greater than 256.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup