### PR TITLE
Fix typo in setup module warning

### DIFF
--- a/changelogs/fragments/setup-warning-typo.yml
+++ b/changelogs/fragments/setup-warning-typo.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- setup - Fix up typo ``collection -> collect`` when a timeout occurred during a fact subset

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -1230,7 +1230,7 @@ $ansibleFacts.measure_info.$subset = $end.TotalSeconds
     else {
         # Give a best effort chance to stop it, we can't call .Stop() in case it blocks.
         $null = $ps.BeginStop($null, $null)
-        $module.Warn("Failed to collection $($name) due to timeout")
+        $module.Warn("Failed to collect $($name) due to timeout")
     }
 }
 


### PR DESCRIPTION
##### SUMMARY
Fix typo in the `setup` module to be `collect` and not `collection`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup