### PR TITLE
update private key check when exporting to pkcs12

### DIFF
--- a/changelogs/fragments/508-win_certificate_store-privatekey-check-update.yml
+++ b/changelogs/fragments/508-win_certificate_store-privatekey-check-update.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - win_certificate_store - the private key check, when exporting to pkcs12, has been modified to handle the case where the ``PrivateKey`` property is null despite it being there

--- a/plugins/modules/win_certificate_store.ps1
+++ b/plugins/modules/win_certificate_store.ps1
@@ -245,10 +245,7 @@ Function New-CertFile($module, $cert, $path, $type, $password) {
                     $module.FailJson("Cannot export cert with key as PKCS12 $($cert.PublicKey.Oid.FriendlyName) algorithm isn't supported")
                 }
             }
-            if ($null -ne $certPrivateKey) {
-                $missing_key = $false
-            }
-            elseif ($certPrivateKey.ExportPolicy -ne [System.Security.Cryptography.CngExportPolicies]::None) {
+            if (($null -ne $certPrivateKey) -and ($certPrivateKey.ExportPolicy -ne [System.Security.Cryptography.CngExportPolicies]::None)) {
                 $missing_key = $false
             }
         }

--- a/plugins/modules/win_certificate_store.ps1
+++ b/plugins/modules/win_certificate_store.ps1
@@ -250,8 +250,10 @@ Function New-CertFile($module, $cert, $path, $type, $password) {
         $cert_bytes = $file_encoding.GetBytes($cert_content)
     }
     elseif ($type -eq "pkcs12") {
-        # to ensure backwards compatibility, if $false Export will fail.
-        $module.Result.key_exportable = $true
+        $module.Result.key_exported = $false
+        if ($null -ne $cert.PrivateKey) {
+            $module.Result.key_exportable = $cert.PrivateKey.CspKeyContainerInfo.Exportable
+        }
     }
 
     if (-not $module.CheckMode) {

--- a/plugins/modules/win_certificate_store.ps1
+++ b/plugins/modules/win_certificate_store.ps1
@@ -229,12 +229,28 @@ Function New-CertFile($module, $cert, $path, $type, $password) {
         "pkcs12" { [System.Security.Cryptography.X509Certificates.X509ContentType]::Pkcs12 }
     }
     if ($type -eq "pkcs12") {
-        $missing_key = $false
-        if ($null -eq $cert.PrivateKey) {
-            $missing_key = $true
-        }
-        elseif ($cert.PrivateKey.CspKeyContainerInfo.Exportable -eq $false) {
-            $missing_key = $true
+        $missing_key = $true
+        if ($cert.HasPrivateKey) {
+            switch ($cert.PublicKey.Oid.FriendlyName) {
+                "DSA" {
+                    $certPrivateKey = [Security.Cryptography.X509Certificates.DSACertificateExtensions]::GetDSAPrivateKey($cert[0]).Key
+                }
+                "RSA" {
+                    $certPrivateKey = [Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($cert[0]).Key
+                }
+                "ECC" {
+                    $certPrivateKey = [Security.Cryptography.X509Certificates.ECDsaCertificateExtensions]::GetECDsaPrivateKey($cert[0]).Key
+                }
+                default {
+                    $module.FailJson("Cannot export cert with key as PKCS12 $($cert.PublicKey.Oid.FriendlyName) algorithm isn't supported")
+                }
+            }
+            if ($null -ne $certPrivateKey) {
+                $missing_key = $false
+            }
+            elseif ($certPrivateKey.ExportPolicy -ne [System.Security.Cryptography.CngExportPolicies]::None) {
+                $missing_key = $false
+            }
         }
         if ($missing_key) {
             $module.FailJson("Cannot export cert with key as PKCS12 when the key is not marked as exportable or not accessible by the current user")
@@ -262,10 +278,7 @@ Function New-CertFile($module, $cert, $path, $type, $password) {
         $cert_bytes = $file_encoding.GetBytes($cert_content)
     }
     elseif ($type -eq "pkcs12") {
-        $module.Result.key_exported = $false
-        if ($null -ne $cert.PrivateKey) {
-            $module.Result.key_exportable = $cert.PrivateKey.CspKeyContainerInfo.Exportable
-        }
+        $module.Result.key_exportable = [string]$certPrivateKey.ExportPolicy
     }
 
     if (-not $module.CheckMode) {

--- a/tests/integration/targets/win_certificate_store/tasks/main.yml
+++ b/tests/integration/targets/win_certificate_store/tasks/main.yml
@@ -104,6 +104,10 @@
     with_items:
     - '{{subj_thumbprint}}'
     - '{{root_thumbprint}}'
+    - '{{certificat_using_cng_nonexportable.stdout_lines[0]}}'
+    - '{{certificat_using_cng_exportable.stdout_lines[0]}}'
+    - '{{certificat_using_capi_nonexportable.stdout_lines[0]}}'
+    - '{{certificat_using_capi_exportable.stdout_lines[0]}}'
 
   - name: ensure certificates are removed from custom store after test
     win_certificate_store:

--- a/tests/integration/targets/win_certificate_store/tasks/test.yml
+++ b/tests/integration/targets/win_certificate_store/tasks/test.yml
@@ -795,7 +795,7 @@
     file_type: pkcs12
   vars: *become_vars
   register: fail_export_non_exportable
-  failed_when: fail_export_non_exportable.msg != 'Cannot export cert with key as PKCS12 when the key is not marked as exportable or not accessible by the current user'
+  failed_when: fail_export_non_exportable.msg is not search("Key not valid for use in specified state.")
 
 - name: fail to import with invalid service name
   win_certificate_store:
@@ -922,3 +922,89 @@
       store_type: service
       store_location: WinRM
       state: absent
+
+- name: Generate nonexportable certificate using Microsoft Software Key Storage Provider (CNG)
+  win_shell: (New-SelfSignedCertificate -DnsName cng.local -KeyExportPolicy NonExportable -Provider "Microsoft Software Key Storage Provider").Thumbprint
+  register: certificat_using_cng_nonexportable
+
+- name: Fail to export certificate using Microsoft Software Key Storage Provider (CNG) with key as pfx with password when not marked as exportable
+  win_certificate_store:
+    path: "{{ win_cert_dir }}\\exported\\cert-fail.pfx"
+    thumbprint: "{{ certificat_using_cng_nonexportable.stdout_lines[0] }}"
+    state: exported
+    file_type: pkcs12
+  vars: *become_vars
+  register: fail_export_cng_non_exportable
+  failed_when: fail_export_cng_non_exportable.msg is not search("Key not valid for use in specified state.")
+
+- name: Generate exportable certificate using Microsoft Software Key Storage Provider (CNG)
+  win_shell: (New-SelfSignedCertificate -DnsName cng.local -KeyExportPolicy Exportable -Provider "Microsoft Software Key Storage Provider").Thumbprint
+  register: certificat_using_cng_exportable
+
+- name: Got to export certificate using Microsoft Software Key Storage Provider (CNG) with key without password as pfx when marked as exportable
+  win_certificate_store:
+    path: "{{ win_cert_dir }}\\exported\\{{ certificat_using_cng_exportable.stdout_lines[0] }}-pass.pfx"
+    thumbprint: "{{ certificat_using_cng_exportable.stdout_lines[0] }}"
+    state: exported
+    file_type: pkcs12
+    password: "{{ key_password }}"
+  vars: *become_vars
+  register: export_cng_pfx_with_pass
+
+- name: Get result of export certificate using Microsoft Software Key Storage Provider (CNG) with key and password as pfx when marked as exportable
+  win_shell: |
+    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
+    $cert.Import("{{ win_cert_dir }}\\exported\\{{ certificat_using_cng_exportable.stdout_lines[0] }}-pass.pfx", "{{ key_password }}", 0)
+    $cert.HasPrivateKey
+  vars: *become_vars
+  register: export_cng_pfx_with_pass_result
+
+- name: Assert results of export certificate using Microsoft Software Key Storage Provider (CNG) with key and password as pfx when marked as exportable
+  assert:
+    that:
+      - export_cng_pfx_with_pass is changed
+      - export_cng_pfx_with_pass.thumbprints == [certificat_using_cng_exportable.stdout_lines[0]]
+      - export_cng_pfx_with_pass_result.stdout_lines[0] == "True"
+
+- name: Generate nonexportable certificate using Microsoft RSA SChannel Cryptographic Provider (CAPI)
+  win_shell: (New-SelfSignedCertificate -DnsName capi.local -KeyExportPolicy NonExportable -Provider "Microsoft RSA SChannel Cryptographic Provider").Thumbprint
+  register: certificat_using_capi_nonexportable
+
+- name: Fail to export certificate using Microsoft RSA SChannel Cryptographic Provider (CAPI) with key as pfx with password when not marked as exportable
+  win_certificate_store:
+    path: "{{ win_cert_dir }}\\exported\\cert-fail.pfx"
+    thumbprint: "{{ certificat_using_capi_nonexportable.stdout_lines[0] }}"
+    state: exported
+    file_type: pkcs12
+  vars: *become_vars
+  register: fail_export_capi_non_exportable
+  failed_when: fail_export_capi_non_exportable.msg is not search("Key not valid for use in specified state.")
+
+- name: Generate exportable certificate using Microsoft RSA SChannel Cryptographic Provider (CAPI)
+  win_shell: (New-SelfSignedCertificate -DnsName capi.local -KeyExportPolicy Exportable -Provider "Microsoft RSA SChannel Cryptographic Provider").Thumbprint
+  register: certificat_using_capi_exportable
+
+- name: Got to export certificate using Microsoft RSA SChannel Cryptographic Provider (CAPI) with key without password as pfx when marked as exportable
+  win_certificate_store:
+    path: "{{ win_cert_dir }}\\exported\\{{ certificat_using_capi_exportable.stdout_lines[0] }}-pass.pfx"
+    thumbprint: "{{ certificat_using_capi_exportable.stdout_lines[0] }}"
+    state: exported
+    file_type: pkcs12
+    password: "{{ key_password }}"
+  vars: *become_vars
+  register: export_capi_pfx_with_pass
+
+- name: Get result of export certificate using Microsoft RSA SChannel Cryptographic Provider (CAPI) with key and password as pfx when marked as exportable
+  win_shell: |
+    $cert = New-Object -TypeName System.Security.Cryptography.X509Certificates.X509Certificate2
+    $cert.Import("{{ win_cert_dir }}\\exported\\{{ certificat_using_capi_exportable.stdout_lines[0] }}-pass.pfx", "{{ key_password }}", 0)
+    $cert.HasPrivateKey
+  vars: *become_vars
+  register: export_capi_pfx_with_pass_result
+
+- name: Assert results of export certificate using Microsoft RSA SChannel Cryptographic Provider (CAPI) with key and password as pfx when marked as exportable
+  assert:
+    that:
+      - export_capi_pfx_with_pass is changed
+      - export_capi_pfx_with_pass.thumbprints == [certificat_using_capi_exportable.stdout_lines[0]]
+      - export_capi_pfx_with_pass_result.stdout_lines[0] == "True"


### PR DESCRIPTION
##### SUMMARY
This proposed change, update private key check, when exporting to pkcs12, to handle the case where the ``PrivateKey`` property is null despite it being there.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_certificate_store

##### ADDITIONAL INFORMATION
[X509Certificate2.PrivateKey](https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.x509certificates.x509certificate2.privatekey) is not always set, depending the method used to generate key. it's also marked as obsolete by microsoft.

A way to check this
```paste below
> New-SelfSignedCertificate -DnsName test.local

   PSParentPath: Microsoft.PowerShell.Security\Certificate::LocalMachine\MY

Thumbprint                                Subject
----------                                -------
DC9D1037DCB465195F5F90400100B2759C3DF8DB  CN=test.local

> (Get-Item Cert:\LocalMachine\My\DC9D1037DCB465195F5F90400100B2759C3DF8DB).HasPrivateKey
True
> (Get-Item Cert:\LocalMachine\My\DC9D1037DCB465195F5F90400100B2759C3DF8DB).PrivateKey

> [Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey((Get-Item Cert:\LocalMachine\My\DC9D1037DCB465195F5F90400100B2759C3DF8DB)).Key

AlgorithmGroup     : RSA
Algorithm          : RSA
ExportPolicy       : AllowExport
Handle             : Microsoft.Win32.SafeHandles.SafeNCryptKeyHandle
IsEphemeral        : False
IsMachineKey       : True
KeyName            : te-a3d1cfb3-c570-4d46-b33a-75de1bd2a175
KeySize            : 2048
KeyUsage           : Decryption, Signing
ParentWindowHandle : 0
Provider           : Microsoft Software Key Storage Provider
ProviderHandle     : Microsoft.Win32.SafeHandles.SafeNCryptProviderHandle
UniqueName         : de19eccdfb0a8f913ccc1589b9b9c5ef_4adca362-26b7-4222-911c-fa932fda9d7a
UIPolicy           : System.Security.Cryptography.CngUIPolicy
```
