### PR TITLE
return accurate result values when check_mode is used

### DIFF
--- a/changelogs/fragments/win_group_membership-check_mode_results.yml
+++ b/changelogs/fragments/win_group_membership-check_mode_results.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_group_membership - Return accurate results when using check_mode - https://github.com/ansible-collections/ansible.windows/issues/532

--- a/plugins/modules/win_group_membership.ps1
+++ b/plugins/modules/win_group_membership.ps1
@@ -136,15 +136,15 @@ foreach ($member in $members) {
         if ($state -in @("present", "pure") -and !$user_in_group) {
             if (!$check_mode) {
                 $group.Add($member_sid)
-                $result.added += $group_member.account_name
             }
+            $result.added += $group_member.account_name
             $result.changed = $true
         }
         elseif ($state -eq "absent" -and $user_in_group) {
             if (!$check_mode) {
                 $group.Remove($member_sid)
-                $result.removed += $group_member.account_name
             }
+            $result.removed += $group_member.account_name
             $result.changed = $true
         }
     }
@@ -172,8 +172,8 @@ if ($state -eq "pure") {
             if ($user_to_remove) {
                 if (!$check_mode) {
                     $group.Remove($member_sid)
-                    $result.removed += $current_member.account_name
                 }
+                $result.removed += $current_member.account_name
                 $result.changed = $true
             }
         }
@@ -187,6 +187,10 @@ $final_members = Get-GroupMember -Group $group
 
 if ($final_members) {
     $result.members = [Array]$final_members.account_name
+    if ($check_mode) {
+        $result.members += $result.added 
+        $result.members = $result.members | ? {$_ -notin $result.removed}
+    }
 }
 else {
     $result.members = @()

--- a/plugins/modules/win_group_membership.ps1
+++ b/plugins/modules/win_group_membership.ps1
@@ -188,8 +188,8 @@ $final_members = Get-GroupMember -Group $group
 if ($final_members) {
     $result.members = [Array]$final_members.account_name
     if ($check_mode) {
-        $result.members += $result.added 
-        $result.members = $result.members | ? {$_ -notin $result.removed}
+        $result.members += $result.added
+        $result.members = $result.members | Where-Object {$_ -notin $result.removed}
     }
 }
 else {

--- a/plugins/modules/win_group_membership.ps1
+++ b/plugins/modules/win_group_membership.ps1
@@ -193,7 +193,7 @@ else {
 }
 
 if ($check_mode) {
-    if ($result.removed.added -gt 0) {
+    if ($result.added.count -gt 0) {
         $result.members += $result.added
     }
     if ($result.removed.count -gt 0) {

--- a/plugins/modules/win_group_membership.ps1
+++ b/plugins/modules/win_group_membership.ps1
@@ -194,7 +194,9 @@ else {
 
 if ($check_mode) {
     $result.members += $result.added
-    $result.members = $result.members | Where-Object { $_ -notin $result.removed }
+    if ($result.removed.count -gt 0) {
+        $result.members = $result.members | Where-Object { $_ -notin $result.removed }
+    }
 }
 
 Exit-Json -obj $result

--- a/plugins/modules/win_group_membership.ps1
+++ b/plugins/modules/win_group_membership.ps1
@@ -189,7 +189,7 @@ if ($final_members) {
     $result.members = [Array]$final_members.account_name
     if ($check_mode) {
         $result.members += $result.added
-        $result.members = $result.members | Where-Object {$_ -notin $result.removed}
+        $result.members = $result.members | Where-Object { $_ -notin $result.removed }
     }
 }
 else {

--- a/plugins/modules/win_group_membership.ps1
+++ b/plugins/modules/win_group_membership.ps1
@@ -193,7 +193,9 @@ else {
 }
 
 if ($check_mode) {
-    $result.members += $result.added
+    if ($result.removed.added -gt 0) {
+        $result.members += $result.added
+    }
     if ($result.removed.count -gt 0) {
         $result.members = $result.members | Where-Object { $_ -notin $result.removed }
     }

--- a/plugins/modules/win_group_membership.ps1
+++ b/plugins/modules/win_group_membership.ps1
@@ -187,13 +187,14 @@ $final_members = Get-GroupMember -Group $group
 
 if ($final_members) {
     $result.members = [Array]$final_members.account_name
-    if ($check_mode) {
-        $result.members += $result.added
-        $result.members = $result.members | Where-Object { $_ -notin $result.removed }
-    }
 }
 else {
     $result.members = @()
+}
+
+if ($check_mode) {
+    $result.members += $result.added
+    $result.members = $result.members | Where-Object { $_ -notin $result.removed }
 }
 
 Exit-Json -obj $result

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -81,6 +81,13 @@
     - add_users_to_group_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
   when: not in_check_mode
 
+- name: Test add_users_to_group_again (check mode)
+  assert:
+    that:
+    - add_users_to_group_again.changed == true
+    - add_users_to_group_again.added == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+    - add_users_to_group_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+  when: in_check_mode
 
 - name: Add different syntax users to group (again)
   win_group_membership:
@@ -121,7 +128,7 @@
     - add_another_user_to_group.added == ["NT AUTHORITY\\NETWORK SERVICE"]
     - add_another_user_to_group.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM", "NT AUTHORITY\\NETWORK SERVICE"]
   when: not in_check_mode
-
+  
 - name: Retrieve group content
   win_group_membership:
     name: "{{ win_local_group }}"
@@ -272,10 +279,11 @@
       - "{{ admin_account_name }}"
       - NT AUTHORITY\NETWORK SERVICE
   register: base_user_as_pure
+  check_mode: false
 
 - name: Variable wgm_present
   debug:
-    var: wgm_present
+    var: *wgm_present
     
 - name: Base pure users
   debug:
@@ -289,16 +297,27 @@
 
 - name: Variable wgm_pure
   debug:
-    var: wgm_pure
+    var: *wgm_pure
 
 - name: Variable wgm_present
   debug:
-    var: wgm_present
+    var: *wgm_present
     
 - name: After define users as pure
   debug:
     var: define_users_as_pure
-    
+
+- name: Retrieve group content after pure
+  win_group_membership:
+    name: "{{ win_local_group }}"
+    members:
+    state: present
+  register: group_content_pure
+
+- name: Variable group_content after pure
+  debug:
+    var: group_content_pure
+	
 - name: Test define_users_as_pure (normal mode)
   assert:
     that:

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -101,8 +101,8 @@
 - name: Test add_different_syntax_users_to_group_again (check-mode)
   assert:
     that:
-    - add_different_syntax_users_to_group_again.changed == false
-    - add_different_syntax_users_to_group_again.added == []
+    - add_different_syntax_users_to_group_again.changed == true
+    - add_different_syntax_users_to_group_again.added == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
     - add_different_syntax_users_to_group_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
   when: in_check_mode
 
@@ -199,8 +199,8 @@
 - name: Test add_different_syntax_users_to_group_again (check-mode)
   assert:
     that:
-    - remove_different_syntax_users_from_group_again.changed == false
-    - remove_different_syntax_users_from_group_again.removed == []
+    - remove_different_syntax_users_from_group_again.changed == true
+    - remove_different_syntax_users_from_group_again.removed == ["{{ ansible_hostname }}\\{{ admin_account_name }}", ".\\{{ win_local_user }}"]
     - remove_different_syntax_users_from_group_again.members == ["NT AUTHORITY\\NETWORK SERVICE"]
   when: in_check_mode
 
@@ -223,9 +223,9 @@
 - name: Test remove_another_user_from_group (check-mode)
   assert:
     that:
-    - remove_another_user_from_group.changed == false
+    - remove_another_user_from_group.changed == true
     - remove_another_user_from_group.removed == ["NT AUTHORITY\\NETWORK SERVICE"]
-    - remove_another_user_from_group.members == []
+    - remove_another_user_from_group.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]]
   when: in_check_mode
 
 

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -129,7 +129,7 @@
     state: present
   register: group_content
 
-  - name: Variable group_content
+- name: Variable group_content
   debug:
     var: group_content
     

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -161,9 +161,9 @@
 - name: Test remove_users_from_group (check-mode)
   assert:
     that:
-    - remove_users_from_group.changed == true
-    - remove_users_from_group.removed == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
-    - remove_users_from_group.members == ["NT AUTHORITY\\NETWORK SERVICE"]
+    - remove_users_from_group.changed == false
+    - remove_users_from_group.removed == []
+    - remove_users_from_group.members == []
   when: in_check_mode
 
 
@@ -196,12 +196,12 @@
     - remove_different_syntax_users_from_group_again.members == ["NT AUTHORITY\\NETWORK SERVICE"]
   when: not in_check_mode
 
-- name: Test add_different_syntax_users_to_group_again (check-mode)
+- name: Test remove_different_syntax_users_to_group_again (check-mode)
   assert:
     that:
-    - remove_different_syntax_users_from_group_again.changed == true
-    - remove_different_syntax_users_from_group_again.removed == ["{{ ansible_hostname }}\\{{ admin_account_name }}", ".\\{{ win_local_user }}"]
-    - remove_different_syntax_users_from_group_again.members == ["NT AUTHORITY\\NETWORK SERVICE"]
+    - remove_different_syntax_users_from_group_again.changed == false
+    - remove_different_syntax_users_from_group_again.removed == []
+    - remove_different_syntax_users_from_group_again.members == []
   when: in_check_mode
 
 
@@ -223,9 +223,9 @@
 - name: Test remove_another_user_from_group (check-mode)
   assert:
     that:
-    - remove_another_user_from_group.changed == true
-    - remove_another_user_from_group.removed == ["NT AUTHORITY\\NETWORK SERVICE"]
-    - remove_another_user_from_group.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]]
+    - remove_another_user_from_group.changed == false
+    - remove_another_user_from_group.removed == []
+    - remove_another_user_from_group.members == []
   when: in_check_mode
 
 

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -283,7 +283,7 @@
 
 - name: Variable wgm_present
   debug:
-    var: *wgm_present
+    var: wgm_present
     
 - name: Base pure users
   debug:
@@ -297,11 +297,11 @@
 
 - name: Variable wgm_pure
   debug:
-    var: *wgm_pure
+    var: wgm_pure
 
 - name: Variable wgm_present
   debug:
-    var: *wgm_present
+    var: wgm_present
     
 - name: After define users as pure
   debug:

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -140,13 +140,13 @@
   debug:
     var: group_content
     
-#- name: Test add_another_user_to_group (check-mode)
-#  assert:
-#    that:
-#    - add_another_user_to_group.changed == true
-#    - add_another_user_to_group.added == ["NT AUTHORITY\\NETWORK SERVICE"]
-#    - add_another_user_to_group.members == ["NT AUTHORITY\\NETWORK SERVICE"]
-#  when: in_check_mode
+- name: Test add_another_user_to_group (check-mode)
+  assert:
+    that:
+    - add_another_user_to_group.changed == true
+    - add_another_user_to_group.added == ["NT AUTHORITY\\NETWORK SERVICE"]
+    - add_another_user_to_group.members == ["NT AUTHORITY\\NETWORK SERVICE"]
+  when: in_check_mode
 
 
 - name: Add another user to group (again)
@@ -166,13 +166,13 @@
     var: add_another_user_to_group_again
 
     
-#- name: Test add_another_user_to_group_1_again (check mode)
-#  assert:
-#    that:
-#    - add_another_user_to_group_again.changed == true
-#    - add_another_user_to_group_again.added == ["NT AUTHORITY\\NETWORK SERVICE"]
-#    - add_another_user_to_group_again.members == ["NT AUTHORITY\\NETWORK SERVICE"]
-#  when: in_check_mode
+- name: Test add_another_user_to_group_1_again (check mode)
+  assert:
+    that:
+    - add_another_user_to_group_again.changed == true
+    - add_another_user_to_group_again.added == ["NT AUTHORITY\\NETWORK SERVICE"]
+    - add_another_user_to_group_again.members == ["NT AUTHORITY\\NETWORK SERVICE"]
+  when: in_check_mode
 
 - name: Remove users from group
   win_group_membership: &wgm_absent
@@ -280,10 +280,6 @@
       - NT AUTHORITY\NETWORK SERVICE
   register: base_user_as_pure
   check_mode: false
-
-- name: Variable wgm_present
-  debug:
-    var: wgm_present
     
 - name: Base pure users
   debug:
@@ -295,14 +291,6 @@
     state: pure
   register: define_users_as_pure
 
-- name: Variable wgm_pure
-  debug:
-    var: wgm_pure
-
-- name: Variable wgm_present
-  debug:
-    var: wgm_present
-    
 - name: After define users as pure
   debug:
     var: define_users_as_pure
@@ -380,7 +368,7 @@
   assert:
     that:
     - define_different_syntax_users_as_pure.changed == true
-    - define_different_syntax_users_as_pure.added == []
+    - define_different_syntax_users_as_pure.added == ["{{ ansible_hostname }}\\{{ win_local_user }}"]
     - define_different_syntax_users_as_pure.removed == ["NT AUTHORITY\\NETWORK SERVICE"]
     - define_different_syntax_users_as_pure.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}"]
   when: in_check_mode

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -122,6 +122,17 @@
     - add_another_user_to_group.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM", "NT AUTHORITY\\NETWORK SERVICE"]
   when: not in_check_mode
 
+- name: Retrieve group content
+  win_group_membership:
+    name: "{{ win_local_group }}"
+    members:
+    state: present
+  register: group_content
+
+  - name: Variable group_content
+  debug:
+    var: group_content
+    
 #- name: Test add_another_user_to_group (check-mode)
 #  assert:
 #    that:
@@ -146,6 +157,7 @@
 - name: Test add_another_user_to_group_1_again results
   debug:
     var: add_another_user_to_group_again
+
     
 #- name: Test add_another_user_to_group_1_again (check mode)
 #  assert:
@@ -261,6 +273,10 @@
       - NT AUTHORITY\NETWORK SERVICE
   register: base_user_as_pure
 
+- name: Variable wgm_present
+  debug:
+    var: wgm_present
+    
 - name: Base pure users
   debug:
     var: base_user_as_pure
@@ -271,6 +287,14 @@
     state: pure
   register: define_users_as_pure
 
+- name: Variable wgm_pure
+  debug:
+    var: wgm_pure
+
+- name: Variable wgm_present
+  debug:
+    var: wgm_present
+    
 - name: After define users as pure
   debug:
     var: define_users_as_pure

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -64,8 +64,8 @@
   assert:
     that:
     - add_users_to_group.changed == true
-    - add_users_to_group.added == []
-    - add_users_to_group.members == []
+    - add_users_to_group.added == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+    - add_users_to_group.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
   when: in_check_mode
 
 
@@ -101,9 +101,9 @@
 - name: Test add_different_syntax_users_to_group_again (check-mode)
   assert:
     that:
-    - add_different_syntax_users_to_group_again.changed == true
+    - add_different_syntax_users_to_group_again.changed == false
     - add_different_syntax_users_to_group_again.added == []
-    - add_different_syntax_users_to_group_again.members == []
+    - add_different_syntax_users_to_group_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
   when: in_check_mode
 
 
@@ -126,8 +126,8 @@
   assert:
     that:
     - add_another_user_to_group.changed == true
-    - add_another_user_to_group.added == []
-    - add_another_user_to_group.members == []
+    - add_another_user_to_group.added == ["NT AUTHORITY\\NETWORK SERVICE"]
+    - add_another_user_to_group.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM", "NT AUTHORITY\\NETWORK SERVICE"]
   when: in_check_mode
 
 
@@ -161,9 +161,9 @@
 - name: Test remove_users_from_group (check-mode)
   assert:
     that:
-    - remove_users_from_group.changed == false
-    - remove_users_from_group.removed == []
-    - remove_users_from_group.members == []
+    - remove_users_from_group.changed == true
+    - remove_users_from_group.removed == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+    - remove_users_from_group.members == ["NT AUTHORITY\\NETWORK SERVICE"]
   when: in_check_mode
 
 
@@ -201,7 +201,7 @@
     that:
     - remove_different_syntax_users_from_group_again.changed == false
     - remove_different_syntax_users_from_group_again.removed == []
-    - remove_different_syntax_users_from_group_again.members == []
+    - remove_different_syntax_users_from_group_again.members == ["NT AUTHORITY\\NETWORK SERVICE"]
   when: in_check_mode
 
 
@@ -224,7 +224,7 @@
   assert:
     that:
     - remove_another_user_from_group.changed == false
-    - remove_another_user_from_group.removed == []
+    - remove_another_user_from_group.removed == ["NT AUTHORITY\\NETWORK SERVICE"]
     - remove_another_user_from_group.members == []
   when: in_check_mode
 
@@ -269,9 +269,9 @@
   assert:
     that:
     - define_users_as_pure.changed == true
-    - define_users_as_pure.added == []
-    - define_users_as_pure.removed == []
-    - define_users_as_pure.members == []
+    - define_users_as_pure.added == ["{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+    - define_users_as_pure.removed == ["NT AUTHORITY\\NETWORK SERVICE"]
+    - define_users_as_pure.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
   when: in_check_mode
 
 
@@ -311,8 +311,8 @@
     that:
     - define_different_syntax_users_as_pure.changed == true
     - define_different_syntax_users_as_pure.added == []
-    - define_different_syntax_users_as_pure.removed == []
-    - define_different_syntax_users_as_pure.members == []
+    - define_different_syntax_users_as_pure.removed == ["NT AUTHORITY\\SYSTEM"]
+    - define_different_syntax_users_as_pure.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}"]
   when: in_check_mode
 
 

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -122,13 +122,13 @@
     - add_another_user_to_group.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM", "NT AUTHORITY\\NETWORK SERVICE"]
   when: not in_check_mode
 
-#- name: Test add_another_user_to_group (check-mode)
-#  assert:
-#    that:
-#    - add_another_user_to_group.changed == true
-#    - add_another_user_to_group.added == ["NT AUTHORITY\\NETWORK SERVICE"]
-#    - add_another_user_to_group.members == ["NT AUTHORITY\\NETWORK SERVICE"]
-#  when: in_check_mode
+- name: Test add_another_user_to_group (check-mode)
+  assert:
+    that:
+    - add_another_user_to_group.changed == true
+    - add_another_user_to_group.added == ["NT AUTHORITY\\NETWORK SERVICE"]
+    - add_another_user_to_group.members == ["NT AUTHORITY\\NETWORK SERVICE"]
+  when: in_check_mode
 
 
 - name: Add another user to group (again)
@@ -163,7 +163,7 @@
     that:
     - remove_users_from_group.changed == false
     - remove_users_from_group.removed == []
-    - remove_users_from_group.members == null
+    - remove_users_from_group.members == []
   when: in_check_mode
 
 
@@ -201,7 +201,7 @@
     that:
     - remove_different_syntax_users_from_group_again.changed == false
     - remove_different_syntax_users_from_group_again.removed == []
-    - remove_different_syntax_users_from_group_again.members == null
+    - remove_different_syntax_users_from_group_again.members == []
   when: in_check_mode
 
 
@@ -225,7 +225,7 @@
     that:
     - remove_another_user_from_group.changed == false
     - remove_another_user_from_group.removed == []
-    - remove_another_user_from_group.members == null
+    - remove_another_user_from_group.members == []
   when: in_check_mode
 
 

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -122,13 +122,13 @@
     - add_another_user_to_group.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM", "NT AUTHORITY\\NETWORK SERVICE"]
   when: not in_check_mode
 
-- name: Test add_another_user_to_group (check-mode)
-  assert:
-    that:
-    - add_another_user_to_group.changed == true
-    - add_another_user_to_group.added == ["NT AUTHORITY\\NETWORK SERVICE"]
-    - add_another_user_to_group.members == ["NT AUTHORITY\\NETWORK SERVICE"]
-  when: in_check_mode
+#- name: Test add_another_user_to_group (check-mode)
+#  assert:
+#    that:
+#    - add_another_user_to_group.changed == true
+#    - add_another_user_to_group.added == ["NT AUTHORITY\\NETWORK SERVICE"]
+#    - add_another_user_to_group.members == ["NT AUTHORITY\\NETWORK SERVICE"]
+#  when: in_check_mode
 
 
 - name: Add another user to group (again)

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -143,6 +143,10 @@
     - add_another_user_to_group_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM", "NT AUTHORITY\\NETWORK SERVICE"]
   when: not in_check_mode
 
+- name: Test add_another_user_to_group_1_again results
+  debug:
+    var: add_another_user_to_group_again
+    
 #- name: Test add_another_user_to_group_1_again (check mode)
 #  assert:
 #    that:
@@ -255,14 +259,22 @@
     members:
       - "{{ admin_account_name }}"
       - NT AUTHORITY\NETWORK SERVICE
+  register: base_user_as_pure
 
-
+- name: Base pure users
+  debug:
+    var: base_user_as_pure
+    
 - name: Define users as pure
   win_group_membership: &wgm_pure
     <<: *wgm_present
     state: pure
   register: define_users_as_pure
 
+- name: After define users as pure
+  debug:
+    var: define_users_as_pure
+    
 - name: Test define_users_as_pure (normal mode)
   assert:
     that:

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -143,13 +143,13 @@
     - add_another_user_to_group_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM", "NT AUTHORITY\\NETWORK SERVICE"]
   when: not in_check_mode
 
-- name: Test add_another_user_to_group_1_again (check mode)
-  assert:
-    that:
-    - add_another_user_to_group_again.changed == true
-    - add_another_user_to_group_again.added == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
-    - add_another_user_to_group_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM", "NT AUTHORITY\\NETWORK SERVICE"]
-  when: in_check_mode
+#- name: Test add_another_user_to_group_1_again (check mode)
+#  assert:
+#    that:
+#    - add_another_user_to_group_again.changed == true
+#    - add_another_user_to_group_again.added == ["NT AUTHORITY\\NETWORK SERVICE"]
+#    - add_another_user_to_group_again.members == ["NT AUTHORITY\\NETWORK SERVICE"]
+#  when: in_check_mode
 
 - name: Remove users from group
   win_group_membership: &wgm_absent

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -317,7 +317,7 @@
 - name: Variable group_content after pure
   debug:
     var: group_content_pure
-	
+
 - name: Test define_users_as_pure (normal mode)
   assert:
     that:

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -127,7 +127,7 @@
     that:
     - add_another_user_to_group.changed == true
     - add_another_user_to_group.added == ["NT AUTHORITY\\NETWORK SERVICE"]
-    - add_another_user_to_group.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM", "NT AUTHORITY\\NETWORK SERVICE"]
+    - add_another_user_to_group.members == ["NT AUTHORITY\\NETWORK SERVICE"]
   when: in_check_mode
 
 

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -102,8 +102,8 @@
   assert:
     that:
     - add_different_syntax_users_to_group_again.changed == true
-    - add_different_syntax_users_to_group_again.added == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
-    - add_different_syntax_users_to_group_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+    - add_different_syntax_users_to_group_again.added == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}"]
+    - add_different_syntax_users_to_group_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}"]
   when: in_check_mode
 
 

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -163,7 +163,7 @@
     that:
     - remove_users_from_group.changed == false
     - remove_users_from_group.removed == []
-    - remove_users_from_group.members == []
+    - remove_users_from_group.members == null
   when: in_check_mode
 
 
@@ -201,7 +201,7 @@
     that:
     - remove_different_syntax_users_from_group_again.changed == false
     - remove_different_syntax_users_from_group_again.removed == []
-    - remove_different_syntax_users_from_group_again.members == []
+    - remove_different_syntax_users_from_group_again.members == null
   when: in_check_mode
 
 
@@ -225,7 +225,7 @@
     that:
     - remove_another_user_from_group.changed == false
     - remove_another_user_from_group.removed == []
-    - remove_another_user_from_group.members == []
+    - remove_another_user_from_group.members == null
   when: in_check_mode
 
 

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -122,13 +122,13 @@
     - add_another_user_to_group.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM", "NT AUTHORITY\\NETWORK SERVICE"]
   when: not in_check_mode
 
-- name: Test add_another_user_to_group (check-mode)
-  assert:
-    that:
-    - add_another_user_to_group.changed == true
-    - add_another_user_to_group.added == ["NT AUTHORITY\\NETWORK SERVICE"]
-    - add_another_user_to_group.members == ["NT AUTHORITY\\NETWORK SERVICE"]
-  when: in_check_mode
+#- name: Test add_another_user_to_group (check-mode)
+#  assert:
+#    that:
+#    - add_another_user_to_group.changed == true
+#    - add_another_user_to_group.added == ["NT AUTHORITY\\NETWORK SERVICE"]
+#    - add_another_user_to_group.members == ["NT AUTHORITY\\NETWORK SERVICE"]
+#  when: in_check_mode
 
 
 - name: Add another user to group (again)
@@ -143,6 +143,13 @@
     - add_another_user_to_group_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM", "NT AUTHORITY\\NETWORK SERVICE"]
   when: not in_check_mode
 
+- name: Test add_another_user_to_group_1_again (check mode)
+  assert:
+    that:
+    - add_another_user_to_group_again.changed == true
+    - add_another_user_to_group_again.added == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+    - add_another_user_to_group_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM", "NT AUTHORITY\\NETWORK SERVICE"]
+  when: in_check_mode
 
 - name: Remove users from group
   win_group_membership: &wgm_absent
@@ -288,6 +295,14 @@
     - define_users_as_pure_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
   when: not in_check_mode
 
+- name: Test define_users_as_pure_again (check mode)
+  assert:
+    that:
+    - define_users_as_pure_again.changed == true
+    - define_users_as_pure_again.added == ["{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+    - define_users_as_pure_again.removed == ["NT AUTHORITY\\NETWORK SERVICE"]
+    - define_users_as_pure_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+  when: in_check_mode
 
 - name: Define different syntax users as pure
   win_group_membership:
@@ -311,7 +326,7 @@
     that:
     - define_different_syntax_users_as_pure.changed == true
     - define_different_syntax_users_as_pure.added == []
-    - define_different_syntax_users_as_pure.removed == ["NT AUTHORITY\\SYSTEM"]
+    - define_different_syntax_users_as_pure.removed == ["NT AUTHORITY\\NETWORK SERVICE"]
     - define_different_syntax_users_as_pure.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}"]
   when: in_check_mode
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #532

Using check_mode on ansible.windows.win_group_membership module does not return accurate result values.

The win_group_membership module has 4 return values, but the added/removed and members value do not represent accurate results when using pure mode.

I we populate the $result variable with added and removed values we'll get accurate results in check_mode, currently the $result variable is only updated when we don't run in check_mode 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible.windows.win_group_membership

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:

ok: [testserver.fabrikam.com] => {
    "varlocalmembership": {
        "added": [],
        "changed": true,
        "failed": false,
        "members": [
            "TESTSERVER\\\\Administrator",
            "FABRIKAM\\\\Domain Admins",
            "TESTSERVER\\\\LocalAccount",
            "FABRIKAM\\\\G-WSOSADMIN",
            "FABRIKAM\\\\G-TESTSERVER-ADMIN",
			"FABRIKAM\\\\G-SQLDB-A"
        ],
        "name": "Administrators",
        "removed": []
    }
}

After:

ok: [testserver.fabrikam.com] => {
    "varlocalmembership": {
        "added": [
            "FABRIKAM\\\\G-SQLDB-P"
        ],
        "changed": true,
        "failed": false,
        "members": [
            "TESTSERVER\\\\Administrator",
            "FABRIKAM\\\\Domain Admins",
            "TESTSERVER\\\\LocalAccount",
            "FABRIKAM\\\\G-WSOSADMIN",
            "FABRIKAM\\\\G-TESTSERVER-ADMIN"
        ],
        "name": "Administrators",
        "removed": [
            "FABRIKAM\\\\G-SQLDB-A"
        ]
    }
}
