### PR TITLE
Potential fix for issue #518

### DIFF
--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -831,7 +831,7 @@ class ActionModule(ActionBase):
 
         return result
 
-    def _run_sync(self, task_vars, module_options, reboot, reboot_timeout, post_reboot_delay):  # type: (Dict, Dict, bool, int) -> Dict
+    def _run_sync(self, task_vars, module_options, reboot, reboot_timeout, post_reboot_delay):  # type: (Dict, Dict, bool, int, int) -> Dict
         """Installs the updates in a synchronous fashion with multiple update invocations if needed."""
         # In case we are running with become we need to make sure the module uses the correct dir
         module_options['_output_path'], poll_script_path, cancel_script_path = self._setup_updates_tmpdir()

--- a/plugins/modules/win_updates.ps1
+++ b/plugins/modules/win_updates.ps1
@@ -26,6 +26,7 @@ $spec = @{
         # options used by the action plugin - ignored here
         reboot = @{ type = 'bool'; default = $false }
         reboot_timeout = @{ type = 'int'; default = 1200 }
+        post_reboot_delay = @{ type = 'int'; default = 0 }
         _wait = @{ type = 'bool'; default = $false }
         _output_path = @{ type = 'str' }
     }

--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -61,6 +61,12 @@ options:
         - This is only used if C(reboot=true) and a reboot is required.
         default: 1200
         type: int
+    post_reboot_delay:
+        description:
+        - Seconds to wait after the reboot command was successful before attempting to validate the system rebooted successfully.
+        - This is only used if C(reboot=true) and a reboot is required.
+        default: 0
+        type: int
     server_selection:
         description:
         - Defines the Windows Update source catalog.

--- a/tests/integration/targets/win_updates/tasks/main.yml
+++ b/tests/integration/targets/win_updates/tasks/main.yml
@@ -26,6 +26,17 @@
     - reboot_timeout_not_int is failed
     - '"Invalid value given for ''reboot_timeout''" in reboot_timeout_not_int.msg'
 
+- name: failure with post_reboot_delay not an int
+  win_updates:
+    post_reboot_delay: a
+  register: post_reboot_delay_not_int
+  ignore_errors: yes
+
+- assert:
+    that:
+    - post_reboot_delay_not_int is failed
+    - '"Invalid value given for ''post_reboot_delay''" in post_reboot_delay_not_int.msg'
+
 - name: failure on async with reboot=True
   win_updates:
     reboot: True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Post patching, and after reboot, WinRM connection is not stable. While new uptime is received, win_updates crashes with WinRMOperationTimeoutError when attempting another cycle of patching / updates and/or validating if there are more patches to install.

From log:
```
[WARNING]: ERROR DURING WINRM SEND INPUT - attempting to recover:
WinRMOperationTimeoutError
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Potentially fixes #518 by allowing the connection to "sleep" for n seconds after connection is made, post reboot, before continuing. This allows the WinRM connection to be more reliable and avoids crashing win_updates. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Adds support for post_reboot_delay parameter, from win_reboot module, to win_updates module