### PR TITLE
Add support for setting ACL rules on certificates

### DIFF
--- a/plugins/module_utils/CertACLHelper.cs
+++ b/plugins/module_utils/CertACLHelper.cs
@@ -8,7 +8,6 @@ using System.Security.Principal;
 
 //TypeAccelerator -Name Ansible.Windows.CertAclHelper.CryptHandle -TypeName CryptHandle
 //TypeAccelerator -Name Ansible.Windows.CertAclHelper.SafeSecurityDescriptorPtr -TypeName SafeSecurityDescriptorPtr
-//TypeAccelerator -Name Ansible.Windows.CertAclHelper.CertAccessRights -TypeName CertAccessRights
 //TypeAccelerator -Name Ansible.Windows.CertAclHelper.CertAclHelper -TypeName CertAclHelper
 
 namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
@@ -72,13 +71,6 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
                 return false;
             }
         }
-    }
-
-    [Flags]
-    public enum CertAccessRights : uint
-    {
-        Read = 0x80000000,
-        FullControl = 0x10000000
     }
 
     public class CertAclHelper

--- a/plugins/module_utils/CertACLHelper.cs
+++ b/plugins/module_utils/CertACLHelper.cs
@@ -8,11 +8,12 @@ using System.Security.Principal;
 
 //TypeAccelerator -Name Ansible.Windows.CertAclHelper.CryptHandle -TypeName CryptHandle
 //TypeAccelerator -Name Ansible.Windows.CertAclHelper.SafeSecurityDescriptorPtr -TypeName SafeSecurityDescriptorPtr
+//TypeAccelerator -Name Ansible.Windows.CertAclHelper.CertAccessRights -TypeName CertAccessRights
 //TypeAccelerator -Name Ansible.Windows.CertAclHelper.CertAclHelper -TypeName CertAclHelper
 
 namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
 {
-    private class CryptHandle : SafeHandleZeroOrMinusOneIsInvalid
+    class CryptHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         public CryptHandle()
             : base(true)
@@ -35,7 +36,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
         }
     }
 
-    private class SafeSecurityDescriptorPtr : SafeHandleZeroOrMinusOneIsInvalid
+    class SafeSecurityDescriptorPtr : SafeHandleZeroOrMinusOneIsInvalid
     {
         private int size = -1;
 
@@ -73,6 +74,13 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
         }
     }
 
+    [Flags]
+    public enum CertAccessRights : uint
+    {
+        Read = 0x80000000,
+        FullControl = 0x10000000
+    }
+
     public class CertAclHelper
     {
         [Flags]
@@ -86,7 +94,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
             CRYPT_ACQUIRE_SILENT_FLAG = 0x00000040,
         }
         [Flags]
-        private enum CryptAcquireKeyFlagControl : uint
+        public enum CryptAcquireKeyFlagControl : uint
         {
             CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG = 0x00010000,
             CRYPT_ACQUIRE_PREFER_NCRYPT_KEY_FLAG = 0x00020000,
@@ -156,7 +164,6 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
                 throw new Win32Exception(Marshal.GetLastWin32Error());
             }
         }
-
         public FileSecurity Acl
         {
             get

--- a/plugins/module_utils/CertACLHelper.cs
+++ b/plugins/module_utils/CertACLHelper.cs
@@ -165,27 +165,29 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
                 uint securityDescriptorSize = 0;
                 if (ncrypt)
                 {
-                    if (NCryptGetProperty(
+                    int securityDescriptorResult = NCryptGetProperty(
                         handle,
                         "Security Descr",
                         new SafeSecurityDescriptorPtr(),
                         0,
                         ref securityDescriptorSize,
-                        SecurityInformationFlags.DACL_SECURITY_INFORMATION) != 0)
+                        SecurityInformationFlags.DACL_SECURITY_INFORMATION);
+                    if (securityDescriptorResult != 0)
                     {
-                        throw new Exception("Could not get security descriptor");
+                        throw new Win32Exception(securityDescriptorResult);
                     }
                     securityDescriptorBuffer = new SafeSecurityDescriptorPtr(securityDescriptorSize);
 
-                    if (NCryptGetProperty(
+                    securityDescriptorResult = NCryptGetProperty(
                         handle,
                         "Security Descr",
                         securityDescriptorBuffer,
                         securityDescriptorSize,
                         ref securityDescriptorSize,
-                        SecurityInformationFlags.DACL_SECURITY_INFORMATION) != 0)
+                        SecurityInformationFlags.DACL_SECURITY_INFORMATION);
+                    if (securityDescriptorResult != 0)
                     {
-                        throw new Exception("Could not get security descriptor");
+                        throw new Win32Exception(securityDescriptorResult);
                     }
 
                 }
@@ -225,14 +227,15 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
                 if (ncrypt)
                 {
                     byte[] sd = value.GetSecurityDescriptorBinaryForm();
-                    if (NCryptSetProperty(
+                    int setPropertyResult = NCryptSetProperty(
                         handle,
                         "Security Descr",
                         sd,
                         (uint)sd.Length,
-                        SecurityInformationFlags.DACL_SECURITY_INFORMATION) != 0)
+                        SecurityInformationFlags.DACL_SECURITY_INFORMATION);
+                    if (setPropertyResult != 0)
                     {
-                        throw new Exception("Could not set security descriptor");
+                        throw new Win32Exception(setPropertyResult);
                     }
                 }
                 else

--- a/plugins/module_utils/CertACLHelper.cs
+++ b/plugins/module_utils/CertACLHelper.cs
@@ -8,6 +8,7 @@ using System.Security.Principal;
 
 //TypeAccelerator -Name Ansible.Windows.CertAclHelper.CryptHandle -TypeName CryptHandle
 //TypeAccelerator -Name Ansible.Windows.CertAclHelper.SafeSecurityDescriptorPtr -TypeName SafeSecurityDescriptorPtr
+//TypeAccelerator -Name Ansible.Windows.CertAclHelper.CertAccessRights -TypeName CertAccessRights
 //TypeAccelerator -Name Ansible.Windows.CertAclHelper.CertAclHelper -TypeName CertAclHelper
 
 namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
@@ -71,6 +72,13 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
                 return false;
             }
         }
+    }
+
+    [Flags]
+    public enum CertAccessRights : int
+    {
+        Read = -2146303863,
+        FullControl = -803274241
     }
 
     public class CertAclHelper

--- a/plugins/module_utils/CertACLHelper.cs
+++ b/plugins/module_utils/CertACLHelper.cs
@@ -1,0 +1,252 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.Win32.SafeHandles;
+using System.Security.Principal;
+
+//TypeAccelerator -Name Ansible.Windows.CertAclHelper.CryptHandle -TypeName CryptHandle
+//TypeAccelerator -Name Ansible.Windows.CertAclHelper.SafeSecurityDescriptorPtr -TypeName SafeSecurityDescriptorPtr
+//TypeAccelerator -Name Ansible.Windows.CertAclHelper.CertAclHelper -TypeName CertAclHelper
+
+namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
+{
+    private class CryptHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        public CryptHandle()
+            : base(true)
+        {
+        }
+
+        public CryptHandle(IntPtr handle)
+            : base(true)
+        {
+            this.SetHandle(handle);
+        }
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CryptReleaseContext(IntPtr safeProvHandle, uint dwFlags);
+
+        protected override bool ReleaseHandle()
+        {
+            return CryptReleaseContext(this.handle, 0);
+        }
+    }
+
+    private class SafeSecurityDescriptorPtr : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        private int size = -1;
+
+        public SafeSecurityDescriptorPtr()
+            : base(true)
+        {
+        }
+
+        public SafeSecurityDescriptorPtr(uint size)
+            : base(true)
+        {
+            this.size = (int)size;
+            this.SetHandle(Marshal.AllocHGlobal(this.size));
+        }
+
+        public SafeSecurityDescriptorPtr(IntPtr handle)
+            : base(true)
+        {
+            this.SetHandle(handle);
+        }
+
+        protected override bool ReleaseHandle()
+        {
+            try
+            {
+                Marshal.FreeHGlobal(this.handle);
+                return true;
+            }
+            catch
+            {
+                // semantics of this function are to never throw an exception so we must eat the underlying error and 
+                // return false. 
+                return false;
+            }
+        }
+    }
+
+    public class CertAclHelper
+    {
+        [Flags]
+        public enum SecurityInformationFlags : uint
+        {
+            DACL_SECURITY_INFORMATION = 0x00000004,
+        }
+        [Flags]
+        public enum CryptAcquireKeyFlags : uint
+        {
+            CRYPT_ACQUIRE_SILENT_FLAG = 0x00000040,
+        }
+        [Flags]
+        private enum CryptAcquireKeyFlagControl : uint
+        {
+            CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG = 0x00010000,
+            CRYPT_ACQUIRE_PREFER_NCRYPT_KEY_FLAG = 0x00020000,
+            CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG = 0x00040000,
+        }
+        public enum KeySpec : uint
+        {
+            NONE = 0x0,
+            AT_KEYEXCHANGE = 0x1,
+            AT_SIGNATURE = 2,
+            CERT_NCRYPT_KEY_SPEC = 0xFFFFFFFF
+        }
+
+        [DllImport("crypt32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern bool CryptAcquireCertificatePrivateKey(IntPtr pCert, uint dwFlags, IntPtr pvParameters, out CryptHandle phCryptProvOrNCryptKey, out KeySpec pdwKeySpec, out bool pfCallerFreeProvOrNCryptKey);
+
+        [DllImport("ncrypt.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern int NCryptGetProperty(CryptHandle hObject, [MarshalAs(UnmanagedType.LPWStr)] string pszProperty, SafeSecurityDescriptorPtr pbOutput, uint cbOutput, ref uint pcbResult, SecurityInformationFlags dwFlags);
+
+        [DllImport("ncrypt.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern int NCryptSetProperty(CryptHandle hObject, [MarshalAs(UnmanagedType.LPWStr)] string pszProperty, [MarshalAs(UnmanagedType.LPArray)] byte[] pbInput, uint cbInput, SecurityInformationFlags dwFlags);
+
+        public enum CryptProvParam : uint
+        {
+            PP_KEYSET_SEC_DESCR = 8
+        }
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CryptGetProvParam(CryptHandle safeProvHandle, CryptProvParam dwParam, SafeSecurityDescriptorPtr pbData, ref uint dwDataLen, SecurityInformationFlags dwFlags);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CryptSetProvParam(CryptHandle safeProvHandle, CryptProvParam dwParam, [MarshalAs(UnmanagedType.LPArray)] byte[] pbData, SecurityInformationFlags dwFlags);
+
+        CryptHandle handle;
+        bool ncrypt = false;
+
+        public CertAclHelper(X509Certificate2 certificate)
+        {
+            CryptHandle certPkeyHandle;
+            KeySpec keySpec;
+
+            bool ownHandle;
+            if (CryptAcquireCertificatePrivateKey(
+                    certificate.Handle,
+                    (uint)CryptAcquireKeyFlags.CRYPT_ACQUIRE_SILENT_FLAG | (uint)CryptAcquireKeyFlagControl.CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG,
+                    IntPtr.Zero,
+                    out certPkeyHandle,
+                    out keySpec,
+                    out ownHandle))
+            {
+                if (!ownHandle)
+                {
+                    throw new NotSupportedException("Could not take ownership of certificate private key handle");
+                }
+
+                if (keySpec == KeySpec.CERT_NCRYPT_KEY_SPEC)
+                {
+                    ncrypt = true;
+                }
+
+                handle = certPkeyHandle;
+            }
+            else
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error());
+            }
+        }
+
+        public FileSecurity Acl
+        {
+            get
+            {
+                SafeSecurityDescriptorPtr securityDescriptorBuffer;
+                uint securityDescriptorSize = 0;
+                if (ncrypt)
+                {
+                    if (NCryptGetProperty(
+                        handle,
+                        "Security Descr",
+                        new SafeSecurityDescriptorPtr(),
+                        0,
+                        ref securityDescriptorSize,
+                        SecurityInformationFlags.DACL_SECURITY_INFORMATION) != 0)
+                    {
+                        throw new Exception("Could not get security descriptor");
+                    }
+                    securityDescriptorBuffer = new SafeSecurityDescriptorPtr(securityDescriptorSize);
+
+                    if (NCryptGetProperty(
+                        handle,
+                        "Security Descr",
+                        securityDescriptorBuffer,
+                        securityDescriptorSize,
+                        ref securityDescriptorSize,
+                        SecurityInformationFlags.DACL_SECURITY_INFORMATION) != 0)
+                    {
+                        throw new Exception("Could not get security descriptor");
+                    }
+
+                }
+                else
+                {
+                    if (!CryptGetProvParam(
+                            handle,
+                            CryptProvParam.PP_KEYSET_SEC_DESCR,
+                            new SafeSecurityDescriptorPtr(),
+                            ref securityDescriptorSize,
+                            SecurityInformationFlags.DACL_SECURITY_INFORMATION))
+                    {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+
+                    securityDescriptorBuffer = new SafeSecurityDescriptorPtr(securityDescriptorSize);
+                    if (!CryptGetProvParam(
+                            handle,
+                            CryptProvParam.PP_KEYSET_SEC_DESCR,
+                            securityDescriptorBuffer,
+                            ref securityDescriptorSize,
+                            SecurityInformationFlags.DACL_SECURITY_INFORMATION))
+                    {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+
+                }
+                byte[] buffer = new byte[securityDescriptorSize];
+                Marshal.Copy(securityDescriptorBuffer.DangerousGetHandle(), buffer, 0, buffer.Length);
+                FileSecurity acl = new FileSecurity();
+                acl.SetSecurityDescriptorBinaryForm(buffer);
+
+                return acl;
+            }
+            set
+            {
+                if (ncrypt)
+                {
+                    byte[] sd = value.GetSecurityDescriptorBinaryForm();
+                    if (NCryptSetProperty(
+                        handle,
+                        "Security Descr",
+                        sd,
+                        (uint)sd.Length,
+                        SecurityInformationFlags.DACL_SECURITY_INFORMATION) != 0)
+                    {
+                        throw new Exception("Could not set security descriptor");
+                    }
+                }
+                else
+                {
+                    if (!CryptSetProvParam(
+                        handle, 
+                        CryptProvParam.PP_KEYSET_SEC_DESCR,
+                        value.GetSecurityDescriptorBinaryForm(), 
+                        SecurityInformationFlags.DACL_SECURITY_INFORMATION))
+                    {
+                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                    }
+                }
+            }
+        }
+    }
+}

--- a/plugins/module_utils/CertACLHelper.cs
+++ b/plugins/module_utils/CertACLHelper.cs
@@ -6,14 +6,12 @@ using System.Security.Cryptography.X509Certificates;
 using Microsoft.Win32.SafeHandles;
 using System.Security.Principal;
 
-//TypeAccelerator -Name Ansible.Windows.CertAclHelper.CryptHandle -TypeName CryptHandle
-//TypeAccelerator -Name Ansible.Windows.CertAclHelper.SafeSecurityDescriptorPtr -TypeName SafeSecurityDescriptorPtr
 //TypeAccelerator -Name Ansible.Windows.CertAclHelper.CertAccessRights -TypeName CertAccessRights
 //TypeAccelerator -Name Ansible.Windows.CertAclHelper.CertAclHelper -TypeName CertAclHelper
 
 namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
 {
-    class CryptHandle : SafeHandleZeroOrMinusOneIsInvalid
+    internal class CryptHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
         public CryptHandle()
             : base(true)
@@ -36,8 +34,8 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
         }
     }
 
-    class SafeSecurityDescriptorPtr : SafeHandleZeroOrMinusOneIsInvalid
-    {
+    internal class SafeSecurityDescriptorPtr : SafeHandleZeroOrMinusOneIsInvalid
+    {        
         private int size = -1;
 
         public SafeSecurityDescriptorPtr()
@@ -50,12 +48,6 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
         {
             this.size = (int)size;
             this.SetHandle(Marshal.AllocHGlobal(this.size));
-        }
-
-        public SafeSecurityDescriptorPtr(IntPtr handle)
-            : base(true)
-        {
-            this.SetHandle(handle);
         }
 
         protected override bool ReleaseHandle()
@@ -84,23 +76,26 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
     public class CertAclHelper
     {
         [Flags]
-        public enum SecurityInformationFlags : uint
+        private enum SecurityInformationFlags : uint
         {
             DACL_SECURITY_INFORMATION = 0x00000004,
         }
+
         [Flags]
-        public enum CryptAcquireKeyFlags : uint
+        private enum CryptAcquireKeyFlags : uint
         {
             CRYPT_ACQUIRE_SILENT_FLAG = 0x00000040,
         }
+
         [Flags]
-        public enum CryptAcquireKeyFlagControl : uint
+        private enum CryptAcquireKeyFlagControl : uint
         {
             CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG = 0x00010000,
             CRYPT_ACQUIRE_PREFER_NCRYPT_KEY_FLAG = 0x00020000,
             CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG = 0x00040000,
         }
-        public enum KeySpec : uint
+
+        private enum KeySpec : uint
         {
             NONE = 0x0,
             AT_KEYEXCHANGE = 0x1,
@@ -117,7 +112,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
         [DllImport("ncrypt.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern int NCryptSetProperty(CryptHandle hObject, [MarshalAs(UnmanagedType.LPWStr)] string pszProperty, [MarshalAs(UnmanagedType.LPArray)] byte[] pbInput, uint cbInput, SecurityInformationFlags dwFlags);
 
-        public enum CryptProvParam : uint
+        private enum CryptProvParam : uint
         {
             PP_KEYSET_SEC_DESCR = 8
         }
@@ -161,9 +156,10 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
             }
             else
             {
-                throw new Win32Exception(Marshal.GetLastWin32Error());
+                throw new Win32Exception();
             }
         }
+
         public FileSecurity Acl
         {
             get
@@ -207,7 +203,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
                             ref securityDescriptorSize,
                             SecurityInformationFlags.DACL_SECURITY_INFORMATION))
                     {
-                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                        throw new Win32Exception();
                     }
 
                     securityDescriptorBuffer = new SafeSecurityDescriptorPtr(securityDescriptorSize);
@@ -218,7 +214,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
                             ref securityDescriptorSize,
                             SecurityInformationFlags.DACL_SECURITY_INFORMATION))
                     {
-                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                        throw new Win32Exception();
                     }
 
                 }
@@ -253,7 +249,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
                         value.GetSecurityDescriptorBinaryForm(), 
                         SecurityInformationFlags.DACL_SECURITY_INFORMATION))
                     {
-                        throw new Win32Exception(Marshal.GetLastWin32Error());
+                        throw new Win32Exception();
                     }
                 }
             }

--- a/plugins/module_utils/_CertACLHelper.cs
+++ b/plugins/module_utils/_CertACLHelper.cs
@@ -123,14 +123,13 @@ namespace ansible_collections.ansible.windows.plugins.module_utils._CertACLHelpe
         [return: MarshalAs(UnmanagedType.Bool)]
         private static extern bool CryptSetProvParam(SafeCryptHandle safeProvHandle, CryptProvParam dwParam, [MarshalAs(UnmanagedType.LPArray)] byte[] pbData, SecurityInformationFlags dwFlags);
 
-        SafeCryptHandle handle;
-        bool ncrypt = false;
+        private SafeCryptHandle handle;
+        private bool ncrypt = false;
 
         public CertAclHelper(X509Certificate2 certificate)
         {
             SafeCryptHandle certPkeyHandle;
             KeySpec keySpec;
-
             bool ownHandle;
             if (CryptAcquireCertificatePrivateKey(
                     certificate.Handle,
@@ -166,7 +165,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils._CertACLHelpe
                 uint securityDescriptorSize = 0;
                 if (ncrypt)
                 {
-                    int securityDescriptorResult = NCryptGetProperty(
+                    var securityDescriptorResult = NCryptGetProperty(
                         handle,
                         "Security Descr",
                         new SafeSecurityDescriptorPtr(),
@@ -216,9 +215,9 @@ namespace ansible_collections.ansible.windows.plugins.module_utils._CertACLHelpe
                     }
 
                 }
-                byte[] buffer = new byte[securityDescriptorSize];
+                var buffer = new byte[securityDescriptorSize];
                 Marshal.Copy(securityDescriptorBuffer.DangerousGetHandle(), buffer, 0, buffer.Length);
-                FileSecurity acl = new FileSecurity();
+                var acl = new FileSecurity();
                 acl.SetSecurityDescriptorBinaryForm(buffer);
 
                 return acl;
@@ -227,8 +226,8 @@ namespace ansible_collections.ansible.windows.plugins.module_utils._CertACLHelpe
             {
                 if (ncrypt)
                 {
-                    byte[] sd = value.GetSecurityDescriptorBinaryForm();
-                    int setPropertyResult = NCryptSetProperty(
+                    var sd = value.GetSecurityDescriptorBinaryForm();
+                    var setPropertyResult = NCryptSetProperty(
                         handle,
                         "Security Descr",
                         sd,

--- a/plugins/module_utils/_CertACLHelper.cs
+++ b/plugins/module_utils/_CertACLHelper.cs
@@ -10,10 +10,10 @@ using System.Security.Cryptography.X509Certificates;
 using Microsoft.Win32.SafeHandles;
 using System.Security.Principal;
 
-//TypeAccelerator -Name Ansible.Windows.CertAclHelper.CertAccessRights -TypeName CertAccessRights
-//TypeAccelerator -Name Ansible.Windows.CertAclHelper.CertAclHelper -TypeName CertAclHelper
+//TypeAccelerator -Name Ansible.Windows._CertAclHelper.CertAccessRights -TypeName CertAccessRights
+//TypeAccelerator -Name Ansible.Windows._CertAclHelper.CertAclHelper -TypeName CertAclHelper
 
-namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
+namespace ansible_collections.ansible.windows.plugins.module_utils._CertACLHelper
 {
     internal class CryptHandle : SafeHandleZeroOrMinusOneIsInvalid
     {

--- a/plugins/module_utils/_CertACLHelper.cs
+++ b/plugins/module_utils/_CertACLHelper.cs
@@ -15,9 +15,9 @@ using System.Security.Principal;
 
 namespace ansible_collections.ansible.windows.plugins.module_utils._CertACLHelper
 {
-    internal class CryptHandle : SafeHandleZeroOrMinusOneIsInvalid
+    internal class SafeCryptHandle : SafeHandleZeroOrMinusOneIsInvalid
     {
-        public CryptHandle()
+        public SafeCryptHandle()
             : base(true)
         {
         }
@@ -102,13 +102,13 @@ namespace ansible_collections.ansible.windows.plugins.module_utils._CertACLHelpe
         }
 
         [DllImport("crypt32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern bool CryptAcquireCertificatePrivateKey(IntPtr pCert, uint dwFlags, IntPtr pvParameters, out CryptHandle phCryptProvOrNCryptKey, out KeySpec pdwKeySpec, out bool pfCallerFreeProvOrNCryptKey);
+        private static extern bool CryptAcquireCertificatePrivateKey(IntPtr pCert, uint dwFlags, IntPtr pvParameters, out SafeCryptHandle phCryptProvOrNCryptKey, out KeySpec pdwKeySpec, out bool pfCallerFreeProvOrNCryptKey);
 
         [DllImport("ncrypt.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern int NCryptGetProperty(CryptHandle hObject, [MarshalAs(UnmanagedType.LPWStr)] string pszProperty, SafeSecurityDescriptorPtr pbOutput, uint cbOutput, ref uint pcbResult, SecurityInformationFlags dwFlags);
+        private static extern int NCryptGetProperty(SafeCryptHandle hObject, [MarshalAs(UnmanagedType.LPWStr)] string pszProperty, SafeSecurityDescriptorPtr pbOutput, uint cbOutput, ref uint pcbResult, SecurityInformationFlags dwFlags);
 
         [DllImport("ncrypt.dll", CharSet = CharSet.Unicode, SetLastError = true)]
-        private static extern int NCryptSetProperty(CryptHandle hObject, [MarshalAs(UnmanagedType.LPWStr)] string pszProperty, [MarshalAs(UnmanagedType.LPArray)] byte[] pbInput, uint cbInput, SecurityInformationFlags dwFlags);
+        private static extern int NCryptSetProperty(SafeCryptHandle hObject, [MarshalAs(UnmanagedType.LPWStr)] string pszProperty, [MarshalAs(UnmanagedType.LPArray)] byte[] pbInput, uint cbInput, SecurityInformationFlags dwFlags);
 
         private enum CryptProvParam : uint
         {
@@ -117,18 +117,18 @@ namespace ansible_collections.ansible.windows.plugins.module_utils._CertACLHelpe
 
         [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool CryptGetProvParam(CryptHandle safeProvHandle, CryptProvParam dwParam, SafeSecurityDescriptorPtr pbData, ref uint dwDataLen, SecurityInformationFlags dwFlags);
+        private static extern bool CryptGetProvParam(SafeCryptHandle safeProvHandle, CryptProvParam dwParam, SafeSecurityDescriptorPtr pbData, ref uint dwDataLen, SecurityInformationFlags dwFlags);
 
         [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool CryptSetProvParam(CryptHandle safeProvHandle, CryptProvParam dwParam, [MarshalAs(UnmanagedType.LPArray)] byte[] pbData, SecurityInformationFlags dwFlags);
+        private static extern bool CryptSetProvParam(SafeCryptHandle safeProvHandle, CryptProvParam dwParam, [MarshalAs(UnmanagedType.LPArray)] byte[] pbData, SecurityInformationFlags dwFlags);
 
-        CryptHandle handle;
+        SafeCryptHandle handle;
         bool ncrypt = false;
 
         public CertAclHelper(X509Certificate2 certificate)
         {
-            CryptHandle certPkeyHandle;
+            SafeCryptHandle certPkeyHandle;
             KeySpec keySpec;
 
             bool ownHandle;

--- a/plugins/module_utils/_CertACLHelper.cs
+++ b/plugins/module_utils/_CertACLHelper.cs
@@ -112,9 +112,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils._CertACLHelpe
         [Flags]
         private enum CryptAcquireKeyFlagControl : uint
         {
-            CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG = 0x00010000,
             CRYPT_ACQUIRE_PREFER_NCRYPT_KEY_FLAG = 0x00020000,
-            CRYPT_ACQUIRE_ONLY_NCRYPT_KEY_FLAG = 0x00040000,
         }
 
         private enum KeySpec : uint
@@ -155,7 +153,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils._CertACLHelpe
             bool shouldFreeKey;
             if (!CryptAcquireCertificatePrivateKey(
                     certificate.Handle,
-                    (uint)CryptAcquireKeyFlags.CRYPT_ACQUIRE_SILENT_FLAG | (uint)CryptAcquireKeyFlagControl.CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG,
+                    (uint)CryptAcquireKeyFlags.CRYPT_ACQUIRE_SILENT_FLAG | (uint)CryptAcquireKeyFlagControl.CRYPT_ACQUIRE_PREFER_NCRYPT_KEY_FLAG,
                     IntPtr.Zero,
                     out handle,
                     out keySpec,

--- a/plugins/module_utils/_CertACLHelper.cs
+++ b/plugins/module_utils/_CertACLHelper.cs
@@ -112,6 +112,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils._CertACLHelpe
         [Flags]
         private enum CryptAcquireKeyFlagControl : uint
         {
+            CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG = 0x00010000,
             CRYPT_ACQUIRE_PREFER_NCRYPT_KEY_FLAG = 0x00020000,
         }
 
@@ -153,7 +154,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils._CertACLHelpe
             bool shouldFreeKey;
             if (!CryptAcquireCertificatePrivateKey(
                     certificate.Handle,
-                    (uint)CryptAcquireKeyFlags.CRYPT_ACQUIRE_SILENT_FLAG | (uint)CryptAcquireKeyFlagControl.CRYPT_ACQUIRE_PREFER_NCRYPT_KEY_FLAG,
+                    (uint)CryptAcquireKeyFlags.CRYPT_ACQUIRE_SILENT_FLAG | (uint)CryptAcquireKeyFlagControl.CRYPT_ACQUIRE_ALLOW_NCRYPT_KEY_FLAG,
                     IntPtr.Zero,
                     out handle,
                     out keySpec,

--- a/plugins/module_utils/_CertACLHelper.cs
+++ b/plugins/module_utils/_CertACLHelper.cs
@@ -179,10 +179,15 @@ namespace ansible_collections.ansible.windows.plugins.module_utils._CertACLHelpe
                     // We first have to find out how large of a buffer to reserve, so the docs say that
                     // we should pass NULL for the buffer address, then the penultimate parameter will
                     // get assigned the required size.
+                    //
+                    // Note: Despite the documentation saying we should pass NULL for the buffer address,
+                    //       the marshalling between C# and C misbehaves when this happens. When I tried
+                    //       this, the entire getter mysteriously returned null (instead of throwing).
+                    //       Instead, we must pass a non-null empty buffer (`new SafeSecurityDescriptorPtr`)
                     var securityDescriptorResult = NCryptGetProperty(
                         handle,
                         KeyStorageProperty.NCRYPT_SECURITY_DESCR_PROPERTY,
-                        null,
+                        new SafeSecurityDescriptorPtr(),
                         0,
                         ref securityDescriptorSize,
                         SecurityInformationFlags.DACL_SECURITY_INFORMATION | SecurityInformationFlags.NCRYPT_SILENT_FLAG);
@@ -211,10 +216,15 @@ namespace ansible_collections.ansible.windows.plugins.module_utils._CertACLHelpe
                     // We first have to find out how large of a buffer to reserve, so the docs say that
                     // we should pass NULL for the buffer address, then the penultimate parameter will
                     // get assigned the required size.
+                    //
+                    // Note: Despite the documentation saying we should pass NULL for the buffer address,
+                    //       the marshalling between C# and C misbehaves when this happens. When I tried
+                    //       this, the entire getter mysteriously returned null (instead of throwing).
+                    //       Instead, we must pass a non-null empty buffer (`new SafeSecurityDescriptorPtr`)
                     if (!CryptGetProvParam(
                             handle,
                             CryptProvParam.PP_KEYSET_SEC_DESCR,
-                            null,
+                            new SafeSecurityDescriptorPtr(),
                             ref securityDescriptorSize,
                             SecurityInformationFlags.DACL_SECURITY_INFORMATION))
                     {
@@ -233,7 +243,6 @@ namespace ansible_collections.ansible.windows.plugins.module_utils._CertACLHelpe
                     {
                         throw new Win32Exception();
                     }
-
                 }
                 var buffer = new byte[securityDescriptorSize];
                 Marshal.Copy(securityDescriptorBuffer.DangerousGetHandle(), buffer, 0, buffer.Length);

--- a/plugins/module_utils/_CertACLHelper.cs
+++ b/plugins/module_utils/_CertACLHelper.cs
@@ -1,3 +1,7 @@
+// Note: The contents of this file are for internal use only! Do not depend on these classes
+//       or their methods and properties. The API can change without any warning or respect to
+//       semantic versioning.
+
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
@@ -16,12 +20,6 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
         public CryptHandle()
             : base(true)
         {
-        }
-
-        public CryptHandle(IntPtr handle)
-            : base(true)
-        {
-            this.SetHandle(handle);
         }
 
         [DllImport("advapi32.dll", CharSet = CharSet.Unicode, SetLastError = true)]

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -210,6 +210,9 @@ Try {
                 Break
             }
         }
+        ElseIf ($path_item.PSProvider.Name -eq "Certificate") {
+            # TODO - this is where idempotency is detected
+        }
         else {
             If (
                 ($rule.FileSystemRights -eq $objACE.FileSystemRights) -And

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -3,6 +3,7 @@
 # Copyright: (c) 2015, Phil Schwartz <schwartzmx@gmail.com>
 # Copyright: (c) 2015, Trond Hindenes
 # Copyright: (c) 2015, Hans-Joachim Kliemeck <git@kliemeck.de>
+# Copyright: (c) 2020, Håkon Heggernes Lerring <hakon@lerring.no>
 # Copyright: (c) 2023, Jordan Pitlor <jordan@pitlor.dev>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -229,7 +230,8 @@ Try {
             $objACL.AddAccessRule($objACE)
             if ($path_item.PSProvider.Name -eq "Certificate") {
                 $certSecurityHandle.Acl = $objACL
-            } else {
+            }
+            else {
                 Try {
                     Set-ACL -LiteralPath $path -AclObject $objACL
                 }
@@ -251,7 +253,8 @@ Try {
             }
             elseif ($path_item.PSProvider.Name -eq "Certificate") {
                 $certSecurityHandle.Acl = $objACL
-            } else {
+            }
+            else {
                 (Get-Item -LiteralPath $path).SetAccessControl($objACL)
             }
             $result.changed = $true

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -11,7 +11,7 @@
 #Requires -Module Ansible.ModuleUtils.PrivilegeUtil
 #Requires -Module Ansible.ModuleUtils.SID
 #Requires -Module Ansible.ModuleUtils.LinkUtil
-#AnsibleRequires -CSharpUtil ansible_collections.ansible.windows.plugins.module_utils.CertACLHelper
+#AnsibleRequires -CSharpUtil ansible_collections.ansible.windows.plugins.module_utils._CertACLHelper
 
 $ErrorActionPreference = "Stop"
 
@@ -156,7 +156,7 @@ Try {
         $colRights = [System.Security.AccessControl.RegistryRights]$rights
     }
     ElseIf ($path_item.PSProvider.Name -eq "Certificate") {
-        $colRights = [Ansible.Windows.CertAclHelper.CertAccessRights]$rights
+        $colRights = [Ansible.Windows._CertAclHelper.CertAccessRights]$rights
     }
     Else {
         $colRights = [System.Security.AccessControl.FileSystemRights]$rights
@@ -175,7 +175,7 @@ Try {
     $objUser = New-Object System.Security.Principal.SecurityIdentifier($sid)
     If ($path_item.PSProvider.Name -eq "Certificate") {
         $cert = Get-Item -LiteralPath $path
-        $certSecurityHandle = [Ansible.Windows.CertAclHelper.CertAclHelper]::new($cert)
+        $certSecurityHandle = [Ansible.Windows._CertAclHelper.CertAclHelper]::new($cert)
         $objACL = $certSecurityHandle.Acl
         $objACE = $objACL.AccessRuleFactory($objUser, [int]$colRights, $False, $InheritanceFlag, $PropagationFlag, $objType)
     }

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -107,9 +107,6 @@ if ($path_qualifier -eq "HKU:" -and (-not (Test-Path -LiteralPath HKU:\))) {
 if ($path_qualifier -eq "HKCC:" -and (-not (Test-Path -LiteralPath HKCC:\))) {
     New-PSDrive -Name HKCC -PSProvider Registry -Root HKEY_CURRENT_CONFIG > $null
 }
-if ($path_qualifier -eq "Cert:" -and (-not (Test-Path -LiteralPath Cert:\))) {
-    New-PSDrive -Name Cert -PSProvider Certificate -Root \ > $null
-}
 
 Load-LinkUtils
 while ($follow) {

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -157,7 +157,7 @@ Try {
     $path_item = Get-Item -LiteralPath $path -Force
     If ($path_item.PSProvider.Name -eq "Registry") {
         $colRights = [System.Security.AccessControl.RegistryRights]$rights
-    }   
+    }
     ElseIf ($path_item.PSProvider.Name -eq "Certificate") {
         $colRights = [Ansible.Windows.CertAclHelper.CertAccessRights]$rights
     }
@@ -278,7 +278,7 @@ Catch {
     Fail-Json -obj $result -message "an error occurred when attempting to $state $rights permission(s) on $path for $user - $($_.Exception.Message)"
 }
 Finally {
-    # Make sure we revert the location stack to the original path just for cleanups sake    
+    # Make sure we revert the location stack to the original path just for cleanups sake
     if (($null -ne $path_qualifier) -and ($path_qualifier -ne "Cert:")) {
         Pop-Location
     }

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -95,7 +95,7 @@ $inherit = Get-AnsibleParam -obj $params -name "inherit" -type "str"
 $propagation = Get-AnsibleParam -obj $params -name "propagation" -type "str" -default "None" -validateset "InheritOnly", "None", "NoPropagateInherit"
 $follow = Get-AnsibleParam -obj $params -name "follow" -type "bool" -default "false"
 
-# We mount the HKCR, HKU, and HKCC registry hives and the certificate stores so PS can access them.
+# We mount the HKCR, HKU, and HKCC registry hives so PS can access them.
 # Network paths have no qualifiers so we use -EA SilentlyContinue to ignore that
 $path_qualifier = Split-Path -Path $path -Qualifier -ErrorAction SilentlyContinue
 if ($path_qualifier -eq "HKCR:" -and (-not (Test-Path -LiteralPath HKCR:\))) {

--- a/plugins/modules/win_acl.py
+++ b/plugins/modules/win_acl.py
@@ -47,7 +47,7 @@ options:
       FileSystemRights U(https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.filesystemrights.aspx).
     - If C(path) is a registry key, rights can be any right under MSDN
       RegistryRights U(https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.registryrights.aspx).
-    - If I(path) is a certificate key, rights can be C(Read) and/or C(FullControl). (Added in 1.15.0)
+    - If I(path) is a certificate key, rights can be C(Read) and/or C(FullControl). (Added in 2.2.0)
     type: str
     required: yes
   inherit:

--- a/plugins/modules/win_acl.py
+++ b/plugins/modules/win_acl.py
@@ -4,12 +4,13 @@
 # Copyright: (c) 2015, Phil Schwartz <schwartzmx@gmail.com>
 # Copyright: (c) 2015, Trond Hindenes
 # Copyright: (c) 2015, Hans-Joachim Kliemeck <git@kliemeck.de>
+# Copyright: (c) 2023, Jordan Pitlor <jordan@pitlor.dev>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 DOCUMENTATION = r'''
 ---
 module: win_acl
-short_description: Set file/directory/registry permissions for a system user or group
+short_description: Set file/directory/registry/certificate permissions for a system user or group
 description:
 - Add or remove rights/permissions for a given user or group for the specified
   file, folder, registry key or AppPool identifies.
@@ -45,6 +46,7 @@ options:
       FileSystemRights U(https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.filesystemrights.aspx).
     - If C(path) is a registry key, rights can be any right under MSDN
       RegistryRights U(https://msdn.microsoft.com/en-us/library/system.security.accesscontrol.registryrights.aspx).
+    - If I(path) is a certificate key, rights can be C(Read) and/or C(FullControl). (Added in 1.15.0)
     type: str
     required: yes
   inherit:
@@ -129,4 +131,12 @@ EXAMPLES = r'''
     rights: Read,Write,Modify,FullControl,Delete
     type: deny
     state: present
+
+- name: Set certificate private key FullControl to IIS_IUSRS
+  ansible.windows.win_acl:
+    path: Cert:\LocalMachine\My\168ba8c488463f88c6648466a22484b6189e165f
+    user: IIS_IUSRS
+    type: allow
+    state: present
+    rights: FullControl
 '''

--- a/plugins/modules/win_acl.py
+++ b/plugins/modules/win_acl.py
@@ -4,6 +4,7 @@
 # Copyright: (c) 2015, Phil Schwartz <schwartzmx@gmail.com>
 # Copyright: (c) 2015, Trond Hindenes
 # Copyright: (c) 2015, Hans-Joachim Kliemeck <git@kliemeck.de>
+# Copyright: (c) 2020, Håkon Heggernes Lerring <hakon@lerring.no>
 # Copyright: (c) 2023, Jordan Pitlor <jordan@pitlor.dev>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/tests/integration/targets/win_acl/defaults/main.yml
+++ b/tests/integration/targets/win_acl/defaults/main.yml
@@ -3,4 +3,3 @@ test_acl_path: '{{ win_output_dir }}\win_acl .ÅÑŚÌβŁÈ [$!@^&test(;)]'
 test_acl_network_path: \\localhost\{{ test_acl_path[0:1] }}$\{{ test_acl_path[3:] }}
 # Use HKU as that path is not automatically loaded in the PSProvider making our test more complex
 test_acl_reg_path: HKU:\.DEFAULT\Ansible Test .ÅÑŚÌβŁÈ [$!@^&test(;)]
-test_acl_certificate_path: '{{ win_output_dir }}\certificate'

--- a/tests/integration/targets/win_acl/defaults/main.yml
+++ b/tests/integration/targets/win_acl/defaults/main.yml
@@ -3,3 +3,4 @@ test_acl_path: '{{ win_output_dir }}\win_acl .ÅÑŚÌβŁÈ [$!@^&test(;)]'
 test_acl_network_path: \\localhost\{{ test_acl_path[0:1] }}$\{{ test_acl_path[3:] }}
 # Use HKU as that path is not automatically loaded in the PSProvider making our test more complex
 test_acl_reg_path: HKU:\.DEFAULT\Ansible Test .ÅÑŚÌβŁÈ [$!@^&test(;)]
+test_acl_certificate_path: '{{ win_output_dir }}\certificate'

--- a/tests/integration/targets/win_acl/tasks/main.yml
+++ b/tests/integration/targets/win_acl/tasks/main.yml
@@ -16,9 +16,21 @@
   - absent
   - present
 
-- name: create certificate for testing
-  win_shell: '(New-SelfSignedCertificate -Subject "ACL Test" -KeyExportPolicy Exportable).Thumbprint'
-  register: test_acl_certificate_thumbprint
+- name: create certificates for testing
+  win_shell: |
+    $certParams = @{
+        KeyAlgorithm = 'RSA'
+        KeyExportPolicy = 'Exportable'
+        KeyLength = 2048
+    }
+    (New-SelfSignedCertificate @certParams -Subject "ACL Test CNG" -Provider "Microsoft Software Key Storage Provider").Thumbprint
+    (New-SelfSignedCertificate @certParams -Subject "ACL Test CryptoAPI" -Provider "Microsoft Base Cryptographic Provider v1.0" -KeySpec Signature).Thumbprint
+  register: test_acl_cert_info
+
+- name: set variables of certificate thumbprints
+  set_fact:
+    test_acl_certificiate_cng_thumbprint: '{{ test_acl_cert_info.stdout_lines[0] }}'
+    test_acl_certificiate_cryptoapi_thumbprint: '{{ test_acl_cert_info.stdout_lines[1] }}'
 
 - block:
   - name: create test dir for link target
@@ -53,9 +65,12 @@
       delete_key: yes
       state: absent
 
-  - name: uninstall testing certificate
+  - name: uninstall testing certificates
     win_certificate_store:
-      thumbprint: '{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
+      thumbprint: '{{ item }}'
       state: absent
       store_location: LocalMachine
       store_name: My
+    with_items:
+      - test_acl_certificiate_cng_thumbprint
+      - test_acl_certificiate_cryptoapi_thumbprint

--- a/tests/integration/targets/win_acl/tasks/main.yml
+++ b/tests/integration/targets/win_acl/tasks/main.yml
@@ -17,7 +17,7 @@
   - present
 
 - name: add PKI module to Powershell to create testing certificate
-  win_psmodule:
+  community.windows.win_psmodule:
     name: PKI
     state: present
 

--- a/tests/integration/targets/win_acl/tasks/main.yml
+++ b/tests/integration/targets/win_acl/tasks/main.yml
@@ -17,9 +17,7 @@
   - present
 
 - name: add PKI module to Powershell to create testing certificate
-  community.windows.win_psmodule:
-    name: PKI
-    state: present
+  win_shell: Install-Module pki
 
 - name: create certificate for testing
   win_shell: '(New-SelfSignedCertificate -Subject "ACL Test" -KeyExportPolicy Exportable).Thumbprint'

--- a/tests/integration/targets/win_acl/tasks/main.yml
+++ b/tests/integration/targets/win_acl/tasks/main.yml
@@ -17,7 +17,7 @@
   - present
 
 - name: add PKI module to Powershell to create testing certificate
-  win_shell: Import-Module -Name C:\Windows\System32\WindowsPowerShell\v1.0\Modules\PKI\pki.psd1 -SkipEditionCheck
+  win_shell: Import-Module PKI
 
 - name: create certificate for testing
   win_shell: '(New-SelfSignedCertificate -Subject "ACL Test" -KeyExportPolicy Exportable).Thumbprint'

--- a/tests/integration/targets/win_acl/tasks/main.yml
+++ b/tests/integration/targets/win_acl/tasks/main.yml
@@ -15,6 +15,30 @@
   with_items:
   - absent
   - present
+  
+- name: ensure we start with a clean certificate dir
+  win_file:
+    path: '{{ test_acl_certificate_path }}'
+    state: '{{ item }}'
+  with_items:
+  - absent
+  - directory
+
+- name: create certificate for testing
+  win_shell: |
+    openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout acl-test.key -out acl-test.crt -batch *>$null
+    openssl pkcs12 -export -out acl-test.pfx -inkey acl-test.key -in acl-test.crt -passout pass:
+    echo (Get-PfxCertificate .\acl-test.pfx).Thumbprint
+  args:
+    chdir: '{{ test_acl_certificate_path }}'
+  register: test_acl_certificate_thumbprint
+  
+- name: install testing certificate
+  win_certificate_store:
+    path: '{{ test_acl_certificate_path }}\acl-test.pfx'
+    state: present
+    store_location: CurrentUser
+    store_name: My
 
 - block:
   - name: create test dir for link target
@@ -47,4 +71,16 @@
     win_regedit:
       path: '{{ test_acl_reg_path }}'
       delete_key: yes
+      state: absent
+
+  - name: uninstall testing certificate
+    win_certificate_store:
+      thumbprint: '{{ test_acl_certificate_thumbprint }}'
+      state: absent
+      store_location: CurrentUser
+      store_name: My
+
+  - name: cleanup testing certificate path
+    win_file:
+      path: '{{ test_acl_certificate_path }}'
       state: absent

--- a/tests/integration/targets/win_acl/tasks/main.yml
+++ b/tests/integration/targets/win_acl/tasks/main.yml
@@ -17,7 +17,7 @@
   - present
 
 - name: add PKI module to Powershell to create testing certificate
-  win_shell: Install-Module pki
+  win_shell: Import-Module -Name C:\Windows\System32\WindowsPowerShell\v1.0\Modules\PKI\pki.psd1 -SkipEditionCheck
 
 - name: create certificate for testing
   win_shell: '(New-SelfSignedCertificate -Subject "ACL Test" -KeyExportPolicy Exportable).Thumbprint'

--- a/tests/integration/targets/win_acl/tasks/main.yml
+++ b/tests/integration/targets/win_acl/tasks/main.yml
@@ -15,30 +15,15 @@
   with_items:
   - absent
   - present
-  
-- name: ensure we start with a clean certificate dir
-  win_file:
-    path: '{{ test_acl_certificate_path }}'
-    state: '{{ item }}'
-  with_items:
-  - absent
-  - directory
+
+- name: add PKI module to Powershell to create testing certificate
+  win_psmodule:
+    name: PKI
+    state: present
 
 - name: create certificate for testing
-  win_shell: |
-    openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -keyout acl-test.key -out acl-test.crt -batch *>$null
-    openssl pkcs12 -export -out acl-test.pfx -inkey acl-test.key -in acl-test.crt -passout pass:
-    echo (Get-PfxCertificate .\acl-test.pfx).Thumbprint
-  args:
-    chdir: '{{ test_acl_certificate_path }}'
+  win_shell: '(New-SelfSignedCertificate -Subject "ACL Test" -KeyExportPolicy Exportable).Thumbprint'
   register: test_acl_certificate_thumbprint
-  
-- name: install testing certificate
-  win_certificate_store:
-    path: '{{ test_acl_certificate_path }}\acl-test.pfx'
-    state: present
-    store_location: CurrentUser
-    store_name: My
 
 - block:
   - name: create test dir for link target
@@ -75,12 +60,7 @@
 
   - name: uninstall testing certificate
     win_certificate_store:
-      thumbprint: '{{ test_acl_certificate_thumbprint }}'
+      thumbprint: '{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
       state: absent
-      store_location: CurrentUser
+      store_location: LocalMachine
       store_name: My
-
-  - name: cleanup testing certificate path
-    win_file:
-      path: '{{ test_acl_certificate_path }}'
-      state: absent

--- a/tests/integration/targets/win_acl/tasks/main.yml
+++ b/tests/integration/targets/win_acl/tasks/main.yml
@@ -16,9 +16,6 @@
   - absent
   - present
 
-- name: add PKI module to Powershell to create testing certificate
-  win_shell: Import-Module PKI
-
 - name: create certificate for testing
   win_shell: '(New-SelfSignedCertificate -Subject "ACL Test" -KeyExportPolicy Exportable).Thumbprint'
   register: test_acl_certificate_thumbprint

--- a/tests/integration/targets/win_acl/tasks/tests.yml
+++ b/tests/integration/targets/win_acl/tasks/tests.yml
@@ -22,13 +22,13 @@
           "FileSystemRights"
       }
       $ace_list = (Get-Acl -LiteralPath $path).Access | Where-Object { $_.IsInherited -eq $false } | ForEach-Object {
-        @{
-            rights = $_."$rights_key".ToString()
-            type = $_.AccessControlType.ToString()
-            identity = $_.IdentityReference.Value.ToString()
-            inheritance_flags = $_.InheritanceFlags.ToString()
-            propagation_flags = $_.PropagationFlags.ToString()
-        }
+          @{
+              rights = $_."$rights_key".ToString()
+              type = $_.AccessControlType.ToString()
+              identity = $_.IdentityReference.Value.ToString()
+              inheritance_flags = $_.InheritanceFlags.ToString()
+              propagation_flags = $_.PropagationFlags.ToString()
+          }
       }
       Pop-Location
       ConvertTo-Json -InputObject @($ace_list)

--- a/tests/integration/targets/win_acl/tasks/tests.yml
+++ b/tests/integration/targets/win_acl/tasks/tests.yml
@@ -2,39 +2,32 @@
 ---
 - name: get register cmd that will get ace info
   set_fact:
+    test_cert_ace_cmd: |
+      $certificate = Get-ChildItem Cert:\LocalMachine\My | Where-Object Thumbprint -eq $thumbprint
+      $privateKey = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($certificate)
+      $containerName = if ($privateKey.GetType().Name -ieq "RSACng") {
+          $privateKey.Key.UniqueName
+      } else {
+          $privateKey.CspKeyContainerInfo.UniqueKeyContainerName
+      }
+      $keyFullPath = $env:ProgramData + "\Microsoft\Crypto\Keys\" + $containerName;
+      ConvertTo-Json -InputObject @((Get-Acl $keyFullPath).Access)
     test_ace_cmd: |
       # Overcome bug in Set-Acl/Get-Acl for registry paths and -LiteralPath
       New-PSDrive -Name HKU -PSProvider Registry -Root HKEY_USERS > $null
-      New-PSDrive -Name Cert -PSProvider Certificate -Root \ > $null
       Push-Location -LiteralPath (Split-Path -Path $path -Qualifier)
       $rights_key = if ((Get-Item -LiteralPath $path -Force).PSProvider.Name -eq "Registry") {
           "RegistryRights"
-      } else if ((Get-Item -LiteralPath $path -Force).PSProvider.Name -eq "Certificate") {
-          "CertAccessRights"
       } else {
           "FileSystemRights"
       }
-      $ace_list = if ((Get-Item -LiteralPath $path -Force).PSProvider.Name -eq "Certificate") {
-        [Ansible.Windows.CertAclHelper.CertAclHelper]::new(Get-Item -LiteralPath $path).Acl `
-            .GetAccessRules($true, $false, [System.Security.Principal.SecurityIdentifier]) | `
-            ForEach-Object {
-                @{
-                    rights = $_."$rights_key".ToString()
-                    type = $_.AccessControlType.ToString()
-                    identity = $_.IdentityReference.Value.ToString()
-                    inheritance_flags = $_.InheritanceFlags.ToString()
-                    propagation_flags = $_.PropagationFlags.ToString()
-                }
-            }
-      } else {
-        (Get-Acl -LiteralPath $path).Access | Where-Object { $_.IsInherited -eq $false } | ForEach-Object {
-          @{
-              rights = $_."$rights_key".ToString()
-              type = $_.AccessControlType.ToString()
-              identity = $_.IdentityReference.Value.ToString()
-              inheritance_flags = $_.InheritanceFlags.ToString()
-              propagation_flags = $_.PropagationFlags.ToString()
-          }
+      $ace_list = (Get-Acl -LiteralPath $path).Access | Where-Object { $_.IsInherited -eq $false } | ForEach-Object {
+        @{
+            rights = $_."$rights_key".ToString()
+            type = $_.AccessControlType.ToString()
+            identity = $_.IdentityReference.Value.ToString()
+            inheritance_flags = $_.InheritanceFlags.ToString()
+            propagation_flags = $_.PropagationFlags.ToString()
         }
       }
       Pop-Location
@@ -450,7 +443,7 @@
 
 - name: add FullAccess rights on certificate - check mode
   win_acl:
-    path: 'Cert:\CurrentUser\My\{{ test_acl_certificate_thumbprint }}'
+    path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
     user: Guests
     type: allow
     state: present
@@ -465,7 +458,7 @@
 
 - name: add FullAccess rights on certificate
   win_acl:
-    path: 'Cert:\CurrentUser\My\{{ test_acl_certificate_thumbprint }}'
+    path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
     user: Guests
     type: allow
     state: present
@@ -473,23 +466,19 @@
   register: add_rights_on_certificate
 
 - name: get result of add FullAccess rights on certificate
-  win_shell: '$path = ''Cert:\CurrentUser\My\{{ test_acl_certificate_thumbprint }}''; {{ test_ace_cmd }}'
+  win_shell: '$thumbprint = ''{{ test_acl_certificate_thumbprint.stdout_lines[0] }}''; {{ test_cert_ace_cmd }}'
   register: add_rights_on_certificate_actual
 
 - name: assert add FullAccess rights on certificate
   assert:
     that:
     - add_rights_on_certificate is changed
-    - (add_rights_on_certificate_actual.stdout|from_json)|count == 1
-    - (add_rights_on_certificate_actual.stdout|from_json)[0].identity == 'BUILTIN\Guests'
-    - (add_rights_on_certificate_actual.stdout|from_json)[0].inheritance_flags == 'ContainerInherit, ObjectInherit'
-    - (add_rights_on_certificate_actual.stdout|from_json)[0].propagation_flags == 'None'
-    - (add_rights_on_certificate_actual.stdout|from_json)[0].rights == 'WriteKey'
-    - (add_rights_on_certificate_actual.stdout|from_json)[0].type == 'Allow'
+    - (add_rights_on_certificate_actual.stdout|from_json|last).IdentityReference.Value == 'BUILTIN\Guests'
+    - (add_rights_on_certificate_actual.stdout|from_json|last).FileSystemRights == 2032127 # This is the FullAccess flag
 
 - name: add FullAccess rights on certificate again
   win_acl:
-    path: 'Cert:\CurrentUser\My\{{ test_acl_certificate_thumbprint }}'
+    path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
     user: Guests
     type: allow
     state: present
@@ -503,7 +492,7 @@
 
 - name: remove FullAccess rights on certificate - check mode
   win_acl:
-    path: 'Cert:\CurrentUser\My\{{ test_acl_certificate_thumbprint }}'
+    path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
     user: Guests
     type: allow
     state: absent
@@ -518,7 +507,7 @@
 
 - name: remove FullAccess rights on certificate
   win_acl:
-    path: 'Cert:\CurrentUser\My\{{ test_acl_certificate_thumbprint }}'
+    path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
     user: Guests
     type: allow
     state: absent
@@ -526,7 +515,7 @@
   register: remove_rights_on_certificate
 
 - name: get result of REMOVE FullAccess rights on certificate
-  win_shell: '$path = ''Cert:\CurrentUser\My\{{ test_acl_certificate_thumbprint }}''; {{ test_ace_cmd }}'
+  win_shell: '$thumbprint = ''{{ test_acl_certificate_thumbprint.stdout_lines[0] }}''; {{ test_cert_ace_cmd }}'
   register: remove_rights_on_certificate_actual
 
 - name: assert remove FullAccess rights on certificate
@@ -537,7 +526,7 @@
 
 - name: remove FullAccess rights on certificate again
   win_acl:
-    path: 'Cert:\CurrentUser\My\{{ test_acl_certificate_thumbprint }}'
+    path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
     user: Guests
     type: allow
     state: absent

--- a/tests/integration/targets/win_acl/tasks/tests.yml
+++ b/tests/integration/targets/win_acl/tasks/tests.yml
@@ -522,7 +522,8 @@
   assert:
     that:
     - remove_rights_on_certificate is changed
-    - remove_rights_on_certificate_actual.stdout_lines == ["[", "", "]"]
+    - item.IdentityReference.Value != 'BUILTIN\Guests' or item.FileSystemRights != 2032127 # This is the FullAccess flag
+  with_items: '{{ remove_rights_on_certificate_actual.stdout|from_json }}'
 
 - name: remove FullAccess rights on certificate again
   win_acl:

--- a/tests/integration/targets/win_acl/tasks/tests.yml
+++ b/tests/integration/targets/win_acl/tasks/tests.yml
@@ -441,7 +441,10 @@
     that:
     - not remove_deny_right_reg_again is changed
 
-- name: add FullAccess rights on certificate - check mode
+# As a note: in this test you'll see checks for access masks using different numbers than the ACL helper. This is
+# intentional. In our test scenario, we know where the private key file is and are getting the ACL of that file. Files
+# have very different access masks than private keys in the crypt API
+- name: add FullControl rights on certificate - check mode
   win_acl:
     path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
     user: Guests
@@ -449,92 +452,135 @@
     state: present
     rights: FullControl
   check_mode: true
-  register: add_rights_on_certificate_check_mode
+  register: add_fullcontrol_rights_on_certificate_check_mode
 
-- name: assert add FullAccess rights on certificate - check mode
+- name: assert add FullControl rights on certificate - check mode
   assert:
     that:
-    - not add_rights_on_certificate_check_mode is changed
+    - not add_fullcontrol_rights_on_certificate_check_mode is changed
 
-- name: add FullAccess rights on certificate
+- name: add FullControl rights on certificate
   win_acl:
     path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
     user: Guests
     type: allow
     state: present
     rights: FullControl
-  register: add_rights_on_certificate
+  register: add_fullcontrol_rights_on_certificate
 
-- name: get result of add FullAccess rights on certificate
+- name: get result of add FullControl rights on certificate
   win_shell: '$thumbprint = ''{{ test_acl_certificate_thumbprint.stdout_lines[0] }}''; {{ test_cert_ace_cmd }}'
-  register: add_rights_on_certificate_actual
+  register: add_fullcontrol_rights_on_certificate_actual
 
-- name: assert add FullAccess rights on certificate
+- name: assert add FullControl rights on certificate
   assert:
     that:
-    - add_rights_on_certificate is changed
-    - (add_rights_on_certificate_actual.stdout|from_json|last).IdentityReference.Value == 'BUILTIN\Guests'
-    - (add_rights_on_certificate_actual.stdout|from_json|last).FileSystemRights == 2032127 # This is the FullAccess flag
+    - add_fullcontrol_rights_on_certificate is changed
+    - (add_fullcontrol_rights_on_certificate_actual.stdout|from_json|last).IdentityReference.Value == 'BUILTIN\Guests'
+    - (add_fullcontrol_rights_on_certificate_actual.stdout|from_json|last).FileSystemRights == 2032127
 
-- name: add FullAccess rights on certificate again
+- name: add FullControl rights on certificate again
   win_acl:
     path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
     user: Guests
     type: allow
     state: present
     rights: FullControl
-  register: add_rights_on_certificate_again
+  register: add_fullcontrol_rights_on_certificate_again
 
-- name: assert add FullAccess rights on certificate again
+- name: assert add FullControl rights on certificate again
   assert:
     that:
-    - not add_rights_on_certificate_again is changed
+    - not add_fullcontrol_rights_on_certificate_again is changed
 
-- name: remove FullAccess rights on certificate - check mode
+- name: remove FullControl rights on certificate - check mode
   win_acl:
     path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
     user: Guests
     type: allow
     state: absent
     rights: FullControl
-  register: remove_rights_on_certificate_check_mode
+  register: remove_fullcontrol_rights_on_certificate_check_mode
   check_mode: true
 
-- name: assert remove FullAccess rights on certificate - check mode
+- name: assert remove FullControl rights on certificate - check mode
   assert:
     that:
-    - not remove_rights_on_certificate_check_mode is changed
+    - not remove_fullcontrol_rights_on_certificate_check_mode is changed
 
-- name: remove FullAccess rights on certificate
+- name: remove FullControl rights on certificate
   win_acl:
     path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
     user: Guests
     type: allow
     state: absent
     rights: FullControl
-  register: remove_rights_on_certificate
+  register: remove_fullcontrol_rights_on_certificate
 
-- name: get result of REMOVE FullAccess rights on certificate
+- name: get result of remove FullControl rights on certificate
   win_shell: '$thumbprint = ''{{ test_acl_certificate_thumbprint.stdout_lines[0] }}''; {{ test_cert_ace_cmd }}'
-  register: remove_rights_on_certificate_actual
+  register: remove_fullcontrol_rights_on_certificate_actual
 
-- name: assert remove FullAccess rights on certificate
+- name: assert remove FullControl rights on certificate
   assert:
     that:
-    - remove_rights_on_certificate is changed
-    - item.IdentityReference.Value != 'BUILTIN\Guests' or item.FileSystemRights != 2032127 # This is the FullAccess flag
-  with_items: '{{ remove_rights_on_certificate_actual.stdout|from_json }}'
+    - remove_fullcontrol_rights_on_certificate is changed
+    - item.IdentityReference.Value != 'BUILTIN\Guests' or item.FileSystemRights != 2032127
+  with_items: '{{ remove_fullcontrol_rights_on_certificate_actual.stdout|from_json }}'
 
-- name: remove FullAccess rights on certificate again
+- name: remove FullControl rights on certificate again
   win_acl:
     path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
     user: Guests
     type: allow
     state: absent
     rights: FullControl
-  register: remove_rights_on_certificate_again
+  register: remove_fullcontrol_rights_on_certificate_again
 
-- name: assert remove FullAccess rights on certificate again
+- name: assert remove FullControl rights on certificate again
   assert:
     that:
-    - not remove_rights_on_certificate_again is changed
+    - not remove_fullcontrol_rights_on_certificate_again is changed
+
+# These tests are not strictly neccessary, but discovering the actual enum values for the access mask was a gnarly
+# process, so let's just be exhaustive and test that they're still correct
+
+- name: add Read rights on certificate
+  win_acl:
+    path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
+    user: Guests
+    type: allow
+    state: present
+    rights: Read
+  register: add_read_rights_on_certificate
+
+- name: get result of add Read rights on certificate
+  win_shell: '$thumbprint = ''{{ test_acl_certificate_thumbprint.stdout_lines[0] }}''; {{ test_cert_ace_cmd }}'
+  register: add_read_rights_on_certificate_actual
+
+- name: assert add Read rights on certificate
+  assert:
+    that:
+    - add_read_rights_on_certificate is changed
+    - (add_read_rights_on_certificate_actual.stdout|from_json|last).IdentityReference.Value == 'BUILTIN\Guests'
+    - (add_read_rights_on_certificate_actual.stdout|from_json|last).FileSystemRights == 1179785
+
+- name: remove Read rights on certificate
+  win_acl:
+    path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
+    user: Guests
+    type: allow
+    state: absent
+    rights: Read
+  register: remove_read_rights_on_certificate
+
+- name: get result of remove Read rights on certificate
+  win_shell: '$thumbprint = ''{{ test_acl_certificate_thumbprint.stdout_lines[0] }}''; {{ test_cert_ace_cmd }}'
+  register: remove_read_rights_on_certificate_actual
+
+- name: assert remove Read rights on certificate
+  assert:
+    that:
+    - remove_read_rights_on_certificate is changed
+    - item.IdentityReference.Value != 'BUILTIN\Guests' or item.FileSystemRights != 1179785
+  with_items: '{{ remove_read_rights_on_certificate_actual.stdout|from_json }}'

--- a/tests/integration/targets/win_acl/tasks/tests.yml
+++ b/tests/integration/targets/win_acl/tasks/tests.yml
@@ -5,13 +5,29 @@
     test_ace_cmd: |
       # Overcome bug in Set-Acl/Get-Acl for registry paths and -LiteralPath
       New-PSDrive -Name HKU -PSProvider Registry -Root HKEY_USERS > $null
+      New-PSDrive -Name Cert -PSProvider Certificate -Root \ > $null
       Push-Location -LiteralPath (Split-Path -Path $path -Qualifier)
       $rights_key = if ((Get-Item -LiteralPath $path -Force).PSProvider.Name -eq "Registry") {
           "RegistryRights"
+      } else if ((Get-Item -LiteralPath $path -Force).PSProvider.Name -eq "Certificate") {
+          "CertAccessRights"
       } else {
           "FileSystemRights"
       }
-      $ace_list = (Get-Acl -LiteralPath $path).Access | Where-Object { $_.IsInherited -eq $false } | ForEach-Object {
+      $ace_list = if ((Get-Item -LiteralPath $path -Force).PSProvider.Name -eq "Certificate") {
+        [Ansible.Windows.CertAclHelper.CertAclHelper]::new(Get-Item -LiteralPath $path).Acl `
+            .GetAccessRules($true, $false, [System.Security.Principal.SecurityIdentifier]) | `
+            ForEach-Object {
+                @{
+                    rights = $_."$rights_key".ToString()
+                    type = $_.AccessControlType.ToString()
+                    identity = $_.IdentityReference.Value.ToString()
+                    inheritance_flags = $_.InheritanceFlags.ToString()
+                    propagation_flags = $_.PropagationFlags.ToString()
+                }
+            }
+      } else {
+        (Get-Acl -LiteralPath $path).Access | Where-Object { $_.IsInherited -eq $false } | ForEach-Object {
           @{
               rights = $_."$rights_key".ToString()
               type = $_.AccessControlType.ToString()
@@ -19,6 +35,7 @@
               inheritance_flags = $_.InheritanceFlags.ToString()
               propagation_flags = $_.PropagationFlags.ToString()
           }
+        }
       }
       Pop-Location
       ConvertTo-Json -InputObject @($ace_list)
@@ -430,3 +447,104 @@
   assert:
     that:
     - not remove_deny_right_reg_again is changed
+
+- name: add FullAccess rights on certificate - check mode
+  win_acl:
+    path: 'Cert:\CurrentUser\My\{{ test_acl_certificate_thumbprint }}'
+    user: Guests
+    type: allow
+    state: present
+    rights: FullControl
+  check_mode: true
+  register: add_rights_on_certificate_check_mode
+
+- name: assert add FullAccess rights on certificate - check mode
+  assert:
+    that:
+    - not add_rights_on_certificate_check_mode is changed
+
+- name: add FullAccess rights on certificate
+  win_acl:
+    path: 'Cert:\CurrentUser\My\{{ test_acl_certificate_thumbprint }}'
+    user: Guests
+    type: allow
+    state: present
+    rights: FullControl
+  register: add_rights_on_certificate
+
+- name: get result of add FullAccess rights on certificate
+  win_shell: '$path = ''Cert:\CurrentUser\My\{{ test_acl_certificate_thumbprint }}''; {{ test_ace_cmd }}'
+  register: add_rights_on_certificate_actual
+
+- name: assert add FullAccess rights on certificate
+  assert:
+    that:
+    - add_rights_on_certificate is changed
+    - (add_rights_on_certificate_actual.stdout|from_json)|count == 1
+    - (add_rights_on_certificate_actual.stdout|from_json)[0].identity == 'BUILTIN\Guests'
+    - (add_rights_on_certificate_actual.stdout|from_json)[0].inheritance_flags == 'ContainerInherit, ObjectInherit'
+    - (add_rights_on_certificate_actual.stdout|from_json)[0].propagation_flags == 'None'
+    - (add_rights_on_certificate_actual.stdout|from_json)[0].rights == 'WriteKey'
+    - (add_rights_on_certificate_actual.stdout|from_json)[0].type == 'Allow'
+
+- name: add FullAccess rights on certificate again
+  win_acl:
+    path: 'Cert:\CurrentUser\My\{{ test_acl_certificate_thumbprint }}'
+    user: Guests
+    type: allow
+    state: present
+    rights: FullControl
+  register: add_rights_on_certificate_again
+
+- name: assert add FullAccess rights on certificate again
+  assert:
+    that:
+    - not add_rights_on_certificate_again is changed
+
+- name: remove FullAccess rights on certificate - check mode
+  win_acl:
+    path: 'Cert:\CurrentUser\My\{{ test_acl_certificate_thumbprint }}'
+    user: Guests
+    type: allow
+    state: absent
+    rights: FullControl
+  register: remove_rights_on_certificate_check_mode
+  check_mode: true
+
+- name: assert remove FullAccess rights on certificate - check mode
+  assert:
+    that:
+    - not remove_rights_on_certificate_check_mode is changed
+
+- name: remove FullAccess rights on certificate
+  win_acl:
+    path: 'Cert:\CurrentUser\My\{{ test_acl_certificate_thumbprint }}'
+    user: Guests
+    type: allow
+    state: absent
+    rights: FullControl
+  register: remove_rights_on_certificate
+
+- name: get result of REMOVE FullAccess rights on certificate
+  win_shell: '$path = ''Cert:\CurrentUser\My\{{ test_acl_certificate_thumbprint }}''; {{ test_ace_cmd }}'
+  register: remove_rights_on_certificate_actual
+
+- name: assert remove FullAccess rights on certificate
+  assert:
+    that:
+    - remove_rights_on_certificate is changed
+    - remove_rights_on_certificate_actual.stdout_lines == ["[", "", "]"]
+
+- name: remove FullAccess rights on certificate again
+  win_acl:
+    path: 'Cert:\CurrentUser\My\{{ test_acl_certificate_thumbprint }}'
+    user: Guests
+    type: allow
+    state: absent
+    rights: FullControl
+  register: remove_rights_on_certificate_again
+
+- name: assert remove FullAccess rights on certificate again
+  assert:
+    that:
+    - not remove_rights_on_certificate_again is changed

--- a/tests/integration/targets/win_acl/tasks/tests.yml
+++ b/tests/integration/targets/win_acl/tasks/tests.yml
@@ -12,6 +12,16 @@
       }
       $keyFullPath = $env:ProgramData + "\Microsoft\Crypto\Keys\" + $containerName;
       ConvertTo-Json -InputObject @((Get-Acl $keyFullPath).Access)
+    test_crypto_cert_ace_cmd: |
+      $certificate = Get-ChildItem Cert:\LocalMachine\My | Where-Object Thumbprint -eq $thumbprint
+      $privateKey = [System.Security.Cryptography.X509Certificates.RSACertificateExtensions]::GetRSAPrivateKey($certificate)
+      $containerName = if ($privateKey.GetType().Name -ieq "RSACng") {
+          $privateKey.Key.UniqueName
+      } else {
+          $privateKey.CspKeyContainerInfo.UniqueKeyContainerName
+      }
+      $keyFullPath = $env:ProgramData + "\Microsoft\Crypto\RSA\MachineKeys\" + $containerName;
+      ConvertTo-Json -InputObject @((Get-Acl $keyFullPath).Access)
     test_ace_cmd: |
       # Overcome bug in Set-Acl/Get-Acl for registry paths and -LiteralPath
       New-PSDrive -Name HKU -PSProvider Registry -Root HKEY_USERS > $null
@@ -446,7 +456,7 @@
 # have very different access masks than private keys in the crypt API
 - name: add FullControl rights on certificate - check mode
   win_acl:
-    path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
+    path: 'Cert:\LocalMachine\My\{{ test_acl_certificiate_cng_thumbprint }}'
     user: Guests
     type: allow
     state: present
@@ -461,7 +471,7 @@
 
 - name: add FullControl rights on certificate
   win_acl:
-    path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
+    path: 'Cert:\LocalMachine\My\{{ test_acl_certificiate_cng_thumbprint }}'
     user: Guests
     type: allow
     state: present
@@ -469,7 +479,7 @@
   register: add_fullcontrol_rights_on_certificate
 
 - name: get result of add FullControl rights on certificate
-  win_shell: '$thumbprint = ''{{ test_acl_certificate_thumbprint.stdout_lines[0] }}''; {{ test_cert_ace_cmd }}'
+  win_shell: '$thumbprint = ''{{ test_acl_certificiate_cng_thumbprint }}''; {{ test_cert_ace_cmd }}'
   register: add_fullcontrol_rights_on_certificate_actual
 
 - name: assert add FullControl rights on certificate
@@ -481,7 +491,7 @@
 
 - name: add FullControl rights on certificate again
   win_acl:
-    path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
+    path: 'Cert:\LocalMachine\My\{{ test_acl_certificiate_cng_thumbprint }}'
     user: Guests
     type: allow
     state: present
@@ -495,7 +505,7 @@
 
 - name: remove FullControl rights on certificate - check mode
   win_acl:
-    path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
+    path: 'Cert:\LocalMachine\My\{{ test_acl_certificiate_cng_thumbprint }}'
     user: Guests
     type: allow
     state: absent
@@ -510,7 +520,7 @@
 
 - name: remove FullControl rights on certificate
   win_acl:
-    path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
+    path: 'Cert:\LocalMachine\My\{{ test_acl_certificiate_cng_thumbprint }}'
     user: Guests
     type: allow
     state: absent
@@ -518,7 +528,7 @@
   register: remove_fullcontrol_rights_on_certificate
 
 - name: get result of remove FullControl rights on certificate
-  win_shell: '$thumbprint = ''{{ test_acl_certificate_thumbprint.stdout_lines[0] }}''; {{ test_cert_ace_cmd }}'
+  win_shell: '$thumbprint = ''{{ test_acl_certificiate_cng_thumbprint }}''; {{ test_cert_ace_cmd }}'
   register: remove_fullcontrol_rights_on_certificate_actual
 
 - name: assert remove FullControl rights on certificate
@@ -530,7 +540,7 @@
 
 - name: remove FullControl rights on certificate again
   win_acl:
-    path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
+    path: 'Cert:\LocalMachine\My\{{ test_acl_certificiate_cng_thumbprint }}'
     user: Guests
     type: allow
     state: absent
@@ -547,7 +557,7 @@
 
 - name: add Read rights on certificate
   win_acl:
-    path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
+    path: 'Cert:\LocalMachine\My\{{ test_acl_certificiate_cng_thumbprint }}'
     user: Guests
     type: allow
     state: present
@@ -555,7 +565,7 @@
   register: add_read_rights_on_certificate
 
 - name: get result of add Read rights on certificate
-  win_shell: '$thumbprint = ''{{ test_acl_certificate_thumbprint.stdout_lines[0] }}''; {{ test_cert_ace_cmd }}'
+  win_shell: '$thumbprint = ''{{ test_acl_certificiate_cng_thumbprint }}''; {{ test_cert_ace_cmd }}'
   register: add_read_rights_on_certificate_actual
 
 - name: assert add Read rights on certificate
@@ -567,7 +577,7 @@
 
 - name: remove Read rights on certificate
   win_acl:
-    path: 'Cert:\LocalMachine\My\{{ test_acl_certificate_thumbprint.stdout_lines[0] }}'
+    path: 'Cert:\LocalMachine\My\{{ test_acl_certificiate_cng_thumbprint }}'
     user: Guests
     type: allow
     state: absent
@@ -575,7 +585,7 @@
   register: remove_read_rights_on_certificate
 
 - name: get result of remove Read rights on certificate
-  win_shell: '$thumbprint = ''{{ test_acl_certificate_thumbprint.stdout_lines[0] }}''; {{ test_cert_ace_cmd }}'
+  win_shell: '$thumbprint = ''{{ test_acl_certificiate_cng_thumbprint }}''; {{ test_cert_ace_cmd }}'
   register: remove_read_rights_on_certificate_actual
 
 - name: assert remove Read rights on certificate
@@ -584,3 +594,23 @@
     - remove_read_rights_on_certificate is changed
     - item.IdentityReference.Value != 'BUILTIN\Guests' or item.FileSystemRights != 1179785
   with_items: '{{ remove_read_rights_on_certificate_actual.stdout|from_json }}'
+
+- name: add FullControl rights on Crypto certificate
+  win_acl:
+    path: 'Cert:\LocalMachine\My\{{ test_acl_certificiate_cryptoapi_thumbprint }}'
+    user: Guests
+    type: allow
+    state: present
+    rights: FullControl
+  register: add_fullcontrol_rights_on_crypto_certificate
+
+- name: get result of add FullControl rights on Crypto certificate
+  win_shell: '$thumbprint = ''{{ test_acl_certificiate_cryptoapi_thumbprint }}''; {{ test_crypto_cert_ace_cmd }}'
+  register: add_fullcontrol_rights_on_crypto_certificate_actual
+
+- name: assert add FullControl rights on Crypto certificate
+  assert:
+    that:
+    - add_fullcontrol_rights_on_crypto_certificate is changed
+    - (add_fullcontrol_rights_on_crypto_certificate_actual.stdout|from_json|last).IdentityReference.Value == 'BUILTIN\Guests'
+    - (add_fullcontrol_rights_on_crypto_certificate_actual.stdout|from_json|last).FileSystemRights == 2032127


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I'm making this PR that essentially revives #94 to add support to `Cert:\` paths in win_acl. I tried to follow all the unresolved feedback from #94

Fixes #150 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_acl

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
There is one huge caveat that I'm fairly certain my test assertions are wrong, but when I try to use `ansible-test`, I'm getting a very unhelpful error (I'll add more details in a comment), so I'm assuming that's going to block this getting merged. I realize this isn't an Ansible help forum, but if you happen to have any suggestions on what part of this stack trace is useful, I'd love to try and get these tests running

```
WARNING: Excluding target tests marked "unstable" which require --allow-unstable or prefixing with "unstable/": win_wait_for
Traceback (most recent call last):
  File "/home/jpitlor/.local/bin/ansible-test", line 45, in <module>
    main()
  File "/home/jpitlor/.local/bin/ansible-test", line 36, in main
    cli_main(args)
  File "/home/jpitlor/.local/lib/python3.10/site-packages/ansible_test/_internal/__init__.py", line 84, in main
    args.func(config)
  File "/home/jpitlor/.local/lib/python3.10/site-packages/ansible_test/_internal/commands/integration/windows.py", line 76, in command_windows_integration
    host_state, internal_targets = command_integration_filter(args, all_targets)
  File "/home/jpitlor/.local/lib/python3.10/site-packages/ansible_test/_internal/commands/integration/__init__.py", line 941, in command_integration_filter
    cloud_init(args, internal_targets)
  File "/home/jpitlor/.local/lib/python3.10/site-packages/ansible_test/_internal/commands/integration/cloud/__init__.py", line 162, in cloud_init
    provider.setup()
  File "/home/jpitlor/.local/lib/python3.10/site-packages/ansible_test/_internal/commands/integration/cloud/httptester.py", line 58, in setup
    descriptor = run_support_container(
  File "/home/jpitlor/.local/lib/python3.10/site-packages/ansible_test/_internal/containers.py", line 142, in run_support_container
    current_container_id = get_docker_container_id()
  File "/home/jpitlor/.local/lib/python3.10/site-packages/ansible_test/_internal/thread.py", line 59, in wrapper
    return func(*args, **kwargs)
  File "/home/jpitlor/.local/lib/python3.10/site-packages/ansible_test/_internal/util.py", line 158, in cache_func
    value = storage[None] = func()
  File "/home/jpitlor/.local/lib/python3.10/site-packages/ansible_test/_internal/docker_util.py", line 592, in get_docker_container_id
    mounts = MountEntry.loads(mountinfo_path.read_text())
  File "/home/jpitlor/.local/lib/python3.10/site-packages/ansible_test/_internal/cgroup.py", line 107, in loads
    return tuple(cls.parse(line) for line in value.splitlines())
  File "/home/jpitlor/.local/lib/python3.10/site-packages/ansible_test/_internal/cgroup.py", line 107, in <genexpr>
    return tuple(cls.parse(line) for line in value.splitlines())
  File "/home/jpitlor/.local/lib/python3.10/site-packages/ansible_test/_internal/cgroup.py", line 86, in parse
    assert separator == '-'
AssertionError
```