### PR TITLE
win_service_info - ignore file not found errors

### DIFF
--- a/changelogs/fragments/win_service_info-not-found.yml
+++ b/changelogs/fragments/win_service_info-not-found.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_service_info - Warn and not fail if ERROR_FILE_NOT_FOUND when trying to query a service - https://github.com/ansible-collections/ansible.windows/issues/556

--- a/plugins/modules/win_service_info.ps1
+++ b/plugins/modules/win_service_info.ps1
@@ -33,9 +33,12 @@ $module.Result.services = @(
             )
         }
         catch [Ansible.Windows.SCManager.ServiceManagerException] {
-            # ERROR_ACCESS_DENIED, ignore the service and continue on.
-            if ($_.Exception.InnerException -and $_.Exception.InnerException.NativeErrorCode -eq 5) {
-                $msg = "Failed to access service '$($rawService.Name) to get more info, ignoring: $($_.Exception.Message)"
+            # ERROR_FILE_NOT_FOUND (2) - Unsure why this happens but probably
+            # the description or some other text field refers to a shared
+            # resource string.
+            # ERROR_ACCESS_DENIED (5)
+            if ($_.Exception.InnerException -and $_.Exception.InnerException.NativeErrorCode -in @(2, 5)) {
+                $msg = "Failed to open service '$($rawService.Name) to get more info, ignoring: $($_.Exception.Message)"
                 $module.Warn($msg)
                 continue
             }


### PR DESCRIPTION
##### SUMMARY
If a service fails to be open with `ERROR_FILE_NOT_FOUND` treat it as a warning rather than an error. This ensures it can be used to retrieve services even if some fail. It also makes it easier to debug what service it failed on for further investigation.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/556

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_service_info