### PR TITLE
Fix win_powershell usings

### DIFF
--- a/changelogs/fragments/win_powershell-fix-using.yml
+++ b/changelogs/fragments/win_powershell-fix-using.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_powershell - Remove unecessary using in code causing stray error records in output - https://github.com/ansible-collections/ansible.windows/issues/571

--- a/plugins/modules/win_powershell.ps1
+++ b/plugins/modules/win_powershell.ps1
@@ -35,7 +35,6 @@ $module.Result.debug = @()
 $module.Result.information = @()
 
 $stdPinvoke = @'
-using Microsoft.Win32.SafeHandles;
 using System;
 using System.Runtime.InteropServices;
 


### PR DESCRIPTION
##### SUMMARY
Remove the unecessary using entry in the compiled code causing Roslyn to emit a warning during compilation. This only affected people running with an executable as the in process option did not need to recompile the code that had this.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/571

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_powershell