### PR TITLE
win_updates - Add rebooted return value

### DIFF
--- a/changelogs/fragments/win_updates-rebooted.yml
+++ b/changelogs/fragments/win_updates-rebooted.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_updates - Added the ``rebooted`` return value to document if a host was rebooted - https://github.com/ansible-collections/ansible.windows/issues/485

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -823,6 +823,7 @@ class ActionModule(ActionBase):
         result = {
             'changed': False,
             'reboot_required': False,
+            'rebooted': False,
         }
         has_rebooted_on_failure = False
         round = 0
@@ -880,10 +881,12 @@ class ActionModule(ActionBase):
                 else:
                     reboot_res = reboot_host(self._task.action, self._connection, reboot_timeout=reboot_timeout)
 
+                result['rebooted'] = True
+
                 if reboot_res['failed']:
                     msg = 'Failed to reboot host'
                     if 'msg' in reboot_res:
-                        msg += ': ' + reboot_res['msg']
+                        msg += ': ' + str(reboot_res['msg'])
                     reboot_res['msg'] = msg
 
                     result.update(reboot_res)

--- a/plugins/modules/win_updates.ps1
+++ b/plugins/modules/win_updates.ps1
@@ -1613,6 +1613,7 @@ finally {
 if ($invokeSplat.Wait) {
     # Format the output for legacy async behaviour
     $module.Result.reboot_required = $false
+    $module.Result.rebooted = $false
     $module.Result.changed = $false
     $module.Result.found_update_count = 0
     $module.Result.failed_update_count = 0

--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -203,6 +203,14 @@ reboot_required:
     type: bool
     sample: true
 
+rebooted:
+    description:
+    - Set to C(true) when the target Windows host has been rebooted by C(win_updates).
+    returned: success
+    type: bool
+    sample: false
+    version_added: 1.14.0
+
 updates:
     description:
     - Updates that were found/installed.

--- a/tests/integration/targets/win_updates/tasks/main.yml
+++ b/tests/integration/targets/win_updates/tasks/main.yml
@@ -140,6 +140,8 @@
       - not search_async is changed
       - not search_sync.reboot_required
       - not search_async.reboot_required
+      - not search_sync.rebooted
+      - not search_async.rebooted
       - search_sync.failed_update_count == 0
       - search_async.failed_update_count == 0
       - search_sync.installed_update_count == 0

--- a/tests/unit/plugins/action/test_win_updates.py
+++ b/tests/unit/plugins/action/test_win_updates.py
@@ -239,6 +239,7 @@ def test_install_with_multiple_reboots(monkeypatch):
     assert reboot_mock.call_count == 2
     assert actual['changed']
     assert not actual['reboot_required']
+    assert actual['rebooted'] is True
     assert actual['found_update_count'] == 8
     assert actual['failed_update_count'] == 0
     assert actual['installed_update_count'] == 8
@@ -268,6 +269,7 @@ def test_install_without_reboot(monkeypatch):
     assert reboot_mock.call_count == 0
     assert actual['changed']
     assert actual['reboot_required']
+    assert actual['rebooted'] is False
     assert actual['found_update_count'] == 3
     assert actual['failed_update_count'] == 0
     assert actual['installed_update_count'] == 3
@@ -315,6 +317,7 @@ def test_install_with_initial_reboot_required(monkeypatch):
     assert reboot_mock.call_count == 2
     assert actual['changed']
     assert not actual['reboot_required']
+    assert actual['rebooted'] is True
     assert actual['found_update_count'] == 6
     assert actual['failed_update_count'] == 0
     assert actual['installed_update_count'] == 5  # 1 found update was already installed at the beginning
@@ -350,6 +353,7 @@ def test_install_with_reboot_fail(monkeypatch):
     assert reboot_mock.call_count == 1
     assert not actual['changed']
     assert actual['reboot_required']
+    assert actual['rebooted'] is True
     assert actual['failed']
     assert actual['msg'] == 'Failed to reboot host: Failure msg from reboot'
     assert actual['found_update_count'] == 6
@@ -382,6 +386,7 @@ def test_install_with_reboot_check_mode(monkeypatch):
     assert reboot_mock.call_count == 0
     assert actual['changed']
     assert not actual['reboot_required']
+    assert actual['rebooted'] is True
     assert 'failed' not in actual
     assert 'msg' not in actual
     assert actual['found_update_count'] == 6
@@ -414,6 +419,7 @@ def test_install_reboot_with_two_failures(monkeypatch):
     assert reboot_mock.call_count == 1
     assert actual['changed']
     assert not actual['reboot_required']
+    assert actual['rebooted'] is True
     assert actual['failed']
     assert actual['msg'] == 'Searching for updates: Exception from HRESULT: 0x80240032 - The search criteria string was invalid ' \
         '(WU_E_INVALID_CRITERIA 80240032)'
@@ -439,6 +445,7 @@ def test_install_with_initial_reboot_required_but_no_reboot(monkeypatch):
     assert actual['failed']
     assert actual['msg'] == 'A reboot is required before more updates can be installed'
     assert actual['reboot_required']
+    assert actual['rebooted'] is False
     assert actual['found_update_count'] == 5
     assert actual['failed_update_count'] == 0
     assert actual['installed_update_count'] == 0
@@ -507,6 +514,7 @@ def test_fail_install(monkeypatch):
     assert actual['changed']
     assert actual['failed']
     assert actual['reboot_required']
+    assert actual['rebooted'] is False
     assert actual['found_update_count'] == 2
     assert actual['failed_update_count'] == 1
     assert actual['installed_update_count'] == 1
@@ -598,6 +606,7 @@ def test_reboot_with_tmpdir_cleanup(monkeypatch):
 
     assert actual['changed']
     assert not actual['reboot_required']
+    assert actual['rebooted'] is True
     assert actual['found_update_count'] == 6
     assert actual['failed_update_count'] == 0
     assert actual['installed_update_count'] == 6


### PR DESCRIPTION
##### SUMMARY
Add the `rebooted` return value to the `win_updates` return result to track whether the plugin had rebooted the target server or not.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/485

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_updates