### PR TITLE
Fixes ProcessCreationFlags typo

### DIFF
--- a/changelogs/fragments/process-creationflags.yml
+++ b/changelogs/fragments/process-creationflags.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Process.cs - Fix up the ``ProcessCreationFlags.CreateProtectedProcess`` typo in the enum name

--- a/plugins/module_utils/Process.cs
+++ b/plugins/module_utils/Process.cs
@@ -362,7 +362,7 @@ namespace ansible_collections.ansible.windows.plugins.module_utils.Process
         AboveNormalPriorityClass = 0x00008000,
         InheritParentAffinity = 0x00010000,
         InheritCallerPriority = 0x00020000,
-        CreateProctectedProcess = 0x00040000,
+        CreateProtectedProcess = 0x00040000,
         ExtendedStartupInfoPresent = 0x00080000,
         ProcessModeBackgroundBegin = 0x00100000,
         ProcessModeBackgroundEnd = 0x00200000,


### PR DESCRIPTION
##### SUMMARY
Fixes the typo in the enum value for CreateProtectedProcess. This should not affect any callers as creating a protected process is impossible without having a signed binary from Microsoft, it's merely done to ensure the value names are aligned properly.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Process.cs