### PR TITLE
Set new supported ansible minimum version to 2.14

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -93,32 +93,6 @@ stages:
               test: sanity
             - name: Units
               test: units
-  - stage: Ansible_2_13
-    displayName: Ansible 2.13
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: '{0}'
-          testFormat: '2.13/{0}'
-          targets:
-            - name: Sanity
-              test: sanity
-            - name: Units
-              test: units
-  - stage: Ansible_2_12
-    displayName: Ansible 2.12
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: '{0}'
-          testFormat: '2.12/{0}'
-          targets:
-            - name: Sanity
-              test: sanity
-            - name: Units
-              test: units
   - stage: Windows
     displayName: Windows
     dependsOn: []
@@ -142,8 +116,6 @@ stages:
       - Ansible_2_16
       - Ansible_2_15
       - Ansible_2_14
-      - Ansible_2_13
-      - Ansible_2_12
       - Windows
     jobs:
       - template: templates/coverage.yml

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The `ansible.windows` collection includes the core plugins supported by Ansible 
 
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.12**.
+This collection has been tested against following Ansible versions: **>=2.14**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.

--- a/changelogs/fragments/ansible_support.yml
+++ b/changelogs/fragments/ansible_support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Set minimum supported Ansible version to 2.14 to align with the versions still supported by Ansible.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: ansible
 name: windows
-version: 2.1.0
+version: 2.2.0
 readme: README.md
 authors:
 - Jordan Borean @jborean93

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
-requires_ansible: '>=2.12'
+requires_ansible: '>=2.14'
 plugin_routing:
   modules:
     win_domain_controller:

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -6,6 +6,10 @@
 #Requires -Module Ansible.ModuleUtils.AddType
 #AnsibleRequires -CSharpUtil Ansible.Basic
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSCustomUseLiteralPath', '',
+    Justification = 'We want to support wildcard matching')]
+param()
+
 $spec = @{
     options = @{
         # This is not meant to be publicly used, only for debugging how long it takes to capture a subset.

--- a/plugins/modules/win_powershell.ps1
+++ b/plugins/modules/win_powershell.ps1
@@ -424,6 +424,8 @@ Function Format-Exception {
 
 Function Test-AnsiblePath {
     [CmdletBinding()]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSCustomUseLiteralPath', '',
+        Justification = 'We want to support wildcard matching')]
     param (
         [Parameter(Mandatory = $true)]
         [String]

--- a/tests/integration/targets/win_package/library/win_make_appx.ps1
+++ b/tests/integration/targets/win_package/library/win_make_appx.ps1
@@ -7,6 +7,10 @@
 #Requires -Module Ansible.ModuleUtils.ArgvParser
 #Requires -Module Ansible.ModuleUtils.CommandUtil
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '',
+    Justification = 'XML literal values exceed this line')]
+param()
+
 $spec = @{
     options = @{
         packages = @{
@@ -145,7 +149,7 @@ foreach ($info in $packages) {
         $module.FailJson("Failed to make package for $($info.filename): see stdout and stderr for more info")
     }
 
-    Remove-Item -Literalpath $tempDir -Force -Recurse
+    Remove-Item -LiteralPath $tempDir -Force -Recurse
 
     $signArguments = @($signtoolPath, 'sign', '/a', '/v', '/fd', 'SHA256', '/f', $certPath, '/p', $certPassword,
         $outPath)

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,5 +1,0 @@
-plugins/modules/setup.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
-plugins/modules/win_powershell.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
-plugins/modules/win_powershell.py validate-modules:return-syntax-error # Current rules don't allow raw as the return_type https://github.com/ansible/ansible/pull/78231
-tests/integration/targets/win_dsc/files/xTestDsc/1.0.0/DSCResources/ANSIBLE_xTestResource/ANSIBLE_xTestResource.psm1 pslint:PSDSCUseIdenticalMandatoryParametersForDSC # Rule is broken in older PSSA versions
-tests/integration/targets/win_dsc/files/xTestDsc/1.0.1/DSCResources/ANSIBLE_xTestResource/ANSIBLE_xTestResource.psm1 pslint:PSDSCUseIdenticalMandatoryParametersForDSC # Rule is broken in older PSSA versions

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,8 +1,0 @@
-plugins/modules/async_status.yml validate-modules!skip # Does not support sidecar
-plugins/modules/setup.yml validate-modules!skip # Does not support sidecar
-plugins/modules/setup.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
-plugins/modules/slurp.yml validate-modules!skip # Does not support sidecar
-plugins/modules/win_powershell.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore until all ansible-test branches support custom rules
-plugins/modules/win_powershell.py validate-modules:return-syntax-error # Current rules don't allow raw as the return_type https://github.com/ansible/ansible/pull/78231
-tests/integration/targets/win_package/library/win_make_appx.ps1 pslint:PSAvoidLongLines # Cannot ignore until all ansible-test branches support this rule
-tests/integration/targets/win_dsc/files/xTestCompositeDsc/1.0.0/DSCResources/xTestComposite/xTestComposite.schema.psm1 pslint!skip # Pwsh cannot parse DSC to MOF on Linux

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,4 +1,1 @@
-plugins/modules/setup.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
-plugins/modules/win_powershell.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore until all ansible-test branches support custom rules
-tests/integration/targets/win_package/library/win_make_appx.ps1 pslint:PSAvoidLongLines # Cannot ignore until all ansible-test branches support this rule
 tests/integration/targets/win_dsc/files/xTestCompositeDsc/1.0.0/DSCResources/xTestComposite/xTestComposite.schema.psm1 pslint!skip # Pwsh cannot parse DSC to MOF on Linux

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,4 +1,1 @@
-plugins/modules/setup.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
-plugins/modules/win_powershell.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore until all ansible-test branches support custom rules
-tests/integration/targets/win_package/library/win_make_appx.ps1 pslint:PSAvoidLongLines # Cannot ignore until all ansible-test branches support this rule
 tests/integration/targets/win_dsc/files/xTestCompositeDsc/1.0.0/DSCResources/xTestComposite/xTestComposite.schema.psm1 pslint!skip # Pwsh cannot parse DSC to MOF on Linux

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,4 +1,1 @@
-plugins/modules/setup.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
-plugins/modules/win_powershell.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore until all ansible-test branches support custom rules
-tests/integration/targets/win_package/library/win_make_appx.ps1 pslint:PSAvoidLongLines # Cannot ignore until all ansible-test branches support this rule
 tests/integration/targets/win_dsc/files/xTestCompositeDsc/1.0.0/DSCResources/xTestComposite/xTestComposite.schema.psm1 pslint!skip # Pwsh cannot parse DSC to MOF on Linux

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,4 +1,1 @@
-plugins/modules/setup.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore custom rules in the version of PSSA in ansible-test docker
-plugins/modules/win_powershell.ps1 pslint:PSCustomUseLiteralPath # Cannot ignore until all ansible-test branches support custom rules
-tests/integration/targets/win_package/library/win_make_appx.ps1 pslint:PSAvoidLongLines # Cannot ignore until all ansible-test branches support this rule
 tests/integration/targets/win_dsc/files/xTestCompositeDsc/1.0.0/DSCResources/xTestComposite/xTestComposite.schema.psm1 pslint!skip # Pwsh cannot parse DSC to MOF on Linux


### PR DESCRIPTION
##### SUMMARY
Ansible 2.14 is the oldest supported Ansible version, this PR ensures we are testing that as our minimum version.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible.windows