### PR TITLE
Removed deprecated features for 2.0.0

### DIFF
--- a/changelogs/fragments/microsoft-ad-deprecations.yml
+++ b/changelogs/fragments/microsoft-ad-deprecations.yml
@@ -1,0 +1,7 @@
+deprecated_features:
+- >- win_domain - Module is deprecated in favour of the ``microsoft.ad.domain`` module, the
+  ``ansible.windows.win_domain`` module will be removed in the ``3.0.0`` release of this collection.
+- >- win_domain_controller - Module is deprecated in favour of the ``microsoft.ad.domain_controller`` module, the
+  ``ansible.windows.win_domain_controller`` module will be removed in the ``3.0.0`` release of this collection.
+- >- win_domain_membership - Module is deprecated in favour of the ``microsoft.ad.membership`` module, the
+  ``ansible.windows.win_domain_membership`` module will be removed in the ``3.0.0`` release of this collection.

--- a/changelogs/fragments/win_get_url-removed-features.yml
+++ b/changelogs/fragments/win_get_url-removed-features.yml
@@ -1,0 +1,4 @@
+removed_features:
+- win_get_url - Removed the deprecated option alias ``user`` and ``username``, use ``url_username`` instead.
+- win_get_url - Removed the deprecated option alias ``passwordd`, use ``url_password`` instead.
+

--- a/changelogs/fragments/win_package-removed-features.yml
+++ b/changelogs/fragments/win_package-removed-features.yml
@@ -1,0 +1,7 @@
+removed_features:
+- win_package - Removed deprecated module option ``productid``, use ``product_id`` instead.
+- win_package - Removed deprecated module option ``ensure``, use ``state`` instead.
+- >-
+  win_package - Removed deprecated module option ``username``, ``user_name``, ``password``, and ``user_password``. Use
+  ``become`` with ``become_flags: logon_type=new_credentials logon_flags=netcredentials_only`` on the task instead to
+  replicate the same functionality instead.

--- a/changelogs/fragments/win_reboot-removed-features.yml
+++ b/changelogs/fragments/win_reboot-removed-features.yml
@@ -1,0 +1,5 @@
+removed_features:
+- >-
+  win_reboot - Removed backwards compatibility check where ``ignore_errors: true`` will be treated like
+  ``ignore_unreachable: true``. Going forward ``ignore_errors: true`` will only ignore errors the plugin encountered
+  and not an unreachable host. Use ``ignore_unreachable: true`` to ignore that error like any other module.

--- a/changelogs/fragments/win_regedit-forwardslash.yml
+++ b/changelogs/fragments/win_regedit-forwardslash.yml
@@ -1,0 +1,6 @@
+remove_features:
+- >-
+  win_regedit - Removed support for using a ``path`` with forward slashes as a key separator. Using a forward slash has
+  been deprecated since Ansible 2.9. If using forward slashes in the ``win_regedit`` ``path`` value, make sure to
+  change the forward slash ``/`` to a backslash ``\``. If enclosed in double quotes the backslash will have to be
+  doubled up.

--- a/changelogs/fragments/win_updates-removed-features.yml
+++ b/changelogs/fragments/win_updates-removed-features.yml
@@ -1,0 +1,5 @@
+removed_features:
+- win_updates - Removed deprecated alias ``whitelist``, use ``accept_list`` instead.
+- win_updates - Removed deprecated alias ``blacklist``, use ``reject_list`` instead.
+- win_updates - Removed deprecated module option ``use_scheduled_task``. This option did not change any functionality
+  in the module and can be safely removed from the task entry.

--- a/changelogs/fragments/win_uri-removed-features.yml
+++ b/changelogs/fragments/win_uri-removed-features.yml
@@ -1,0 +1,4 @@
+removed_features:
+- win_uri - Removed the deprecated option alias ``user`` and ``username``, use ``url_username`` instead.
+- win_uri - Removed the deprecated option alias ``passwordd`, use ``url_password`` instead.
+

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: ansible
 name: windows
-version: 1.14.0
+version: 2.0.0
 readme: README.md
 authors:
 - Jordan Borean @jborean93

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,1 +1,15 @@
 requires_ansible: '>=2.12'
+plugin_routing:
+  modules:
+    win_domain_controller:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use microsoft.ad.domain_controller instead.
+    win_domain_membership:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use microsoft.ad.membership instead.
+    win_domain:
+      deprecation:
+        removal_version: 3.0.0
+        warning_text: Use microsoft.ad.domain instead.

--- a/plugins/action/win_reboot.py
+++ b/plugins/action/win_reboot.py
@@ -87,14 +87,4 @@ class ActionModule(ActionBase):
 
         result = reboot_host(self._task.action, self._connection, **parameters)
 
-        # Historical behaviour had ignore_errors=True being able to ignore unreachable hosts and not just task errors.
-        # This snippet will allow that to continue but state that it will be removed in a future version and to use
-        # ignore_unreachable to ignore unreachable hosts.
-        if result['unreachable'] and self._task.ignore_errors and not self._task.ignore_unreachable:
-            dep_msg = "Host was unreachable but is being skipped because ignore_errors=True is set. In the future " \
-                      "only ignore_unreachable will be able to ignore an unreachable host for %s" % self._task.action
-            display.deprecated(dep_msg, date="2023-05-01", collection_name="ansible.windows")
-            result['unreachable'] = False
-            result['failed'] = True
-
         return result

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -689,16 +689,15 @@ class _RecreateTempPathException(Exception):
 class ActionModule(ActionBase):
 
     _VALID_ARGS = [
-        'accept_list', 'whitelist',
+        'accept_list',
         'category_names',
         'log_path',
         'reboot',
         'skip_optional',
         'reboot_timeout',
-        'reject_list', 'blacklist',
+        'reject_list',
         'server_selection',
         'state',
-        'use_scheduled_task',
     ]
 
     DEFAULT_REBOOT_TIMEOUT = 1200
@@ -722,11 +721,6 @@ class ActionModule(ActionBase):
         super(ActionModule, self).run(tmp, task_vars)
         del tmp  # tmp no longer has any effect
         task_vars = task_vars or {}
-
-        for dep_arg in ['whitelist', 'blacklist', 'use_scheduled_task']:
-            if dep_arg in self._task.args:
-                dep_msg = "'%s' is deprecated. See the module docs for more information" % dep_arg
-                display.deprecated(dep_msg, date="2023-06-01", collection_name="ansible.windows")
 
         try:
             reboot = check_type_bool(self._task.args.get('reboot', False))

--- a/plugins/modules/win_domain.py
+++ b/plugins/modules/win_domain.py
@@ -11,6 +11,10 @@ description:
 - Ensure that the domain named by C(dns_domain_name) exists and is reachable.
 - If the domain is not reachable, the domain is created in a new forest on the target Windows Server 2012R2+ host.
 - This module may require subsequent use of the M(ansible.windows.win_reboot) action if changes are made.
+deprecated:
+  removed_in: 3.0.0
+  why: This module has been moved into the C(microsoft.ad) collection.
+  alternative: Use the M(microsoft.ad.domain) module instead.
 options:
   dns_domain_name:
     description:

--- a/plugins/modules/win_domain_controller.py
+++ b/plugins/modules/win_domain_controller.py
@@ -11,6 +11,10 @@ short_description: Manage domain controller/member server state for a Windows ho
 description:
     - Ensure that a Windows Server 2012+ host is configured as a domain controller or demoted to member server.
     - This module may require subsequent use of the M(ansible.windows.win_reboot) action if changes are made.
+deprecated:
+  removed_in: 3.0.0
+  why: This module has been moved into the C(microsoft.ad) collection.
+  alternative: Use the M(microsoft.ad.domain_controller) module instead.
 options:
   dns_domain_name:
     description:

--- a/plugins/modules/win_domain_membership.py
+++ b/plugins/modules/win_domain_membership.py
@@ -10,6 +10,10 @@ short_description: Manage domain/workgroup membership for a Windows host
 description:
 - Manages domain membership or workgroup membership for a Windows host. Also supports hostname changes.
 - This module may require subsequent use of the M(ansible.windows.win_reboot) action if changes are made.
+deprecated:
+  removed_in: 3.0.0
+  why: This module has been moved into the C(microsoft.ad) collection.
+  alternative: Use the M(microsoft.ad.membership) module instead.
 options:
   dns_domain_name:
     description:

--- a/plugins/modules/win_get_url.ps1
+++ b/plugins/modules/win_get_url.ps1
@@ -27,21 +27,6 @@ $spec = @{
         url_timeout = @{
             aliases = "timeout"
         }
-
-        # Defined for the alias backwards compatibility, remove once aliases are removed
-        url_username = @{
-            aliases = @("user", "username")
-            deprecated_aliases = @(
-                @{ name = "user"; date = [DateTime]::ParseExact("2022-07-01", "yyyy-MM-dd", $null); collection_name = 'ansible.windows' },
-                @{ name = "username"; date = [DateTime]::ParseExact("2022-07-01", "yyyy-MM-dd", $null); collection_name = 'ansible.windows' }
-            )
-        }
-        url_password = @{
-            aliases = @("password")
-            deprecated_aliases = @(
-                @{ name = "password"; date = [DateTime]::ParseExact("2022-07-01", "yyyy-MM-dd", $null); collection_name = 'ansible.windows' }
-            )
-        }
     }
     mutually_exclusive = @(
         , @('checksum', 'checksum_url')

--- a/plugins/modules/win_get_url.py
+++ b/plugins/modules/win_get_url.py
@@ -67,23 +67,6 @@ options:
   url_timeout:
     aliases:
     - timeout
-
-  # Following defined in the web_request fragment but the module contains deprecated aliases for backwards compatibility.
-  url_username:
-    description:
-    - The username to use for authentication.
-    - The alias I(user) and I(username) is deprecated and will be removed on
-      the major release after C(2022-07-01).
-    aliases:
-    - user
-    - username
-  url_password:
-    description:
-    - The password for I(url_username).
-    - The alias I(password) is deprecated and will be removed on the major
-      release after C(2022-07-01).
-    aliases:
-    - password
 notes:
 - If your URL includes an escaped slash character (%2F) this module will convert it to a real slash.
   This is a result of the behaviour of the System.Uri class as described in

--- a/plugins/modules/win_package.py
+++ b/plugins/modules/win_package.py
@@ -82,14 +82,6 @@ options:
     - This is only valid for MSI files, use C(arguments) for the C(registry)
       provider.
     type: path
-  password:
-    description:
-    - The password for C(user_name), must be set when C(user_name) is.
-    - This option is deprecated in favour of using become, see examples for
-      more information. Will be removed on the major release after
-      C(2022-07-01).
-    type: str
-    aliases: [ user_password ]
   path:
     description:
     - Location of the package to be installed or uninstalled.
@@ -121,10 +113,7 @@ options:
     - This SHOULD be set when the package is an C(exe), or the path is a url
       or a network share and credential delegation is not being used. The
       C(creates_*) options can be used instead but is not recommended.
-    - The alias I(productid) is deprecated and will be removed on the major
-      release after C(2022-07-01).
     type: str
-    aliases: [ productid ]
   provider:
     description:
     - Set the package provider to use when searching for a package.
@@ -164,24 +153,9 @@ options:
       installed or not.
     - For all providers but C(auto), the I(path) can be used for idempotency
       checks if it is locally accesible filesystem path.
-    - The alias I(ensure) is deprecated and will be removed on the major
-      release after C(2022-07-01).
     type: str
     choices: [ absent, present ]
     default: present
-    aliases: [ ensure ]
-  username:
-    description:
-    - Username of an account with access to the package if it is located on a
-      file share.
-    - This is only needed if the WinRM transport is over an auth method that
-      does not support credential delegation like Basic or NTLM or become is
-      not used.
-    - This option is deprecated in favour of using become, see examples for
-      more information. Will be removed on the major release after
-      C(2022-07-01).
-    type: str
-    aliases: [ user_name ]
   wait_for_children:
     description:
     - The module will wait for the process it spawns to finish but any

--- a/plugins/modules/win_regedit.ps1
+++ b/plugins/modules/win_regedit.ps1
@@ -125,15 +125,7 @@ if ($null -eq $name -and $type -ne "string") {
 if ($path -notmatch "^HK(CC|CR|CU|LM|U):\\") {
     $module.FailJson("path: $path is not a valid powershell path, see module documentation for examples.")
 }
-
-# Add a warning if the path does not contains a \ and is not the leaf path
 $registry_path = (Split-Path -Path $path -NoQualifier).Substring(1)  # removes the hive: and leading \
-$registry_leaf = Split-Path -Path $path -Leaf
-if ($registry_path -ne $registry_leaf -and -not $registry_path.Contains('\')) {
-    $msg = "path is not using '\' as a separator, support for '/' as a separator will be removed in a future Ansible version"
-    $module.Deprecate($msg, [DateTime]::ParseExact("2021-07-01", "yyyy-MM-dd", $null))
-    $registry_path = $registry_path.Replace('/', '\')
-}
 
 # Simplified version of Convert-HexStringToByteArray from
 # https://cyber-defense.sans.org/blog/2010/02/11/powershell-byte-array-hex-convert
@@ -160,10 +152,10 @@ Function Convert-RegExportHexStringToByteArray($string) {
         return , @([System.Convert]::ToByte($string, 16))
     }
     elseif (($string.Length % 2 -eq 0) -and ($string.IndexOf(":") -eq -1)) {
-        return , @($string -split '([a-f0-9]{2})' | foreach-object { if ($_) { [System.Convert]::ToByte($_, 16) } })
+        return , @($string -split '([a-f0-9]{2})' | ForEach-Object { if ($_) { [System.Convert]::ToByte($_, 16) } })
     }
     elseif ($string.IndexOf(":") -ne -1) {
-        return , @($string -split ':+' | foreach-object { [System.Convert]::ToByte($_, 16) })
+        return , @($string -split ':+' | ForEach-Object { [System.Convert]::ToByte($_, 16) })
     }
     else {
         return , @()

--- a/plugins/modules/win_updates.ps1
+++ b/plugins/modules/win_updates.ps1
@@ -11,14 +11,14 @@
 
 $spec = @{
     options = @{
-        accept_list = @{ type = 'list'; elements = 'str'; aliases = 'whitelist' }
+        accept_list = @{ type = 'list'; elements = 'str' }
         category_names = @{
             type = 'list'
             elements = 'str'
             default = 'CriticalUpdates', 'SecurityUpdates', 'UpdateRollups'
         }
         log_path = @{ type = 'path' }
-        reject_list = @{ type = 'list'; elements = 'str'; aliases = 'blacklist' }
+        reject_list = @{ type = 'list'; elements = 'str' }
         server_selection = @{ type = 'str'; choices = 'default', 'managed_server', 'windows_update'; default = 'default' }
         state = @{ type = 'str'; choices = 'installed', 'searched', 'downloaded'; default = 'installed' }
         skip_optional = @{ type = 'bool'; default = $false }
@@ -26,7 +26,6 @@ $spec = @{
         # options used by the action plugin - ignored here
         reboot = @{ type = 'bool'; default = $false }
         reboot_timeout = @{ type = 'int'; default = 1200 }
-        use_scheduled_task = @{ type = 'bool'; default = $false }
         _wait = @{ type = 'bool'; default = $false }
         _output_path = @{ type = 'str' }
     }

--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -23,11 +23,8 @@ options:
         - The accept list is only validated on updates that were found based on
           I(category_names). It will not force the module to install an update
           if it was not in the category specified.
-        - The alias C(whitelist) is deprecated and will be removed in a release after C(2023-06-01).
         type: list
         elements: str
-        aliases:
-        - whitelist
     category_names:
         description:
         - A scalar or list of categories to install updates from. To get the list
@@ -98,17 +95,8 @@ options:
           skipped and not installed.
         - Each entry can either be the KB article or Update title as a regex
           according to the PowerShell regex rules.
-        - The alias C(blacklist) is deprecated and will be removed in a release after C(2023-06-01).
         type: list
         elements: str
-        aliases:
-        - blacklist
-    use_scheduled_task:
-        description:
-        - This option is deprecated and no longer does anything since C(v1.7.0) of this collection.
-        - The option will be removed in a release after C(2023-06-01).
-        type: bool
-        default: no
     _output_path:
         description:
         - Internal use only.

--- a/plugins/modules/win_uri.ps1
+++ b/plugins/modules/win_uri.ps1
@@ -29,21 +29,6 @@ $spec = @{
             aliases = "method"
             default = "GET"
         }
-
-        # Defined for the alias backwards compatibility, remove once aliases are removed
-        url_username = @{
-            aliases = @("user", "username")
-            deprecated_aliases = @(
-                @{ name = "user"; date = [DateTime]::ParseExact("2022-07-01", "yyyy-MM-dd", $null); collection_name = 'ansible.windows' },
-                @{ name = "username"; date = [DateTime]::ParseExact("2022-07-01", "yyyy-MM-dd", $null); collection_name = 'ansible.windows' }
-            )
-        }
-        url_password = @{
-            aliases = @("password")
-            deprecated_aliases = @(
-                @{ name = "password"; date = [DateTime]::ParseExact("2022-07-01", "yyyy-MM-dd", $null); collection_name = 'ansible.windows' }
-            )
-        }
     }
     supports_check_mode = $true
 }

--- a/plugins/modules/win_uri.py
+++ b/plugins/modules/win_uri.py
@@ -62,23 +62,6 @@ options:
   url_timeout:
     aliases:
     - timeout
-
-  # Following defined in the web_request fragment but the module contains deprecated aliases for backwards compatibility.
-  url_username:
-    description:
-    - The username to use for authentication.
-    - The alias I(user) and I(username) is deprecated and will be removed on
-      the major release after C(2022-07-01).
-    aliases:
-    - user
-    - username
-  url_password:
-    description:
-    - The password for I(url_username).
-    - The alias I(password) is deprecated and will be removed on the major
-      release after C(2022-07-01).
-    aliases:
-    - password
 extends_documentation_fragment:
 - ansible.windows.web_request
 


### PR DESCRIPTION
##### SUMMARY
This removes all the deprecated options, aliases, modules in time for the 2.0.0 release of the collection. It also deprecates the win_domain, win_domain_controller, and win_domain_membership modules in favour of the microsoft.ad collection equivalents.

All the removed features have been deprecated for at least 2 years, most for even longer.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible.windows