### PR TITLE
win_file: Add support for hard link, symbolic link and junction

### DIFF
--- a/plugins/modules/win_file.ps1
+++ b/plugins/modules/win_file.ps1
@@ -14,7 +14,8 @@ $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -default
 $_remote_tmp = Get-AnsibleParam $params "_ansible_remote_tmp" -type "path" -default $env:TMP
 
 $path = Get-AnsibleParam -obj $params -name "path" -type "path" -failifempty $true -aliases "dest", "name"
-$state = Get-AnsibleParam -obj $params -name "state" -type "str" -validateset "absent", "directory", "file", "touch"
+$src = Get-AnsibleParam -obj $params -name "src" -type "path" -failifempty ($state -in @("hard", "link", "junction"))
+$state = Get-AnsibleParam -obj $params -name "state" -type "str" -validateset "absent", "directory", "file", "touch", "hard", "link", "junction"
 
 # used in template/copy when dest is the path to a dir and source is a file
 $original_basename = Get-AnsibleParam -obj $params -name "_original_basename" -type "str"
@@ -89,6 +90,17 @@ function Remove-Directory($directory, $checkmode) {
     Remove-Item -LiteralPath $directory.FullName -Force -Recurse -WhatIf:$checkmode
 }
 
+# If state is not supplied, test the $path to see if it looks like
+# a file or a folder and set state to file or folder
+if ($null -eq $state) {
+    $basename = Split-Path -Path $path -Leaf
+    if ($basename.length -gt 0) {
+        $state = "file"
+    }
+    else {
+        $state = "directory"
+    }
+}
 
 if ($state -eq "touch") {
     if (Test-Path -LiteralPath $path) {
@@ -102,39 +114,61 @@ if ($state -eq "touch") {
         $result.changed = $true
     }
 }
+elseif ($state -in @("hard", "link", "junction")) {
+    if (Test-Path -LiteralPath $path) {
+        $fileinfo = Get-Item -LiteralPath $path -Force
+        if ($state -eq "hard" -and -not $fileinfo.LinkType -eq "HardLink") {
+            Fail-Json $result "path $path is not a HardLink"
+        }
 
-if (Test-Path -LiteralPath $path) {
-    $fileinfo = Get-Item -LiteralPath $path -Force
-    if ($state -eq "absent") {
-        Remove-File -file $fileinfo -checkmode $check_mode
+        if ($state -eq "link" -and -not $fileinfo.LinkType -eq "SymbolicLink") {
+            Fail-Json $result "path $path is not a SymbolicLink"
+        }
+
+        if ($state -eq "junction" -and -not $fileinfo.LinkType -eq "Junction") {
+            Fail-Json $result "path $path is not a Junction"
+        }
+
+        if (($src -replace "^\\\\", "UNC\") -in $fileinfo.Target) {
+            Exit-Json $result
+        }
+    }
+    if (Test-Path -LiteralPath $src) {
+        try {
+            if ($state -eq "hard") {
+                New-Item -Path $path -Target $src -ItemType HardLink -Force -WhatIf:$check_mode | Out-Null
+            }
+            elseif ($state -eq "link") {
+                New-Item -Path $path -Target $src -ItemType SymbolicLink -Force -WhatIf:$check_mode | Out-Null
+            }
+            elseif ($state -eq "hard") {
+                New-Item -Path $path -Target $src -ItemType Junction -Force -WhatIf:$check_mode | Out-Null
+            }
+        }
+        catch {
+                Fail-Json $result $_.Exception.Message
+        }
         $result.changed = $true
     }
     else {
-        if ($state -eq "directory" -and -not $fileinfo.PsIsContainer) {
+        Fail-Json $result "target $src does not exist"
+    }
+}
+elseif ($state -eq "absent") {
+    if (Test-Path -LiteralPath $path) {
+        $fileinfo = Get-Item -LiteralPath $path -Force
+        Remove-File -file $fileinfo -checkmode $check_mode
+        $result.changed = $true
+    }
+}
+elseif ($state -eq "directory") {
+    if (Test-Path -LiteralPath $path) {
+        $fileinfo = Get-Item -LiteralPath $path -Force
+        if (-not $fileinfo.PsIsContainer) {
             Fail-Json $result "path $path is not a directory"
         }
-
-        if ($state -eq "file" -and $fileinfo.PsIsContainer) {
-            Fail-Json $result "path $path is not a file"
-        }
     }
-
-}
-else {
-
-    # If state is not supplied, test the $path to see if it looks like
-    # a file or a folder and set state to file or folder
-    if ($null -eq $state) {
-        $basename = Split-Path -Path $path -Leaf
-        if ($basename.length -gt 0) {
-            $state = "file"
-        }
-        else {
-            $state = "directory"
-        }
-    }
-
-    if ($state -eq "directory") {
+    else {
         try {
             New-Item -Path $path -ItemType Directory -WhatIf:$check_mode | Out-Null
         }
@@ -151,10 +185,17 @@ else {
         }
         $result.changed = $true
     }
-    elseif ($state -eq "file") {
+}
+elseif ($state -eq "file") {
+    if (Test-Path -LiteralPath $path) {
+        $fileinfo = Get-Item -LiteralPath $path -Force
+        if ($fileinfo.PsIsContainer) {
+            Fail-Json $result "path $path is not a file"
+        }
+    }
+    else {
         Fail-Json $result "path $path will not be created"
     }
-
 }
 
 Exit-Json $result

--- a/plugins/modules/win_file.py
+++ b/plugins/modules/win_file.py
@@ -20,6 +20,12 @@ options:
     required: yes
     type: path
     aliases: [ dest, name ]
+  src:
+    description:
+      - Path of the file or directory to link to.
+      - This applies only to C(state=link), C(state=hard) and C(state=junction).
+      - The path must be present.
+    type: path
   state:
     description:
       - If C(directory), all immediate subdirectories will be created if they
@@ -30,8 +36,11 @@ options:
       - If C(touch), an empty file will be created if the C(path) does not
         exist, while an existing file or directory will receive updated file access and
         modification times (similar to the way C(touch) works from the command line).
+      - If C(hard), a hard link will be created, or updated.
+      - If C(link), a symbolic link will be created, or updated.
+      - If C(junction), a junction will be created, or updated.
     type: str
-    choices: [ absent, directory, file, touch ]
+    choices: [ absent, directory, file, touch, hard, link, junction ]
 seealso:
 - module: ansible.builtin.file
 - module: ansible.windows.win_acl


### PR DESCRIPTION
##### SUMMARY
Adds support to win_file to create and update hard links, symbolic links, and junctions.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_file

##### ADDITIONAL INFORMATION
- This will create or update links like-for-like but not replace other types of files.
- Symbolic links support UNC paths, so there is a regex to convert paths that start \\ to UNC\ as returned by Get-Item when comparing existing values.
- This includes some refactoring to make it easier to read and simplify the update of links.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
