### PR TITLE
More resilient parsing for BIOS release date

### DIFF
--- a/changelogs/fragments/setup-bios-date.yml
+++ b/changelogs/fragments/setup-bios-date.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- setup - Be more resilient when parsing the BIOS release date - https://github.com/ansible-collections/ansible.windows/pull/496

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -516,8 +516,13 @@ namespace Ansible.Windows.Setup
             // Older standards could use a 2 digit year that indicates 19yy.
             string dateFormat = date.Length == 10 ? "MM/dd/yyyy" : "MM/dd/yy";
 
-            DateTime rawDateTime = DateTime.ParseExact(date, dateFormat, null);
-            return DateTime.SpecifyKind(rawDateTime, DateTimeKind.Utc);
+            DateTime rawDateTime;
+            if (DateTime.TryParseExact(date, dateFormat, null, System.Globalization.DateTimeStyles.None, out rawDateTime)) {
+                return DateTime.SpecifyKind(rawDateTime, DateTimeKind.Utc);
+            }
+            else {
+                return null;
+            }
         }
 
         private int CalculateCount(byte count1, ushort count2)


### PR DESCRIPTION
##### SUMMARY
`ParseDateString` function in `setup.ps1` is used to parse BIOS release date. Unfortunatelly, if date is not in either `MM/dd/yyyy` or `MM/dd/yy`, it will throw exception and cause the following warning:
```
[WARNING]: Error when collecting bios facts: New-Object : Exception calling ".ctor" with "0" argument(s): "String was not recognized as a valid DateTime."  At line:2 char:21  + ...         $bios = New-Object -TypeName
Ansible.Windows.Setup.SMBIOSInfo  +                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~      + CategoryInfo          : InvalidOperation: (:) [New-Object], MethodInvocationException      +
FullyQualifiedErrorId : ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand      at <ScriptBlock>, <No file>: line 2
```
I found this issue when accessing Surface device which had its release set as `05.07.2014`. I believe this is the issue described in ansible/ansible#69736 and this pull request should fix it.

My proposed change uses `TryParseExact` and in case of a parsing failure returns `null` which is already properly handled in the calling code.

Another option was to add `DD.MM.YYYY` format Microsoft Surface Pro 4 BIOS seemingly uses but I decided against it as it seems this particular BIOS is quite unique in its usage. I checked all devices I had available (including Surface Go and Surface 5 Pro) and they use "standard" MM/DD/YYYY format. Since it has limited benefit and because I didn't want to refactor the whole function, I kept my changes minimal.

Alternative approach would be a bit more of refactoring using the same overall idea but with date formats extracted into the array thus allowing for future date format expansion.
```csharp
private DateTime? ParseDateString(string date)
{
    string[] dateFormats = new string[] { "MM/dd/yyyy", "MM/dd/yy" };

    DateTime parsedDate;
    if (DateTime.TryParseExact(date, dateFormats, null, System.Globalization.DateTimeStyles.None, out parsedDate)) {
        return DateTime.SpecifyKind(parsedDate, DateTimeKind.Utc);
    }
    else {
        return null;
    }
}
```
I decided against it as adding extra formats is quite unlikely as most BIOS (if not almost all) that report release date do so in the US format. The current code is good enough.

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
Reproduction would require BIOS with release date *not* matching neither `MM/dd/yyyy` nor `MM/dd/yy` date format currently supported.
