### PR TITLE
win_powershell - support scripts with 7 syntax

### DIFF
--- a/changelogs/fragments/powershell-support-7-syntax.yml
+++ b/changelogs/fragments/powershell-support-7-syntax.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- 'win_powershell - Support PowerShell 7 script syntax when targeting ``executable: pwsh.exe`` - https://github.com/ansible-collections/ansible.windows/issues/452'


### PR DESCRIPTION
##### SUMMARY
It is possible to use PowerShell 7 scripts with this module when `executable: pwsh.exe` is used. This means the scriptblock parser that is being used will fail in Windows PowerShell when encountering syntax added in 7. This adds a fallback to using a regex match to check if the script also contains `SupportsShouldProcess`.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/452

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_powershell