### PR TITLE
setup.ps1: added ansible_all_ipv4_addresses ansible_all_ipv6_addresses

### DIFF
--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -564,11 +564,11 @@ $factMeta = @(
             $ips = @()
             $ipv6s = @()
             Foreach ($ip in $NetIPAddress) {
-                if ($ip.IPAddress -and ($ip.AddressFamily -eq 'IPv4' -or $ip.AddressFamily -eq 2) -and 
+                if ($ip.IPAddress -and ($ip.AddressFamily -eq 'IPv4' -or $ip.AddressFamily -eq 2) -and
                    ($ip.PrefixOrigin -ne 'WellKnown' -and $ip.PrefixOrigin -ne 2)) {
                     $ips += $ip.IPAddress
                 }
-                elseif ($ip.IPAddress -and ($ip.AddressFamily -eq 'IPv6' -or $ip.AddressFamily -eq 23) -and 
+                elseif ($ip.IPAddress -and ($ip.AddressFamily -eq 'IPv6' -or $ip.AddressFamily -eq 23) -and
                          ($ip.AddressState -eq 'Preferred' -or $ip.AddressState -eq '4') -and $ip.IPAddress -ne '::1') {
                     if ($ip.PrefixOrigin -eq 'WellKnown' -or $ip.PrefixOrigin -eq '2') {
                         $ipv6s += $ip.IPAddress.Replace('%' + $ip.InterfaceIndex, '')

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -560,16 +560,18 @@ $factMeta = @(
         Subsets = 'all_ipv4_addresses', 'all_ipv6_addresses'
         Code = {
             $NetIPAddress = Get-CimInstance -Namespace ROOT/StandardCimv2 -ClassName MSFT_NetIPAddress
-        
+
             $ips = @()
             $ipv6s = @()
             Foreach ($ip in $NetIPAddress) {
-                If ($ip.IPAddress -and ( $ip.AddressFamily -eq 'IPv4' -or  $ip.AddressFamily -eq 2) -and ($ip.PrefixOrigin -ne 'WellKnown' -and $ip.PrefixOrigin -ne 2))  {
+                if ($ip.IPAddress -and ($ip.AddressFamily -eq 'IPv4' -or  $ip.AddressFamily -eq 2) -and 
+                   ($ip.PrefixOrigin -ne 'WellKnown' -and $ip.PrefixOrigin -ne 2)) {
                     $ips += $ip.IPAddress
-                }elseif($ip.IPAddress -and ( $ip.AddressFamily -eq 'IPv6' -or  $ip.AddressFamily -eq 23) -and ($ip.AddressState -eq 'Preferred' -or $ip.AddressState -eq '4') -and $ip.IPAddress -ne '::1'){
-                    if($ip.PrefixOrigin -eq 'WellKnown' -or $ip.PrefixOrigin -eq '2'){
+                } elseif ($ip.IPAddress -and ($ip.AddressFamily -eq 'IPv6' -or  $ip.AddressFamily -eq 23) -and 
+                         ($ip.AddressState -eq 'Preferred' -or $ip.AddressState -eq '4') -and $ip.IPAddress -ne '::1') {
+                    if ($ip.PrefixOrigin -eq 'WellKnown' -or $ip.PrefixOrigin -eq '2') {
                         $ipv6s += $ip.IPAddress.Replace('%'+$ip.InterfaceIndex,'')
-                    }else{
+                    } else {
                         $ipv6s += $ip.IPAddress
                     }
                 }
@@ -577,7 +579,7 @@ $factMeta = @(
 
             $ansibleFacts.ansible_all_ipv4_addresses = $ips
             $ansibleFacts.ansible_all_ipv6_addresses = $ipv6s
-            $ansibleFacts.ansible_ip_addresses = $ips,$ipv6s
+            $ansibleFacts.ansible_ip_addresses = $ips, $ipv6s
         }
     },
     @{

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -564,14 +564,16 @@ $factMeta = @(
             $ips = @()
             $ipv6s = @()
             Foreach ($ip in $NetIPAddress) {
-                if ($ip.IPAddress -and ($ip.AddressFamily -eq 'IPv4' -or  $ip.AddressFamily -eq 2) -and 
+                if ($ip.IPAddress -and ($ip.AddressFamily -eq 'IPv4' -or $ip.AddressFamily -eq 2) -and 
                    ($ip.PrefixOrigin -ne 'WellKnown' -and $ip.PrefixOrigin -ne 2)) {
                     $ips += $ip.IPAddress
-                } elseif ($ip.IPAddress -and ($ip.AddressFamily -eq 'IPv6' -or  $ip.AddressFamily -eq 23) -and 
+                }
+                elseif ($ip.IPAddress -and ($ip.AddressFamily -eq 'IPv6' -or $ip.AddressFamily -eq 23) -and 
                          ($ip.AddressState -eq 'Preferred' -or $ip.AddressState -eq '4') -and $ip.IPAddress -ne '::1') {
                     if ($ip.PrefixOrigin -eq 'WellKnown' -or $ip.PrefixOrigin -eq '2') {
-                        $ipv6s += $ip.IPAddress.Replace('%'+$ip.InterfaceIndex,'')
-                    } else {
+                        $ipv6s += $ip.IPAddress.Replace('%' + $ip.InterfaceIndex, '')
+                    }
+                    else {
                         $ipv6s += $ip.IPAddress
                     }
                 }

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -559,17 +559,25 @@ $factMeta = @(
     @{
         Subsets = 'all_ipv4_addresses', 'all_ipv6_addresses'
         Code = {
-            $interfaces = [System.Net.NetworkInformation.NetworkInterface]::GetAllNetworkInterfaces()
-            $ips = @(foreach ($interface in $interfaces) {
-                    # Win32_NetworkAdapterConfiguration did not return the local IPs so we replicate that here.
-                    $interface.GetIPProperties().UnicastAddresses | Where-Object {
-                        $_.Address.ToString() -notin @('::1', '127.0.0.1')
-                    } | ForEach-Object -Process {
-                        $_.Address.ToString()
+            $NetIPAddress = Get-CimInstance -Namespace ROOT/StandardCimv2 -ClassName MSFT_NetIPAddress
+        
+            $ips = @()
+            $ipv6s = @()
+            Foreach ($ip in $NetIPAddress) {
+                If ($ip.IPAddress -and ( $ip.AddressFamily -eq 'IPv4' -or  $ip.AddressFamily -eq 2) -and ($ip.PrefixOrigin -ne 'WellKnown' -and $ip.PrefixOrigin -ne 2))  {
+                    $ips += $ip.IPAddress
+                }elseif($ip.IPAddress -and ( $ip.AddressFamily -eq 'IPv6' -or  $ip.AddressFamily -eq 23) -and ($ip.AddressState -eq 'Preferred' -or $ip.AddressState -eq '4') -and $ip.IPAddress -ne '::1'){
+                    if($ip.PrefixOrigin -eq 'WellKnown' -or $ip.PrefixOrigin -eq '2'){
+                        $ipv6s += $ip.IPAddress.Replace('%'+$ip.InterfaceIndex,'')
+                    }else{
+                        $ipv6s += $ip.IPAddress
                     }
-                })
+                }
+            }
 
-            $ansibleFacts.ansible_ip_addresses = $ips
+            $ansibleFacts.ansible_all_ipv4_addresses = $ips
+            $ansibleFacts.ansible_all_ipv6_addresses = $ipv6s
+            $ansibleFacts.ansible_ip_addresses = $ips,$ipv6s
         }
     },
     @{


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This changes collects now all_ipv4_addresses and all_ipv6_addresses as facts like on linux.
The Filtering in the Code is a bit ugly but it returns the ansible_ip_addresses fact the same as here https://github.com/ansible/ansible/blob/74f6e6a134fa4fe57a80c6c0748772ac13182f1b
The Script before this PR did return more IPs than the Test here https://github.com/ansible/ansible/blob/74f6e6a134fa4fe57a80c6c0748772ac13182f1b
Test Output:
```
10.162.xxx.162
fe80::1176:3b0e:xxxx:8337
192.168.xxx.90
fe80::214d:402a:xxxx:52b3
2a02:8071:xxxx:1720:3c5c:1c67:xxxx:8fcc
2a02:8071:xxxx:1720:4cba:16c4:xxxx:4d7f
172.19.xxx.1
fe80::f2b6:75ca:xxxx:7ed5
```
Before this PR:
```
fe80::1176:3b0e:xxxx:8337%33
10.162.xxx.162
fe80::9672:696a:xxxx:9744%18
169.254.xxx.121
fe80::999:4f2d:xxxx:72f5%35
169.254.xxx.95
fe80::36b6:5dce:xxxx:d52d%20
169.254.xxx.20
fe80::78e2:9185:xxxx:827d%17
169.254.xxx.217
2a02:8071:xxxx:1720:4cba:16c4:xxxx:4d7f
2a02:8071:xxxx:1720:3c5c:1c67:xxxx:8fcc
fe80::214d:402a:xxxx:52b3%24
192.168.xxx.90
fe80::152e:5bd:xxxx:e40%38
169.254.xxx.211
fe80::f2b6:75ca:xxxx:7ed5%83
172.19.xxx.1
```
This PR:
```
172.19.xxx.1
192.168.xxx.90
10.162.xxx.162
fe80::f2b6:75ca:xxxx:7ed5
fe80::214d:402a:xxxx:52b3
2a02:8071:xxxx:1720:4cba:16c4:xxxx:4d7f
2a02:8071:xxxx:1720:3c5c:1c67:xxxx:8fcc
fe80::1176:3b0e:xxxx:8337
```
It does also report ipv4 and ipv6 addresses seperate like on Linux
```
PS C:\Users\adimhald\powershell-ansible> $ansibleFacts

Name                           Value
----                           -----
module_setup                   True
ansible_all_ipv6_addresses     {fe80::f2b6:75ca:xxxx:7ed5, fe80::214d:402a:xxxx:52b3, 2a02:8071:xxxx:1720:4cba:16c4:xxxx:4d7f, 2a02:8071:xxxx:1720:3c5c:1c67:xxxx:8fcc…}
ansible_all_ipv4_addresses     {172.19.xxx.1, 192.168.xxx.90, 10.162.xxx.162}
ansible_ip_addresses           {172.19.xxx.1 192.168.xxx.90 10.162.xxx.162, fe80::f2b6:75ca:xxxx:7ed5 fe80::214d:402a:xxxx:52b3 2a02:8071:xxxx:1720:4cba:16c4:xxxx:4d7f 2a02:8071:xxxx:1720:3c5c:1c67:xxxx:8fcc fe80::1176:3b0e:xxxx:8337}
```
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
setup
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
First Pr opened on the wrong Repo https://github.com/ansible/ansible/pull/81991
The Timing got even better with the CIM call instead of the Net Method. (Timing in ms)
|     | Net | CIM |
|-----|-----|----|
| PS5 | 132 | 93 |
| PS7 | 132 | 85 |

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
net-ps5
![net-ps5](https://github.com/ansible-collections/ansible.windows/assets/10107699/bf5666a4-a384-4f7a-b92d-c211a5e963a4)
net-ps7
![net-ps7](https://github.com/ansible-collections/ansible.windows/assets/10107699/e54d7c83-098a-4479-b64c-8a8cdacb2fa9)
cim-ps5
![cim-ps5](https://github.com/ansible-collections/ansible.windows/assets/10107699/cae38383-16d0-48c5-9198-5e24878236b8)
cim-ps7
![cim-ps7](https://github.com/ansible-collections/ansible.windows/assets/10107699/f9424850-cf04-4e08-83ac-612f464f784c)

