### PR TITLE
win_updates - Add alternative to scheduled task

### DIFF
--- a/changelogs/fragments/win_updates-become-proc.yml
+++ b/changelogs/fragments/win_updates-become-proc.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- >-
+  win_updates - Avoid using a scheduled task to spawn the updates background job when running as become. This provides
+  an alternative method available to users in case the task scheduler does not work on their system - https://github.com/ansible-collections/ansible.windows/issues/543

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -945,6 +945,9 @@ class ActionModule(ActionBase):
                 extra_result['stderr'] = result['stderr']
             raise _ReturnResultException(msg, exception=result.get('exception', None), **extra_result)
 
+        for w in result.get('warnings', []):
+            display.warning(w)
+
         return result
 
     def _get_update_info(self, update_id):  # type: (str) -> Dict

--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -130,6 +130,9 @@ notes:
   recommended to set C(-o ServerAliveInterval=30) and disable control master
   in I(ansible_ssh_args) to ensure the client can handle a network reset.
   See the examples showing one way this can be set.
+- By default the module will start a background process using the Task
+  Scheduler on Windows. If the Task Scheduler is unavailable, unreliable, or
+  does not work, run the task with become.
 seealso:
 - module: chocolatey.chocolatey.win_chocolatey
 - module: ansible.windows.win_feature
@@ -162,6 +165,9 @@ EXAMPLES = r"""
       - SecurityUpdates
       - CriticalUpdates
       - UpdateRollups
+  become: true
+  become_method: runas
+  become_user: SYSTEM
 
 - name: Search-only, return list of found updates (if any), log to C:\ansible_wu.txt
   ansible.windows.win_updates:

--- a/tests/integration/targets/win_updates/tasks/main.yml
+++ b/tests/integration/targets/win_updates/tasks/main.yml
@@ -66,26 +66,42 @@
   become_method: runas
   become_user: SYSTEM
 
+- name: search for all updates with async and become
+  win_updates:
+    category_names: '*'
+    state: searched
+  register: search_async_and_become
+  async: 60
+  become: yes
+  become_method: runas
+  become_user: SYSTEM
+
 - assert:
     that:
     - not search_sync is changed
     - not search_async is changed
     - not search_become is changed
+    - not search_async_and_become is changed
     - not search_sync.reboot_required
     - not search_async.reboot_required
     - not search_become.reboot_required
+    - not search_async_and_become.reboot_required
     - search_sync.failed_update_count == 0
     - search_async.failed_update_count == 0
     - search_become.failed_update_count == 0
+    - search_async_and_become.failed_update_count == 0
     - search_sync.installed_update_count == 0
     - search_async.installed_update_count == 0
     - search_become.installed_update_count == 0
+    - search_async_and_become.installed_update_count == 0
     - search_sync.found_update_count == search_sync.updates|length
     - search_async.found_update_count == search_async.updates|length
     - search_become.found_update_count == search_become.updates|length
+    - search_async_and_become.found_update_count == search_async_and_become.updates|length
     - search_sync.filtered_updates == {}
     - search_async.filtered_updates == {}
     - search_become.filtered_updates == {}
+    - search_async_and_become.filtered_updates == {}
 
 - name: search updates - check mode
   win_updates:


### PR DESCRIPTION
##### SUMMARY
The task scheduler can be problematic in a few different scenarios (DA account being used, is corrupted, etc). This PR allows the user to run `win_updates` with become which will spawn the `win_updates` background task without having to use the task scheduler at all. This will give users options allowing them to choose what bootstrapping option fits better for their environment.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/543.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_updates