### PR TITLE
Add deprecation warning for older OS'

### DIFF
--- a/changelogs/fragments/2012-warning.yml
+++ b/changelogs/fragments/2012-warning.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+- Add warning when using Server 2012 or 2012 R2 with the ``setup`` module. These OS' are nearing the End of Life
+  and will not be tested in CI when that time is reached.

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -43,11 +43,10 @@ $gatherSubset = $module.Params.gather_subset
 $gatherTimeout = $module.Params.gather_timeout
 
 $osversion = [Environment]::OSVersion.Version
-if ($osversion -lt [version]"6.2") {
-    # Server 2008, 2008 R2, and Windows 7 are not tested in CI and we want to let customers know about it before
-    # removing support altogether.
+if ($osversion -lt [version]"10.0") {
+    # Anything older than Server 2016 is not supported by Ansible or this collection.
     $versionString = "{0}.{1}" -f ($osversion.Major, $osversion.Minor)
-    $module.Warn("The Windows version '$versionString' will no longer be supported or tested in future releases")
+    $module.Warn("The Windows version '$versionString' is no longer supported or tested by Ansible.")
 }
 
 Add-CSharpType -AnsibleModule $module -References @'


### PR DESCRIPTION
##### SUMMARY
Adds a warning when using the setup module for Windows OS' older than Server 2016. While we won't be dropping the testing for Server 2012 and 2012 R2 straight away, it is becoming End of Life in October so this is a warning to be included in the 2.0.0 release of this collection.

This should not be merged until the 2.0.0 version of this collection is going to be released.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
setup