### PR TITLE
Start testing with Ansible 2.17/devel

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -54,6 +54,19 @@ stages:
               test: sanity
             - name: Units
               test: units
+  - stage: Ansible_2_16
+    displayName: Ansible 2.16
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: '{0}'
+          testFormat: '2.16/{0}'
+          targets:
+            - name: Sanity
+              test: sanity
+            - name: Units
+              test: units
   - stage: Ansible_2_15
     displayName: Ansible 2.15
     dependsOn: []
@@ -126,6 +139,7 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_16
       - Ansible_2_15
       - Ansible_2_14
       - Ansible_2_13

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,0 +1,4 @@
+plugins/modules/setup.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
+plugins/modules/win_powershell.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore until all ansible-test branches support custom rules
+tests/integration/targets/win_package/library/win_make_appx.ps1 pslint:PSAvoidLongLines # Cannot ignore until all ansible-test branches support this rule
+tests/integration/targets/win_dsc/files/xTestCompositeDsc/1.0.0/DSCResources/xTestComposite/xTestComposite.schema.psm1 pslint!skip # Pwsh cannot parse DSC to MOF on Linux


### PR DESCRIPTION
##### SUMMARY
Bump testing to use the newly branched stable-2.16 branch and ensure devel has 2.17 ignores.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible.windows