### PR TITLE
win_updates - Improve batch runner

### DIFF
--- a/changelogs/fragments/win_updates-batch-runner.yml
+++ b/changelogs/fragments/win_updates-batch-runner.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- win_updates - Improve batch task runner reliability and attempt to return more info on failures - https://github.com/ansible-collections/ansible.windows/issues/448
+
+minor_changes:
+- Process - Add support for starting a process with a custom parent

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -974,7 +974,15 @@ class ActionModule(ActionBase):
             'cancel_id' not in result
         ):
             msg = result.get('msg', 'Unknown failure when running win_updates')
-            raise _ReturnResultException(msg, exception=result.get('exception', None))
+
+            extra_result = {}
+            if 'rc' in result:
+                extra_result['rc'] = result['rc']
+            if 'stdout' in result:
+                extra_result['stdout'] = result['stdout']
+            if 'stderr' in result:
+                extra_result['stderr'] = result['stderr']
+            raise _ReturnResultException(msg, exception=result.get('exception', None), **extra_result)
 
         return result['output_path'], result['task_pid'], result['cancel_id']
 


### PR DESCRIPTION
##### SUMMARY
Improve the batch runner bootstrapper that is used in win_updates to run the update code inside a batch process. This is done by starting an ephemeral process through the task scheduler that is unrelated to PowerShell and using a new API to spawn a new PowerShell process as a child of that ephemeral task. Unlike the ephemeral task process, the newly spawned process exposes the stdio handles allowing the module to have better visibility on failures and to send information to run than before.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/448

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
win_updates
module_utils/Process.cs