### PR TITLE
win_package - fix productId check before getting remote files

### DIFF
--- a/changelogs/fragments/win_package-product-id-check.yml
+++ b/changelogs/fragments/win_package-product-id-check.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_package - Fix ``product_id`` check and skip downloaded requested file if the package is already installed - https://github.com/ansible-collections/ansible.windows/issues/479

--- a/plugins/modules/win_package.ps1
+++ b/plugins/modules/win_package.ps1
@@ -1434,7 +1434,7 @@ try {
         CreatesService = $createsService
     }
 
-    # If the packge is a remote file, productId is set and state is set to present 
+    # If the packge is a remote file, productId is set and state is set to present
     # then check if the package is installed and avoid downloading the package to a temp file.
     if ($pathType -and $productId -and ($state -eq 'present')) {
         $packageStatus = Get-InstalledStatus @getParams

--- a/plugins/modules/win_package.ps1
+++ b/plugins/modules/win_package.ps1
@@ -1434,8 +1434,8 @@ try {
         CreatesService = $createsService
     }
 
-    # If the path is a URL or UNC with credentials and no ID is set then create a temp copy for idempotency checks.
-    if ($pathType -and -not $Id) {
+    # If the path is a URL or UNC with credentials and no productId is set then create a temp copy for idempotency checks.
+    if ($pathType -and -not $productId) {
         $tempFile = switch ($pathType) {
             url { Get-UrlFile -Module $module -Url $path }
             unc { Copy-ItemWithCredential -Path $path -Destination $module.Tmpdir -Credential $credential }

--- a/plugins/modules/win_package.ps1
+++ b/plugins/modules/win_package.ps1
@@ -1434,8 +1434,14 @@ try {
         CreatesService = $createsService
     }
 
-    # If the path is a URL or UNC with credentials and no productId is set then create a temp copy for idempotency checks.
-    if ($pathType -and -not $productId) {
+    # If the packge is a remote file, productId is set and state is set to present 
+    # then check if the package is installed and avoid downloading the package to a temp file.
+    if ($pathType -and $productId -and ($state -eq 'present')) {
+        $packageStatus = Get-InstalledStatus @getParams
+    }
+    # If the path is a URL or UNC with credentials and no productId is set or we already checked and the package is not installed
+    # then create a temp copy for idempotency checks.
+    if (($pathType) -and (-not $productId -or -not $packageStatus.Installed)) {
         $tempFile = switch ($pathType) {
             url { Get-UrlFile -Module $module -Url $path }
             unc { Copy-ItemWithCredential -Path $path -Destination $module.Tmpdir -Credential $credential }
@@ -1450,7 +1456,10 @@ try {
         $getParams.Path = $path
     }
 
-    $packageStatus = Get-InstalledStatus @getParams
+    # Check package installation status unless this was already done and we know the package is installed
+    if (-not $packageStatus.Installed) {
+        $packageStatus = Get-InstalledStatus @getParams
+    }
 
     $changed = -not $packageStatus.Skip -and (($state -eq 'present') -ne $packageStatus.Installed)
     $module.Result.rc = 0  # Make sure rc is always set


### PR DESCRIPTION
win_package should not download/copy $path before checking the installation status if product_id is set

##### SUMMARY
Based on the win_package documentation:
"When state=present, product_id is not set and the path is a URL, this file will always be downloaded to a temporary directory for idempotency checks, otherwise the file will only be downloaded if the package has not been installed based on the product_id checks."

But win_package always downloads/copies the file to a temporary location even if product_id is set and the package is installed

The productId is not being correctly checked in win_package.ps1 this commit fixes that. fixes #479 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_package

##### ADDITIONAL INFORMATION