### PR TITLE
win updates include is downloaded property and summary property for all updates

### DIFF
--- a/plugins/action/win_template.py
+++ b/plugins/action/win_template.py
@@ -7,7 +7,6 @@ __metaclass__ = type
 
 import os
 import shutil
-import stat
 import tempfile
 
 from ansible import constants as C

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -4,7 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import json
+import json # pylint: disable=unused-import
 import os.path
 import shutil
 import tempfile

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -7,7 +7,6 @@ __metaclass__ = type
 import json
 import os.path
 import shutil
-import tempfile
 import traceback
 
 from ansible import constants as C

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -7,6 +7,7 @@ __metaclass__ = type
 import json
 import os.path
 import shutil
+import tempfile
 import traceback
 
 from ansible import constants as C

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -778,8 +778,14 @@ class ActionModule(ActionBase):
             result['installed_update_count'] = 0
             result['updates'] = {}
             result['filtered_updates'] = {}
+            result['updates_downloaded'] = True
             for update_id in self._selected_updates:
                 update_info = self._get_update_info(update_id)
+
+                # add a property to confirm all available updates are downloaded
+                if update_info['is_downloaded'] == False:
+                    result['updates_downloaded'] = False
+
                 result['updates'][update_id] = update_info
                 result['found_update_count'] += 1
 
@@ -1029,6 +1035,7 @@ class ActionModule(ActionBase):
             'categories': raw_info['categories'],
             'id': update_id,
             'downloaded': False,
+            'is_downloaded': raw_info['is_downloaded'],
             'installed': False,
         }
 

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -783,7 +783,7 @@ class ActionModule(ActionBase):
                 update_info = self._get_update_info(update_id)
 
                 # add a property to confirm all available updates are downloaded
-                if update_info['is_downloaded'] == False:
+                if update_info['is_downloaded'] is false:
                     result['updates_downloaded'] = False
 
                 result['updates'][update_id] = update_info

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -4,7 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import json # pylint: disable=unused-import
+import json  # pylint: disable=unused-import
 import os.path
 import shutil
 import tempfile

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -783,7 +783,7 @@ class ActionModule(ActionBase):
                 update_info = self._get_update_info(update_id)
 
                 # add a property to confirm all available updates are downloaded
-                if update_info['is_downloaded'] is false:
+                if update_info['is_downloaded'] is False:
                     result['updates_downloaded'] = False
 
                 result['updates'][update_id] = update_info

--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -233,6 +233,12 @@ updates:
             type: bool
             sample: true
             version_added: 1.7.0
+        is_downloaded:
+            description: Is the update downloaded and available to install.
+            returned: always
+            type: bool
+            sample: true
+            version_added: 1.14.0
         installed:
             description: Was the update successfully installed.
             returned: always
@@ -298,4 +304,9 @@ failed_update_count:
     returned: always
     type: int
     sample: 0
+updates_downloaded:
+    description: The available updates are downloaded
+    returned: always
+    type: bool
+    sample: true
 """


### PR DESCRIPTION
##### SUMMARY

When using a managed server, approvals are done centrally and the client machines poll the SUS server on a regular basis. If updates are available our GPO settings tell the client machine to download the updates ready for installing.

As part of our WSUS automation processes we would like to determine which patches have been downloaded and as a summary if all updates have been downloaded. This will help us decide what step to process next in the automation.

To facilitate this we have included on a per update basis the is_downloaded property  and on the task itself a flag to determine if all updates have been downloaded.

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

win_updates module py results processing

##### ADDITIONAL INFORMATION
