### PR TITLE
Fix diff for win_template

### DIFF
--- a/changelogs/fragments/512-fix_diff_for_win_template.yml
+++ b/changelogs/fragments/512-fix_diff_for_win_template.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - win_copy/win_file/win_template - when using `--diff`, no diff would be shown, this fixes that.

--- a/plugins/action/win_copy.py
+++ b/plugins/action/win_copy.py
@@ -502,6 +502,8 @@ class ActionModule(ActionBase):
             file_src = query_return['files'][0]['src']
             file_dest = query_return['files'][0]['dest']
             basename = original_basename or file_dest
+            if self._play_context.diff:
+                result['diff'] =  self._get_diff_data(file_src, file_dest, task_vars)
             result.update(self._copy_single_file(file_src, dest, basename, file_dest,
                                                  task_vars, self._connection._shell.tmpdir, backup))
             if result.get('failed') is True:

--- a/plugins/action/win_copy.py
+++ b/plugins/action/win_copy.py
@@ -503,7 +503,7 @@ class ActionModule(ActionBase):
             file_dest = query_return['files'][0]['dest']
             basename = original_basename or file_dest
             if self._play_context.diff:
-                result['diff'] =  self._get_diff_data(file_src, file_dest, task_vars)
+                result['diff'] = self._get_diff_data(file_src, file_dest, task_vars)
             result.update(self._copy_single_file(file_src, dest, basename, file_dest,
                                                  task_vars, self._connection._shell.tmpdir, backup))
             if result.get('failed') is True:

--- a/plugins/modules/win_file.ps1
+++ b/plugins/modules/win_file.ps1
@@ -157,4 +157,16 @@ else {
 
 }
 
+if (Test-Path -LiteralPath $path) {
+    if ($fileinfo.PsIsContainer) {
+        $result.state = 'directory'
+    }
+    else {
+        $result.state = 'file'
+    }
+}
+else {
+    $result.state = 'absent'
+}
+
 Exit-Json $result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `win_copy` and `win_template` modules don't support displaying diffs, this commit by @amhn fixes that.
Fixes #16
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_template
win_copy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
```shell
$ ansible windows_host \
    --args "content='abc123' dest='%SystemRoot%\Temp\foo.txt'" \
    --connection winrm \
    --inventory windows_host, \
    --module-name ansible.windows.win_copy
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```diff
TASK [Set the contents of a file] *******************************************************************************************************************************************************************************************************************
changed: [windows_host]
```
After:
```diff
TASK [Set the contents of a file] *******************************************************************************************************************************************************************************************************************
--- before: %SystemRoot%\Temp\foo.txt
+++ after: ~/.ansible/tmp/ansible-local-85952imhy3qb/tmp0bs_w60c
@@ -0,0 +1 @@
+abc123
\ No newline at end of file

changed: [windows_host]
```