### PR TITLE
Add depth option to win_find

### DIFF
--- a/changelogs/fragments/win_find-depth.yml
+++ b/changelogs/fragments/win_find-depth.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- win_find - Added ``depth`` option to control how deep to go when scanning into the target path - https://github.com/ansible-collections/ansible.windows/issues/335

--- a/plugins/modules/win_find.ps1
+++ b/plugins/modules/win_find.ps1
@@ -20,7 +20,7 @@ $spec = @{
         use_regex = @{ type = "bool"; default = $false }
         get_checksum = @{ type = "bool"; default = $true }
         checksum_algorithm = @{ type = "str"; default = "sha1"; choices = "md5", "sha1", "sha256", "sha384", "sha512" }
-        depth = @{ type = "int"; default = [System.Int32]::MaxValue }
+        depth = @{ type = "int" }
     }
     supports_check_mode = $true
 }
@@ -203,7 +203,6 @@ Function Search-Path {
         [Switch]
         $Recurse,
 
-        [Parameter(Mandatory = $true)]
         [System.Int32]
         $Depth,
 
@@ -234,7 +233,7 @@ Function Search-Path {
     catch [System.UnauthorizedAccessException] {}  # No ListDirectory permissions, Get-ChildItem ignored this
 
     foreach ($dir_child in $dir_files) {
-        if ($dir_child.Attributes.HasFlag([System.IO.FileAttributes]::Directory) -and $Recurse -and $Depth -gt 1) {
+        if ($dir_child.Attributes.HasFlag([System.IO.FileAttributes]::Directory) -and $Recurse -and $Depth -ne 1) {
             if ($Follow -or -not $dir_child.Attributes.HasFlag([System.IO.FileAttributes]::ReparsePoint)) {
                 $PSBoundParameters.Remove('Path') > $null
                 $PSBoundParameters['Depth'] = ($PSBoundParameters['Depth']) - 1

--- a/plugins/modules/win_find.py
+++ b/plugins/modules/win_find.py
@@ -43,6 +43,7 @@ options:
             - Setting recurse to C(false) will override this value, which is effectively depth 1.
             - Default depth is effectively unlimited (2147483647).
         type: int
+        default: 2147483647
     file_type:
         description: Type of file to search for.
         type: str

--- a/plugins/modules/win_find.py
+++ b/plugins/modules/win_find.py
@@ -37,6 +37,12 @@ options:
         type: str
         choices: [ md5, sha1, sha256, sha384, sha512 ]
         default: sha1
+    depth:
+        description:
+            - Set the maximum number of levels to descend into.
+            - Setting recurse to C(false) will override this value, which is effectively depth 1.
+            - Default depth is effectively unlimited (2147483647).
+        type: int
     file_type:
         description: Type of file to search for.
         type: str

--- a/plugins/modules/win_find.py
+++ b/plugins/modules/win_find.py
@@ -43,6 +43,7 @@ options:
             - Setting recurse to C(false) will override this value, which is effectively depth 1.
             - Default depth is unlimited.
         type: int
+        version_added: 2.0.0
     file_type:
         description: Type of file to search for.
         type: str

--- a/plugins/modules/win_find.py
+++ b/plugins/modules/win_find.py
@@ -41,9 +41,8 @@ options:
         description:
             - Set the maximum number of levels to descend into.
             - Setting recurse to C(false) will override this value, which is effectively depth 1.
-            - Default depth is effectively unlimited (2147483647).
+            - Default depth is unlimited.
         type: int
-        default: 2147483647
     file_type:
         description: Type of file to search for.
         type: str

--- a/tests/integration/targets/win_find/tasks/main.yml
+++ b/tests/integration/targets/win_find/tasks/main.yml
@@ -16,6 +16,7 @@
         "junction-link-dest",
         "broken-link-dest",
         "nested\sub-nest",
+        "nested\sub-nest\sub-sub-nest"
         "shared\folder",
         "hidden",
         "date",
@@ -36,6 +37,7 @@
         "nested\archive.log",
         "nested\sub-nest\test.ps1",
         "nested\sub-nest\readonly.txt",
+        "nested\sub-nest\sub-sub-nest\test.ps1",
         "link-dest\link.ps1",
         "single\test.ps1",
         "single\hidden.ps1",

--- a/tests/integration/targets/win_find/tasks/tests.yml
+++ b/tests/integration/targets/win_find/tasks/tests.yml
@@ -247,7 +247,253 @@
   assert:
     that:
     - not actual is changed
-    - actual.examined == 8
+    - actual.examined == 10
+    - actual.matched == 4
+    - actual.files[0].attributes == 'Archive'
+    - actual.files[0].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'
+    - actual.files[0].creationtime == 1477984205
+    - actual.files[0].exists == True
+    - actual.files[0].extension == '.ps1'
+    - actual.files[0].filename == 'file.ps1'
+    - actual.files[0].hlnk_targets == []
+    - actual.files[0].isarchive == True
+    - actual.files[0].isdir == False
+    - actual.files[0].ishidden == False
+    - actual.files[0].isjunction == False
+    - actual.files[0].islnk == False
+    - actual.files[0].isreadonly == False
+    - actual.files[0].isreg == True
+    - actual.files[0].isshared == False
+    - actual.files[0].lastaccesstime == 1477984205
+    - actual.files[0].lastwritetime == 1477984205
+    - actual.files[0].lnk_source == None
+    - actual.files[0].lnk_target == None
+    - actual.files[0].nlink == 1
+    - actual.files[0].owner == 'BUILTIN\\Administrators'
+    - actual.files[0].path == win_find_dir + '\\nested\\file.ps1'
+    - actual.files[0].sharename == None
+    - actual.files[0].size == 14
+    - actual.files[1].attributes == 'Archive'
+    - actual.files[1].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'
+    - actual.files[1].creationtime == 1477984205
+    - actual.files[1].exists == True
+    - actual.files[1].extension == '.ps1'
+    - actual.files[1].filename == 'test.ps1'
+    - actual.files[1].hlnk_targets == []
+    - actual.files[1].isarchive == True
+    - actual.files[1].isdir == False
+    - actual.files[1].ishidden == False
+    - actual.files[1].isjunction == False
+    - actual.files[1].islnk == False
+    - actual.files[1].isreadonly == False
+    - actual.files[1].isreg == True
+    - actual.files[1].isshared == False
+    - actual.files[1].lastaccesstime == 1477984205
+    - actual.files[1].lastwritetime == 1477984205
+    - actual.files[1].lnk_source == None
+    - actual.files[1].lnk_target == None
+    - actual.files[1].nlink == 1
+    - actual.files[1].owner == 'BUILTIN\\Administrators'
+    - actual.files[1].path == win_find_dir + '\\nested\\sub-nest\\sub-sub-nest\\test.ps1'
+    - actual.files[1].sharename == None
+    - actual.files[1].size == 14
+    - actual.files[2].attributes == 'Archive'
+    - actual.files[2].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'
+    - actual.files[2].creationtime == 1477984205
+    - actual.files[2].exists == True
+    - actual.files[2].extension == '.ps1'
+    - actual.files[2].filename == 'test.ps1'
+    - actual.files[2].hlnk_targets == []
+    - actual.files[2].isarchive == True
+    - actual.files[2].isdir == False
+    - actual.files[2].ishidden == False
+    - actual.files[2].isjunction == False
+    - actual.files[2].islnk == False
+    - actual.files[2].isreadonly == False
+    - actual.files[2].isreg == True
+    - actual.files[2].isshared == False
+    - actual.files[2].lastaccesstime == 1477984205
+    - actual.files[2].lastwritetime == 1477984205
+    - actual.files[2].lnk_source == None
+    - actual.files[2].lnk_target == None
+    - actual.files[2].nlink == 1
+    - actual.files[2].owner == 'BUILTIN\\Administrators'
+    - actual.files[2].path == win_find_dir + '\\nested\\sub-nest\\test.ps1'
+    - actual.files[2].sharename == None
+    - actual.files[2].size == 14
+    - actual.files[3].attributes == 'Archive'
+    - actual.files[3].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'
+    - actual.files[3].creationtime == 1477984205
+    - actual.files[3].exists == True
+    - actual.files[3].extension == '.ps1'
+    - actual.files[3].filename == 'test.ps1'
+    - actual.files[3].hlnk_targets == []
+    - actual.files[3].isarchive == True
+    - actual.files[3].isdir == False
+    - actual.files[3].ishidden == False
+    - actual.files[3].isjunction == False
+    - actual.files[3].islnk == False
+    - actual.files[3].isreadonly == False
+    - actual.files[3].isreg == True
+    - actual.files[3].isshared == False
+    - actual.files[3].lastaccesstime == 1477984205
+    - actual.files[3].lastwritetime == 1477984205
+    - actual.files[3].lnk_source == None
+    - actual.files[3].lnk_target == None
+    - actual.files[3].nlink == 1
+    - actual.files[3].owner == 'BUILTIN\\Administrators'
+    - actual.files[3].path == win_find_dir + '\\nested\\test.ps1'
+    - actual.files[3].sharename == None
+    - actual.files[3].size == 14
+
+- name: find files with recurse set and follow links
+  win_find:
+    paths: '{{win_find_dir}}\nested'
+    recurse: true
+    follow: true
+    patterns: '*.ps1'
+  register: actual
+
+- name: assert find files with recurse set and follow links
+  assert:
+    that:
+    - not actual is changed
+    - actual.examined == 12
+    - actual.matched == 5
+    - actual.files[0].attributes == 'Archive'
+    - actual.files[0].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'
+    - actual.files[0].creationtime == 1477984205
+    - actual.files[0].exists == True
+    - actual.files[0].extension == '.ps1'
+    - actual.files[0].filename == 'file.ps1'
+    - actual.files[0].hlnk_targets == []
+    - actual.files[0].isarchive == True
+    - actual.files[0].isdir == False
+    - actual.files[0].ishidden == False
+    - actual.files[0].isjunction == False
+    - actual.files[0].islnk == False
+    - actual.files[0].isreadonly == False
+    - actual.files[0].isreg == True
+    - actual.files[0].isshared == False
+    - actual.files[0].lastaccesstime == 1477984205
+    - actual.files[0].lastwritetime == 1477984205
+    - actual.files[0].lnk_source == None
+    - actual.files[0].lnk_target == None
+    - actual.files[0].nlink == 1
+    - actual.files[0].owner == 'BUILTIN\\Administrators'
+    - actual.files[0].path == win_find_dir + '\\nested\\file.ps1'
+    - actual.files[0].sharename == None
+    - actual.files[0].size == 14
+    - actual.files[1].attributes == 'Archive'
+    - actual.files[1].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'
+    - actual.files[1].creationtime == 1477984205
+    - actual.files[1].exists == True
+    - actual.files[1].extension == '.ps1'
+    - actual.files[1].filename == 'link.ps1'
+    - actual.files[1].hlnk_targets == []
+    - actual.files[1].isarchive == True
+    - actual.files[1].isdir == False
+    - actual.files[1].ishidden == False
+    - actual.files[1].isjunction == False
+    - actual.files[1].islnk == False
+    - actual.files[1].isreadonly == False
+    - actual.files[1].isreg == True
+    - actual.files[1].isshared == False
+    - actual.files[1].lastaccesstime == 1477984205
+    - actual.files[1].lastwritetime == 1477984205
+    - actual.files[1].lnk_source == None
+    - actual.files[1].lnk_target == None
+    - actual.files[1].nlink == 1
+    - actual.files[1].owner == 'BUILTIN\\Administrators'
+    - actual.files[1].path == win_find_dir + '\\nested\\link\\link.ps1'
+    - actual.files[1].sharename == None
+    - actual.files[1].size == 14
+    - actual.files[2].attributes == 'Archive'
+    - actual.files[2].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'
+    - actual.files[2].creationtime == 1477984205
+    - actual.files[2].exists == True
+    - actual.files[2].extension == '.ps1'
+    - actual.files[2].filename == 'test.ps1'
+    - actual.files[2].hlnk_targets == []
+    - actual.files[2].isarchive == True
+    - actual.files[2].isdir == False
+    - actual.files[2].ishidden == False
+    - actual.files[2].isjunction == False
+    - actual.files[2].islnk == False
+    - actual.files[2].isreadonly == False
+    - actual.files[2].isreg == True
+    - actual.files[2].isshared == False
+    - actual.files[2].lastaccesstime == 1477984205
+    - actual.files[2].lastwritetime == 1477984205
+    - actual.files[2].lnk_source == None
+    - actual.files[2].lnk_target == None
+    - actual.files[2].nlink == 1
+    - actual.files[2].owner == 'BUILTIN\\Administrators'
+    - actual.files[2].path == win_find_dir + '\\nested\\sub-nest\\sub-sub-nest\\test.ps1'
+    - actual.files[2].sharename == None
+    - actual.files[2].size == 14
+    - actual.files[3].attributes == 'Archive'
+    - actual.files[3].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'
+    - actual.files[3].creationtime == 1477984205
+    - actual.files[3].exists == True
+    - actual.files[3].extension == '.ps1'
+    - actual.files[3].filename == 'test.ps1'
+    - actual.files[3].hlnk_targets == []
+    - actual.files[3].isarchive == True
+    - actual.files[3].isdir == False
+    - actual.files[3].ishidden == False
+    - actual.files[3].isjunction == False
+    - actual.files[3].islnk == False
+    - actual.files[3].isreadonly == False
+    - actual.files[3].isreg == True
+    - actual.files[3].isshared == False
+    - actual.files[3].lastaccesstime == 1477984205
+    - actual.files[3].lastwritetime == 1477984205
+    - actual.files[3].lnk_source == None
+    - actual.files[3].lnk_target == None
+    - actual.files[3].nlink == 1
+    - actual.files[3].owner == 'BUILTIN\\Administrators'
+    - actual.files[3].path == win_find_dir + '\\nested\\sub-nest\\test.ps1'
+    - actual.files[3].sharename == None
+    - actual.files[3].size == 14
+    - actual.files[4].attributes == 'Archive'
+    - actual.files[4].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'
+    - actual.files[4].creationtime == 1477984205
+    - actual.files[4].exists == True
+    - actual.files[4].extension == '.ps1'
+    - actual.files[4].filename == 'test.ps1'
+    - actual.files[4].hlnk_targets == []
+    - actual.files[4].isarchive == True
+    - actual.files[4].isdir == False
+    - actual.files[4].ishidden == False
+    - actual.files[4].isjunction == False
+    - actual.files[4].islnk == False
+    - actual.files[4].isreadonly == False
+    - actual.files[4].isreg == True
+    - actual.files[4].isshared == False
+    - actual.files[4].lastaccesstime == 1477984205
+    - actual.files[4].lastwritetime == 1477984205
+    - actual.files[4].lnk_source == None
+    - actual.files[4].lnk_target == None
+    - actual.files[4].nlink == 1
+    - actual.files[4].owner == 'BUILTIN\\Administrators'
+    - actual.files[4].path == win_find_dir + '\\nested\\test.ps1'
+    - actual.files[4].sharename == None
+    - actual.files[4].size == 14
+
+- name: find files with recurse set and depth limited
+  win_find:
+    paths: '{{win_find_dir}}\nested'
+    recurse: true
+    depth: 2
+    patterns: '*.ps1'
+  register: actual
+
+- name: assert find files with recurse set and depth limited
+  assert:
+    that:
+    - not actual is changed
+    - actual.examined == 9
     - actual.matched == 3
     - actual.files[0].attributes == 'Archive'
     - actual.files[0].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'
@@ -322,117 +568,6 @@
     - actual.files[2].sharename == None
     - actual.files[2].size == 14
 
-- name: find files with recurse set and follow links
-  win_find:
-    paths: '{{win_find_dir}}\nested'
-    recurse: true
-    follow: true
-    patterns: '*.ps1'
-  register: actual
-
-- name: assert find files with recurse set and follow links
-  assert:
-    that:
-    - not actual is changed
-    - actual.examined == 10
-    - actual.matched == 4
-    - actual.files[0].attributes == 'Archive'
-    - actual.files[0].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'
-    - actual.files[0].creationtime == 1477984205
-    - actual.files[0].exists == True
-    - actual.files[0].extension == '.ps1'
-    - actual.files[0].filename == 'file.ps1'
-    - actual.files[0].hlnk_targets == []
-    - actual.files[0].isarchive == True
-    - actual.files[0].isdir == False
-    - actual.files[0].ishidden == False
-    - actual.files[0].isjunction == False
-    - actual.files[0].islnk == False
-    - actual.files[0].isreadonly == False
-    - actual.files[0].isreg == True
-    - actual.files[0].isshared == False
-    - actual.files[0].lastaccesstime == 1477984205
-    - actual.files[0].lastwritetime == 1477984205
-    - actual.files[0].lnk_source == None
-    - actual.files[0].lnk_target == None
-    - actual.files[0].nlink == 1
-    - actual.files[0].owner == 'BUILTIN\\Administrators'
-    - actual.files[0].path == win_find_dir + '\\nested\\file.ps1'
-    - actual.files[0].sharename == None
-    - actual.files[0].size == 14
-    - actual.files[1].attributes == 'Archive'
-    - actual.files[1].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'
-    - actual.files[1].creationtime == 1477984205
-    - actual.files[1].exists == True
-    - actual.files[1].extension == '.ps1'
-    - actual.files[1].filename == 'link.ps1'
-    - actual.files[1].hlnk_targets == []
-    - actual.files[1].isarchive == True
-    - actual.files[1].isdir == False
-    - actual.files[1].ishidden == False
-    - actual.files[1].isjunction == False
-    - actual.files[1].islnk == False
-    - actual.files[1].isreadonly == False
-    - actual.files[1].isreg == True
-    - actual.files[1].isshared == False
-    - actual.files[1].lastaccesstime == 1477984205
-    - actual.files[1].lastwritetime == 1477984205
-    - actual.files[1].lnk_source == None
-    - actual.files[1].lnk_target == None
-    - actual.files[1].nlink == 1
-    - actual.files[1].owner == 'BUILTIN\\Administrators'
-    - actual.files[1].path == win_find_dir + '\\nested\\link\\link.ps1'
-    - actual.files[1].sharename == None
-    - actual.files[1].size == 14
-    - actual.files[2].attributes == 'Archive'
-    - actual.files[2].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'
-    - actual.files[2].creationtime == 1477984205
-    - actual.files[2].exists == True
-    - actual.files[2].extension == '.ps1'
-    - actual.files[2].filename == 'test.ps1'
-    - actual.files[2].hlnk_targets == []
-    - actual.files[2].isarchive == True
-    - actual.files[2].isdir == False
-    - actual.files[2].ishidden == False
-    - actual.files[2].isjunction == False
-    - actual.files[2].islnk == False
-    - actual.files[2].isreadonly == False
-    - actual.files[2].isreg == True
-    - actual.files[2].isshared == False
-    - actual.files[2].lastaccesstime == 1477984205
-    - actual.files[2].lastwritetime == 1477984205
-    - actual.files[2].lnk_source == None
-    - actual.files[2].lnk_target == None
-    - actual.files[2].nlink == 1
-    - actual.files[2].owner == 'BUILTIN\\Administrators'
-    - actual.files[2].path == win_find_dir + '\\nested\\sub-nest\\test.ps1'
-    - actual.files[2].sharename == None
-    - actual.files[2].size == 14
-    - actual.files[3].attributes == 'Archive'
-    - actual.files[3].checksum == '8df33cee3325596517df5bb5aa980cf9c5c1fda3'
-    - actual.files[3].creationtime == 1477984205
-    - actual.files[3].exists == True
-    - actual.files[3].extension == '.ps1'
-    - actual.files[3].filename == 'test.ps1'
-    - actual.files[3].hlnk_targets == []
-    - actual.files[3].isarchive == True
-    - actual.files[3].isdir == False
-    - actual.files[3].ishidden == False
-    - actual.files[3].isjunction == False
-    - actual.files[3].islnk == False
-    - actual.files[3].isreadonly == False
-    - actual.files[3].isreg == True
-    - actual.files[3].isshared == False
-    - actual.files[3].lastaccesstime == 1477984205
-    - actual.files[3].lastwritetime == 1477984205
-    - actual.files[3].lnk_source == None
-    - actual.files[3].lnk_target == None
-    - actual.files[3].nlink == 1
-    - actual.files[3].owner == 'BUILTIN\\Administrators'
-    - actual.files[3].path == win_find_dir + '\\nested\\test.ps1'
-    - actual.files[3].sharename == None
-    - actual.files[3].size == 14
-
 - name: find directories
   win_find:
     paths: '{{win_find_dir}}\link-dest'
@@ -482,8 +617,8 @@
   assert:
     that:
     - not actual is changed
-    - actual.examined == 37
-    - actual.matched == 17
+    - actual.examined == 39
+    - actual.matched == 18
     - actual.files[0].filename == 'broken-link'
     - actual.files[0].isjunction == False
     - actual.files[0].islnk == True
@@ -494,10 +629,10 @@
     - actual.files[11].filename == 'link'
     - actual.files[11].islnk == True
     - actual.files[11].lnk_source == win_find_dir + '\\link-dest'
-    - actual.files[15].filename == 'folder'
-    - actual.files[15].islnk == False
-    - actual.files[15].isshared == True
-    - actual.files[15].sharename == 'folder-share'
+    - actual.files[16].filename == 'folder'
+    - actual.files[16].islnk == False
+    - actual.files[16].isshared == True
+    - actual.files[16].sharename == 'folder-share'
 
 - name: filter files by size without byte specified
   win_find:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Added a depth option to the win_find module to limit recursion, implementing #335 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_find

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The depth parameter is passed to the `Search-Path` function and decremented on recursive calls.

Creating an integration test for this option required adding to the existing file/folder structure and updating other tests.

<!--- Paste verbatim command output below, e.g. before and after your change -->
