### PR TITLE
win_updates - try and improve poll output handling

### DIFF
--- a/changelogs/fragments/win_updates-poll-newlines.yml
+++ b/changelogs/fragments/win_updates-poll-newlines.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_updates - Add better handling for the polling output for connection plugins that might drop newlines on the output - https://github.com/ansible-collections/ansible.windows/issues/477

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -93,7 +93,7 @@ try {
         $line
     }
 
-    $fs.Position
+    '{{"position": {0}}}' -f $fs.Position
 }
 finally {
     if ($sr) { $sr.Dispose() }
@@ -983,15 +983,27 @@ class ActionModule(ActionBase):
             msg = "Failed to poll update task, see rc, stdout, stderr for more info"
             raise _ReturnResultException(msg, rc=rc, stdout=stdout, stderr=stderr)
 
-        lines = stdout.splitlines()
-        offset = int(lines.pop(-1))
+        # https://github.com/ansible-collections/ansible.windows/issues/477
+        # We can't rely on the output containing newlines so use JSONDecoder to
+        # stream the JSON objects until there is nothing left
+        stdout = stdout.lstrip()
+        decoder = json.JSONDecoder()
+
         entries = []
-        for l in lines:
+        offset = 0
+        while stdout:
             try:
-                entries.append(json.loads(l))
+                entry, pos = decoder.raw_decode(stdout)
             except getattr(json.decoder, 'JSONDecodeError', ValueError) as e:
                 msg = 'Failed to decode poll result json: %s' % to_native(e)
                 raise _ReturnResultException(msg, rc=rc, stdout=stdout, stderr=stderr)
+
+            if list(entry.keys()) == ["position"]:
+                offset = int(entry["position"])
+            else:
+                entries.append(entry)
+
+            stdout = stdout[pos:].lstrip()
 
         return entries, offset
 


### PR DESCRIPTION
##### SUMMARY
It seems like certain connection plugins might have output with some newlines stripped. While this is a problem that should be fixed there we can certainly try and be more defensive about the output received when we read the polled information.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/477

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_updates