### PR TITLE
Fix broken path in case of volume junction

### DIFF
--- a/changelogs/fragments/win-acl-mount-points.yml
+++ b/changelogs/fragments/win-acl-mount-points.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_async - 

--- a/changelogs/fragments/win-acl-mount-points.yml
+++ b/changelogs/fragments/win-acl-mount-points.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- win_async - 
+- win_acl - Fix broken path in case of volume junction

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -116,7 +116,7 @@ while ($follow) {
 
     if ($link_info -and $link_info.Type -in @("SymbolicLink", "JunctionPoint")) {
         $path = $link_info.AbsolutePath
-        if ($link_info.Type -eq "JunctionPoint") {
+        if ($link_info.SubstituteName -like "\??\*") {
             $path = "\\?\" + $path
         }
     }

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -116,6 +116,9 @@ while ($follow) {
 
     if ($link_info -and $link_info.Type -in @("SymbolicLink", "JunctionPoint")) {
         $path = $link_info.AbsolutePath
+        if ($link_info.Type -eq "JunctionPoint") {
+            $path = "\\?\" + $path
+        }
     }
     else {
         break


### PR DESCRIPTION
##### SUMMARY
win_acl is bronken in case of junction + follow option

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_acl

##### ADDITIONAL INFORMATION
By using the option `folllow`, if the link is a junction to a volume we get an error like :
`"Volume{ad5b0320-77a0-4523-a8c8-00a52b860819}\\ file or directory does not exist on the host"`

The internal function `Get-Link` seems returns the absolute UNC path without prefix...
