### PR TITLE
win_command - add stderr_lines documentation

### DIFF
--- a/plugins/modules/win_command.py
+++ b/plugins/modules/win_command.py
@@ -168,5 +168,5 @@ stderr_lines:
     description: The command standard error split in lines
     returned: always
     type: list
-    sample: [u'ls: cannot access foo: No such file or directory']
+    sample: "['ls: cannot access foo: No such file or directory']"
 '''

--- a/plugins/modules/win_command.py
+++ b/plugins/modules/win_command.py
@@ -163,7 +163,7 @@ stdout_lines:
     description: The command standard output split in lines
     returned: always
     type: list
-    sample: [u'Clustering node rabbit@slave1 with rabbit@main ...']
+    sample: ['Clustering node rabbit@slave1 with rabbit@main ...']
 stderr_lines:
     description: The command standard error split in lines
     returned: always

--- a/plugins/modules/win_command.py
+++ b/plugins/modules/win_command.py
@@ -164,4 +164,9 @@ stdout_lines:
     returned: always
     type: list
     sample: [u'Clustering node rabbit@slave1 with rabbit@main ...']
+stderr_lines:
+    description: The command standard error split in lines
+    returned: always
+    type: list
+    sample: [u'ls: cannot access foo: No such file or directory']
 '''


### PR DESCRIPTION
##### SUMMARY
Add the missing `stderr_lines` for `win_command` to the documentation.

For some reason this value is missing from the return values section.


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_command

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
https://github.com/riemers/ansible-gitlab-runner/pull/280#discussion_r1314205060

We found the doc was missing while fixing a bug in the riemers.gitlab-runner role for Windows.

<!--- Paste verbatim command output below, e.g. before and after your change -->

**Notice stderr_lines was already present**
```paste below
ok: [srv-uitest19.zimmercas.com] => changed=false 
  cmd: c:/gitlab-runner//gitlab-runner.exe --log-format json list
  delta: '0:00:00.116974'
  end: '2023-09-03 14:39:46.779366'
  rc: 0
  start: '2023-09-03 14:39:46.662391'
  stderr: |-
    {"arch":"amd64","level":"info","msg":"Runtime platform","os":"windows","pid":4180,"revision":"d540b510","time":"2023-09-03T10:39:46-04:00","version":"15.9.1"}
    {"ConfigFile":"c:\\gitlab-runner\\config.toml","level":"info","msg":"Listing configured runners","time":"2023-09-03T10:39:46-04:00"}
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
```
