### PR TITLE
win_updates - Improve locking handling

### DIFF
--- a/changelogs/fragments/win_updates-output-lock.yml
+++ b/changelogs/fragments/win_updates-output-lock.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_updates - Add retry mechanism when polling output in case file is locked by another process like an Anti Virus - https://github.com/ansible-collections/ansible.windows/issues/490

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -71,8 +71,23 @@ param (
 $ErrorActionPreference = 'Stop'
 
 $fs = $sr = $null
+for ($i = 0; $i -lt 5; $i++) {
+    try {
+        $fs = [System.IO.File]::Open($OutputPath, 'Open', 'Read', 'ReadWrite')
+    }
+    catch [System.IO.IOException] {
+        if ($i -eq 4) {
+            throw
+        }
+
+        Start-Sleep -Seconds 5
+        continue
+    }
+
+    break
+}
+
 try {
-    $fs = [System.IO.File]::Open($OutputPath, 'Open', 'Read', 'ReadWrite')
     [void]$fs.Seek($Offset, [System.IO.SeekOrigin]::Begin)
     $sr = New-Object -TypeName System.IO.StreamReader -ArgumentList $fs
 

--- a/plugins/modules/win_updates.ps1
+++ b/plugins/modules/win_updates.ps1
@@ -1158,7 +1158,7 @@ namespace Ansible.Windows.WinUpdates
     }
 
     # Make sure the output file exists before running
-    [IO.File]::Create($OutputPath).Dispose()
+    [IO.File]::Open($OutputPath, 'Create', 'Write', 'ReadWrite').Dispose()
     $cancelEvent = New-Object -TypeName System.Threading.EventWaitHandle -ArgumentList @(
         $false,
         [System.Threading.EventResetMode]::ManualReset,


### PR DESCRIPTION
##### SUMMARY
Add a retry mechanism to the output polling code to retry opening the result file if it failed due to a lock. While it is unknown what causes the lock this should at least provide a better mechanism to retry the operation in case it was another process like an antivirus that temporarily locked the file.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/490

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_updates