### PR TITLE
win_wait_for - fix typo found in state=drained

### DIFF
--- a/changelogs/fragments/win_wait_for-drained.yml
+++ b/changelogs/fragments/win_wait_for-drained.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_wait_for - fix incorrect function name during ``state=drained`` - https://github.com/ansible-collections/ansible.windows/issues/451

--- a/plugins/modules/win_wait_for.ps1
+++ b/plugins/modules/win_wait_for.ps1
@@ -227,7 +227,7 @@ elseif ($null -ne $port) {
         $complete = $false
         while (((Get-Date) - $start_time).TotalSeconds -lt $timeout) {
             $attempts += 1
-            $active_connections = Get-PortConnections -hostname $hostname -port $port
+            $active_connections = Get-PortConnection -hostname $hostname -port $port
             if ($null -eq $active_connections) {
                 $complete = $true
                 break

--- a/tests/integration/targets/win_wait_for/files/http-server.ps1
+++ b/tests/integration/targets/win_wait_for/files/http-server.ps1
@@ -1,6 +1,6 @@
 $ErrorActionPreference = 'Stop'
 
-$port = { { test_win_wait_for_port } }
+$port = [int]$args[0]
 
 $endpoint = New-Object -TypeName System.Net.IPEndPoint([System.Net.IPAddress]::Parse("0.0.0.0"), $port)
 $listener = New-Object -TypeName System.Net.Sockets.TcpListener($endpoint)

--- a/tests/integration/targets/win_wait_for/tasks/main.yml
+++ b/tests/integration/targets/win_wait_for/tasks/main.yml
@@ -9,8 +9,8 @@
     path: '{{test_win_wait_for_path}}'
     state: directory
 
-- name: template out the test server
-  win_template:
+- name: copy out the test server
+  win_copy:
     src: http-server.ps1
     dest: '{{test_win_wait_for_path}}\http-server.ps1'
 
@@ -241,7 +241,7 @@
     - fail_timeout_port_online.elapsed > 5
 
 - name: run async task to start web server
-  win_shell: Start-Sleep -Seconds 5; {{test_win_wait_for_path}}\http-server.ps1
+  win_shell: Start-Sleep -Seconds 5; {{test_win_wait_for_path}}\http-server.ps1 {{ test_win_wait_for_port }}
   async: 30
   poll: 0
 
@@ -257,7 +257,7 @@
     - wait_for_port_to_start.wait_attempts > 1
 
 - name: start web server
-  win_shell: '{{test_win_wait_for_path}}\http-server.ps1'
+  win_shell: '{{test_win_wait_for_path}}\http-server.ps1 {{ test_win_wait_for_port }}'
   async: 30
   poll: 0
 
@@ -290,7 +290,7 @@
     - wait_for_port_already_stopped.wait_attempts == 1
 
 - name: start web server for offline port test
-  win_shell: '{{test_win_wait_for_path}}\http-server.ps1'
+  win_shell: '{{test_win_wait_for_path}}\http-server.ps1 {{ test_win_wait_for_port }}'
   async: 30
   poll: 0
 


### PR DESCRIPTION
##### SUMMARY
Fixes: https://github.com/ansible-collections/ansible.windows/issues/451

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_wait_for