### PR TITLE
Update devel tests to track 2.16

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -54,6 +54,19 @@ stages:
               test: sanity
             - name: Units
               test: units
+  - stage: Ansible_2_15
+    displayName: Ansible 2.15
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: '{0}'
+          testFormat: '2.15/{0}'
+          targets:
+            - name: Sanity
+              test: sanity
+            - name: Units
+              test: units
   - stage: Ansible_2_14
     displayName: Ansible 2.14
     dependsOn: []
@@ -115,6 +128,7 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_15
       - Ansible_2_14
       - Ansible_2_13
       - Ansible_2_12

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,0 +1,4 @@
+plugins/modules/setup.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
+plugins/modules/win_powershell.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore until all ansible-test branches support custom rules
+tests/integration/targets/win_package/library/win_make_appx.ps1 pslint:PSAvoidLongLines # Cannot ignore until all ansible-test branches support this rule
+tests/integration/targets/win_dsc/files/xTestCompositeDsc/1.0.0/DSCResources/xTestComposite/xTestComposite.schema.psm1 pslint!skip # Pwsh cannot parse DSC to MOF on Linux


### PR DESCRIPTION
##### SUMMARY
Ansible has bumped the devel version to 2.16 and branched stable-2.15. Ensure we are still testing against 2.15 and fix up sanity ignores for the new devel version.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.windows