### PR TITLE
win_updates - Improve file locking behaviour

### DIFF
--- a/changelogs/fragments/win_updates-file-locking.yml
+++ b/changelogs/fragments/win_updates-file-locking.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_updates - Ensure failure condition doesn't lock the polling file - https://github.com/ansible-collections/ansible.windows/issues/490


### PR DESCRIPTION
##### SUMMARY
Improve the file locking behaviour to allow the polling task to safely open a handle on the output status file. This changes the failure condition to log the failure message with a FILE_SHARE_READ handle allowing others to open a read handle to the same file at the same time.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/490

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_updates