### PR TITLE
setup - more fixes for core count calculation

### DIFF
--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -428,18 +428,23 @@ namespace Ansible.Windows.Setup
                         byte threadCount = 0;
                         ushort threadCount2 = 0;
 
-                        if ((header.Length - headerSize) >= 34)
+                        // SMBIOS 2.5 is when the core and thread count fields
+                        // were added.
+                        if (rawData.SMBIOSMajorVersion > 3 || (rawData.SMBIOSMajorVersion == 2 && rawData.SMBIOSMajorVersion > 4))
                         {
-                            ProcessorCountFound = true;
-                            coreCount = Marshal.ReadByte(headerDataPtr, 31);
-                            threadCount = Marshal.ReadByte(headerDataPtr, 33);
-                        }
+                            if ((header.Length - headerSize) >= 34)
+                            {
+                                ProcessorCountFound = true;
+                                coreCount = Marshal.ReadByte(headerDataPtr, 31);
+                                threadCount = Marshal.ReadByte(headerDataPtr, 33);
+                            }
 
-                        if ((header.Length - headerSize) >= 44)
-                        {
-                            ProcessorCountFound = true;
-                            coreCount2 = (ushort)Marshal.ReadInt16(headerDataPtr, 38);
-                            threadCount2 = (ushort)Marshal.ReadInt16(headerDataPtr, 42);
+                            if ((header.Length - headerSize) >= 44)
+                            {
+                                ProcessorCountFound = true;
+                                coreCount2 = (ushort)Marshal.ReadInt16(headerDataPtr, 38);
+                                threadCount2 = (ushort)Marshal.ReadInt16(headerDataPtr, 42);
+                            }
                         }
 
                         ProcessorInfo.Add(Tuple.Create(


### PR DESCRIPTION
##### SUMMARY
Further fixes to https://github.com/ansible-collections/ansible.windows/pull/457. Have had some reports where the SMBIOS data for the processor information exceeds 34 bytes but the SMBIOS version is still older than 2.4. This resulted in the wrong values being returned by the facts. Instead only use this data if the SMBIOS version is greater than 2.4 and the data length is long enough.

No changelog fragment needed as it's covered by what is in #457.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup