### PR TITLE
Remove default JSON size limitation

### DIFF
--- a/changelogs/fragments/win_async-large-data-output.yml
+++ b/changelogs/fragments/win_async-large-data-output.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_async - Set maximum data size allowed when deserializing async output - https://github.com/ansible-collections/ansible.windows/pull/520

--- a/plugins/modules/async_status.ps1
+++ b/plugins/modules/async_status.ps1
@@ -34,6 +34,7 @@ Try {
 
     # TODO: move this into module_utils/powershell.ps1?
     $jss = New-Object System.Web.Script.Serialization.JavaScriptSerializer
+    $jss.MaxJsonLength = [int]::MaxValue
     $data = $jss.DeserializeObject($data_raw)
 }
 Catch {

--- a/tests/integration/targets/win_async/aliases
+++ b/tests/integration/targets/win_async/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group1

--- a/tests/integration/targets/win_async/tasks/main.yml
+++ b/tests/integration/targets/win_async/tasks/main.yml
@@ -1,0 +1,10 @@
+- name: check that a job can deserialize large data
+  win_shell: '"a" * 2097152'
+  async: 60
+  register: async_large_output
+  no_log: true
+
+- name: assert output can deserialize large data
+  assert:
+    that:
+    - async_large_output.stdout == ('a' * 2097152) + "\r\n"


### PR DESCRIPTION
##### SUMMARY
Change allows JavaScriptSerializer to deserialize the largest possible JSON file. Otherwise large log files from chatty PowerShell scripts will exceed the default limit of 4MB and throw an exception.

No such limitation exists on async_status.py, so this brings the PowerShell script better in line with that

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
async_status.ps1

##### ADDITIONAL INFORMATION
If an async tasks output exceeds 4MB (The default size limit for System.Web.Script.Serialization.JavaScriptSerializer), the deserialization will fail, throwing an exception and failing the async task.

The limit is arbitrary, and is implemented by a simple integer value that the file length is compared against. There is no practical upper limit, except for system resources.

Microsoft documentation: https://learn.microsoft.com/en-us/dotnet/api/system.web.script.serialization.javascriptserializer.maxjsonlength?

Microsoft source code: https://referencesource.microsoft.com/#system.web.extensions/Script/Serialization/JavaScriptSerializer.cs

I can see no reason to maintain a hard limitation. The python equivalent of this module (async_status.py) uses Python's json library, which has no built-in hard limitation.

```
