### PR TITLE
Add tls13 support for win_get_url

### DIFF
--- a/changelogs/fragments/win_get_url-tls13.yml
+++ b/changelogs/fragments/win_get_url-tls13.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- win_get_url - Fix Tls1.3 getting removed from the list of security protocols

--- a/plugins/module_utils/WebRequest.psm1
+++ b/plugins/module_utils/WebRequest.psm1
@@ -199,7 +199,7 @@ Function Get-AnsibleWindowsWebRequest {
     }
     
     # Enable TLS1.1/TLS1.2 if they're available but disabled (eg. .NET 4.5)
-    $NetFrameworkVersion = (Get-ItemProperty -LiteralPath "HKLM:SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full").Release
+		$NetFrameworkVersion = (Get-ItemProperty -LiteralPath "HKLM:SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full").Release
     if ($NetFrameworkVersion -lt "528449") {
         $security_protocols = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::SystemDefault
         if ([System.Net.SecurityProtocolType].GetMember("Tls11").Count -gt 0) {
@@ -210,7 +210,7 @@ Function Get-AnsibleWindowsWebRequest {
         }
         [System.Net.ServicePointManager]::SecurityProtocol = $security_protocols
     }
-    
+		
     $web_request = [System.Net.WebRequest]::Create($Uri)
     if ($UrlMethod) {
         $web_request.Method = $UrlMethod

--- a/plugins/module_utils/WebRequest.psm1
+++ b/plugins/module_utils/WebRequest.psm1
@@ -206,6 +206,9 @@ Function Get-AnsibleWindowsWebRequest {
     if ([System.Net.SecurityProtocolType].GetMember("Tls12").Count -gt 0) {
         $security_protocols = $security_protocols -bor [System.Net.SecurityProtocolType]::Tls12
     }
+    if ([System.Net.SecurityProtocolType].GetMember("Tls13").Count -gt 0) {
+        $security_protocols = $security_protocols -bor [System.Net.SecurityProtocolType]::Tls13
+    }
     [System.Net.ServicePointManager]::SecurityProtocol = $security_protocols
 
     $web_request = [System.Net.WebRequest]::Create($Uri)

--- a/plugins/module_utils/WebRequest.psm1
+++ b/plugins/module_utils/WebRequest.psm1
@@ -197,9 +197,9 @@ Function Get-AnsibleWindowsWebRequest {
     if (-not $ValidateCerts) {
         [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
     }
-    
+
     # Enable TLS1.1/TLS1.2 if they're available but disabled (eg. .NET 4.5)
-		$NetFrameworkVersion = (Get-ItemProperty -LiteralPath "HKLM:SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full").Release
+    $NetFrameworkVersion = (Get-ItemProperty -LiteralPath "HKLM:SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full").Release
     if ($NetFrameworkVersion -lt "528449") {
         $security_protocols = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::SystemDefault
         if ([System.Net.SecurityProtocolType].GetMember("Tls11").Count -gt 0) {
@@ -210,7 +210,7 @@ Function Get-AnsibleWindowsWebRequest {
         }
         [System.Net.ServicePointManager]::SecurityProtocol = $security_protocols
     }
-		
+
     $web_request = [System.Net.WebRequest]::Create($Uri)
     if ($UrlMethod) {
         $web_request.Method = $UrlMethod

--- a/plugins/module_utils/WebRequest.psm1
+++ b/plugins/module_utils/WebRequest.psm1
@@ -197,20 +197,20 @@ Function Get-AnsibleWindowsWebRequest {
     if (-not $ValidateCerts) {
         [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
     }
-
+    
     # Enable TLS1.1/TLS1.2 if they're available but disabled (eg. .NET 4.5)
-    $security_protocols = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::SystemDefault
-    if ([System.Net.SecurityProtocolType].GetMember("Tls11").Count -gt 0) {
-        $security_protocols = $security_protocols -bor [System.Net.SecurityProtocolType]::Tls11
+    $NetFrameworkVersion = (Get-ItemProperty "HKLM:SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full").Release
+    if($NetFrameworkVersion -lt "528449"){
+        $security_protocols = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::SystemDefault
+        if ([System.Net.SecurityProtocolType].GetMember("Tls11").Count -gt 0) {
+            $security_protocols = $security_protocols -bor [System.Net.SecurityProtocolType]::Tls11
+        }
+        if ([System.Net.SecurityProtocolType].GetMember("Tls12").Count -gt 0) {
+            $security_protocols = $security_protocols -bor [System.Net.SecurityProtocolType]::Tls12
+        }
+    [System.Net.ServicePointManager]::SecurityProtocol = $security_protocols  
     }
-    if ([System.Net.SecurityProtocolType].GetMember("Tls12").Count -gt 0) {
-        $security_protocols = $security_protocols -bor [System.Net.SecurityProtocolType]::Tls12
-    }
-    if ([System.Net.SecurityProtocolType].GetMember("Tls13").Count -gt 0) {
-        $security_protocols = $security_protocols -bor [System.Net.SecurityProtocolType]::Tls13
-    }
-    [System.Net.ServicePointManager]::SecurityProtocol = $security_protocols
-
+    
     $web_request = [System.Net.WebRequest]::Create($Uri)
     if ($UrlMethod) {
         $web_request.Method = $UrlMethod

--- a/plugins/module_utils/WebRequest.psm1
+++ b/plugins/module_utils/WebRequest.psm1
@@ -199,8 +199,8 @@ Function Get-AnsibleWindowsWebRequest {
     }
     
     # Enable TLS1.1/TLS1.2 if they're available but disabled (eg. .NET 4.5)
-    $NetFrameworkVersion = (Get-ItemProperty "HKLM:SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full").Release
-    if($NetFrameworkVersion -lt "528449"){
+    $NetFrameworkVersion = (Get-ItemProperty -LiteralPath "HKLM:SOFTWARE\Microsoft\NET Framework Setup\NDP\v4\Full").Release
+    if ($NetFrameworkVersion -lt "528449") {
         $security_protocols = [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::SystemDefault
         if ([System.Net.SecurityProtocolType].GetMember("Tls11").Count -gt 0) {
             $security_protocols = $security_protocols -bor [System.Net.SecurityProtocolType]::Tls11
@@ -208,7 +208,7 @@ Function Get-AnsibleWindowsWebRequest {
         if ([System.Net.SecurityProtocolType].GetMember("Tls12").Count -gt 0) {
             $security_protocols = $security_protocols -bor [System.Net.SecurityProtocolType]::Tls12
         }
-    [System.Net.ServicePointManager]::SecurityProtocol = $security_protocols  
+        [System.Net.ServicePointManager]::SecurityProtocol = $security_protocols
     }
     
     $web_request = [System.Net.WebRequest]::Create($Uri)


### PR DESCRIPTION
##### SUMMARY
Using the win_get_url module I was getting the following error:  "The underlying connection was closed: Could not establish trust relationship for the SSL/TLS secure channel"

However, from the machine the download was working fine within a powershell terminal. After some troubleshooting, I noticed that the issue was with TLS1.3.

Adding an extra condition for TLS1.3 actually fixed the issue. Please let me know what you think.

##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME
win_get_url

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
##### Ansible Version  
```
ansible [core 2.16.1]
  config file = /ansible/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.10/dist-packages/ansible
  ansible collection location = /root/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/local/bin/ansible
  python version = 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0] (/usr/bin/python3)
  jinja version = 3.1.2
  libyaml = True
```
##### OS
Ansible controller: Ubuntu 20.04
Target Machine: Windows Server 2022
```
Major  Minor  Build  Revision
-----  -----  -----  --------
10     0      20348  0
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
Before change
```
FAILED! =>{"changed": false, "dest": "C:\\temp\\dotnet-runtime-wingeturl4.exe", "elapsed": 0.10937519999999999, "msg": "Error downloading 'https://download.visualstudio.microsoft.com/download/pr/2a7ae819-fbc4-4611-a1ba-f3b072d4ea25/32f3b931550f7b315d9827d564202eeb/dotnet-hosting-8.0.0-win.exe' to 'C:\\temp\\dotnet-runtime-wingeturl4.exe': The underlying connection was closed: An unexpected error occurred on a send.", "status_code": null, "url": "https://download.visualstudio.microsoft.com/download/pr/2a7ae819-fbc4-4611-a1ba-f3b072d4ea25/32f3b931550f7b315d9827d564202eeb/dotnet-hosting-8.0.0-win.exe"}
```
After change
```
: ok=3    changed=1    unreachable=0    failed=0    skipped=2    rescued=0    ignored=0
```
