### PR TITLE
New win_assemble module

### DIFF
--- a/plugins/action/win_assemble.py
+++ b/plugins/action/win_assemble.py
@@ -1,0 +1,161 @@
+# (c) 2013-2016, Michael DeHaan <michael.dehaan@gmail.com>
+#           Stephen Fromm <sfromm@gmail.com>
+#           Brian Coca  <briancoca+dev@gmail.com>
+#           Toshio Kuratomi  <tkuratomi@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import codecs
+import os
+import os.path
+import re
+import tempfile
+
+from ansible import constants as C
+from ansible.errors import AnsibleError, AnsibleAction, _AnsibleActionDone, AnsibleActionFail
+from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.parsing.convert_bool import boolean
+from ansible.plugins.action import ActionBase
+from ansible.utils.hashing import checksum_s
+
+
+class ActionModule(ActionBase):
+
+    TRANSFERS_FILES = True
+
+    def _assemble_from_fragments(self, src_path, delimiter=None, compiled_regexp=None, ignore_hidden=False, decrypt=True, header=None, footer=None):
+        ''' assemble a file from a directory of fragments '''
+
+        tmpfd, temp_path = tempfile.mkstemp(dir=C.DEFAULT_LOCAL_TMP)
+        tmp = os.fdopen(tmpfd, 'wb')
+        delimit_me = False
+        add_newline = False
+
+        if header:
+            tmp.write(codecs.escape_decode(header)[0])
+            # Always make sure there's a newline after the header
+            if header[-1] != b'\n':
+            	tmp.write(b'\n')
+
+        if delimiter:
+            # un-escape anything like newlines
+            delimiter = codecs.escape_decode(delimiter)[0]
+            	
+        for f in (to_text(p, errors='surrogate_or_strict') for p in sorted(os.listdir(src_path))):
+            if compiled_regexp and not compiled_regexp.search(f):
+                continue
+            fragment = u"%s/%s" % (src_path, f)
+            if not os.path.isfile(fragment) or (ignore_hidden and os.path.basename(fragment).startswith('.')):
+                continue
+
+            with open(self._loader.get_real_file(fragment, decrypt=decrypt), 'rb') as fragment_fh:
+                fragment_content = fragment_fh.read()
+
+            # always put a newline between fragments if the previous fragment didn't end with a newline.
+            if add_newline:
+                tmp.write(b'\n')
+
+            # delimiters should only appear between fragments
+            if delimit_me:
+                if delimiter:
+                    tmp.write(delimiter)
+                    # always make sure there's a newline after the
+                    # delimiter, so lines don't run together
+                    if delimiter[-1] != b'\n':
+                        tmp.write(b'\n')
+
+            tmp.write(fragment_content)
+            delimit_me = True
+            if fragment_content.endswith(b'\n'):
+                add_newline = False
+            else:
+                add_newline = True
+
+        if footer:
+            tmp.write(codecs.escape_decode(footer)[0])
+
+        tmp.close()
+        return temp_path
+
+    def _copy_single_file(self, local_file, dest, task_vars, tmp, backup):
+        # copy the file across to the server
+        tmp_src = self._connection._shell.join_path(tmp, 'source')
+        self._transfer_file(local_file, tmp_src)
+
+        copy_args = self._task.args.copy()
+        copy_args.update(
+            dict(
+                dest=dest,
+                src=tmp_src,
+            )
+        )
+
+        copy_result = self._execute_module(module_name="ansible.windows.win_assemble",
+                                           module_args=copy_args,
+                                           task_vars=task_vars)
+        return copy_result
+
+    def run(self, tmp=None, task_vars=None):
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        if task_vars is None:
+            task_vars = dict()
+
+        src = self._task.args.get('src', None)
+        dest = self._task.args.get('dest', None)
+        delimiter = self._task.args.get('delimiter', None)
+        remote_src = self._task.args.get('remote_src', 'yes')
+        regexp = self._task.args.get('regexp', None)
+        ignore_hidden = self._task.args.get('ignore_hidden', False)
+        decrypt = self._task.args.pop('decrypt', True)
+        backup = boolean(self._task.args.get('backup', False), strict=False)
+        header = self._task.args.get('header', None)
+        footer = self._task.args.get('footer', None)
+
+        try:
+            if src is None or dest is None:
+                raise AnsibleActionFail("src and dest are required")
+
+            if boolean(remote_src, strict=False):
+                result.update(self._execute_module(module_name='ansible.windows.win_assemble', task_vars=task_vars))
+                raise _AnsibleActionDone()
+            else:
+                try:
+                    src = self._find_needle('files', src)
+                except AnsibleError as e:
+                    raise AnsibleActionFail(to_native(e))
+
+            if not os.path.isdir(src):
+                raise AnsibleActionFail(u"Source (%s) is not a directory" % src)
+
+            _re = None
+            if regexp is not None:
+                _re = re.compile(regexp)
+
+            # Does all work assembling the file
+            path = self._assemble_from_fragments(src, delimiter, _re, ignore_hidden, decrypt, header, footer)
+
+            result.update(self._copy_single_file(path, dest, task_vars, self._connection._shell.tmpdir, backup))
+
+        except AnsibleAction as e:
+            result.update(e.result)
+        finally:
+            self._remove_tmp_path(self._connection._shell.tmpdir)
+
+        return result

--- a/plugins/modules/win_assemble.ps1
+++ b/plugins/modules/win_assemble.ps1
@@ -1,0 +1,154 @@
+#!powershell
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+#Requires -Module Ansible.ModuleUtils.Backup
+
+$ErrorActionPreference = "Stop"
+
+$params = Parse-Args $args -supports_check_mode $true
+
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
+$diff_mode = Get-AnsibleParam -obj $params -name "_ansible_diff" -type "bool" -default $false
+
+$src = Get-AnsibleParam -obj $params -name "src" -type "path" -failifempty $true
+$dest = Get-AnsibleParam -obj $params -name "dest" -type "path" -failifempty $true
+$backup = Get-AnsibleParam -obj $params -name "backup" -type "bool" -default $false
+$delimiter = Get-AnsibleParam -obj $params -name "delimiter" -type "str" -default $null
+$regexp = Get-AnsibleParam -obj $params -name "regexp" -type "str" -default $null
+$ignore_hidden = Get-AnsibleParam -obj $params -name "ignore_hidden" -type "bool" -default $false
+$header = Get-AnsibleParam -obj $params -name "header" -type "str" -default $null
+$footer = Get-AnsibleParam -obj $params -name "footer" -type "str" -default $null
+
+# used in template/copy when dest is the path to a dir and source is a file
+$original_basename = Get-AnsibleParam -obj $params -name "_original_basename" -type "str"
+if ((Test-Path -LiteralPath $src -PathType Container) -and ($null -ne $original_basename)) {
+    $src = Join-Path -Path $src -ChildPath $original_basename
+}
+
+$result = @{
+    changed = $false
+}
+
+function Assemble-Fragments($SrcPath, $Delimiter = $null, $Regexp = $null, $IgnoreHidden = $false, $Header = $null, $Footer = $null, $Remote = $true) {
+    $tmp_dest = (New-TemporaryFile).FullName
+    $delimit_me = $false
+    $sb = [System.Text.StringBuilder]::new()
+    $add_newline = $false
+    
+    # If remote_src = $false and the source is a file, this was already assembled on the remote side
+    if (-not $Remote -and (Test-Path -LiteralPath $SrcPath -PathType leaf)) {
+        # Convert Unix LF to CRLF
+        $content = (Get-Content -LiteralPath $SrcPath -Raw) -Replace "(?<!`r)`n","`r`n"
+        # Use WriteAllText so the content is written as UTF-8 without BOM
+        [IO.File]::WriteAllText($tmp_dest, $content)
+        return $tmp_dest
+    }
+
+    if ($Header -ne $null) {
+        [void]$sb.Append([Text.RegularExpressions.Regex]::Unescape($Header))
+        if ($sb[$sb.Length - 1] -ne "\n") {
+            [void]$sb.AppendLine()
+        }
+    }
+    
+    if ($Delimiter -ne $null) {
+        # un-escape anything like newlines
+        $Delimiter = [Text.RegularExpressions.Regex]::Unescape($Delimiter)
+    }
+    Get-ChildItem -Path $SrcPath -File -Force:(!$IgnoreHidden) | Foreach-Object {
+        if ($Regexp -ne $null -and $_.Name -notmatch $Regexp) {
+            return
+        }
+        $content = Get-Content -LiteralPath $_.FullName
+
+        if ($add_newline) {
+            [void]$sb.AppendLine()
+        }
+        if ($delimit_me) {
+            if ($Delimiter -ne $null) {
+                [void]$sb.Append($Delimiter)
+                if ($sb[$sb.Length - 1] -ne "\n") {
+                    [void]$sb.AppendLine()
+                }
+            }
+        }
+
+        # Content is split by lines to convert Unix LF to CRLF.
+        [void]$sb.Append([String]::Join("\n", $content))
+        if ($sb[$sb.Length - 1] -ne "\n") {
+            $add_newline = $true
+        } else {
+            $add_newline = $false
+        }
+        $delimit_me = $true
+    }
+
+    if ($Footer -ne $null) {
+        if ($add_newline) {
+            [void]$sb.AppendLine()
+        }
+        [void]$sb.Append([Text.RegularExpressions.Regex]::Unescape($Footer))
+    }
+    # WriteAllText writes as UTF8NoBOM, regardless of how Powershell is executed.
+    # Set-Content as executed under Ansible writes as ASCII by default,
+    # and UTF8NoBOM isn't a valid encoding on Powershell 5.
+    [IO.File]::WriteAllText($tmp_dest, $sb.ToString())
+    return $tmp_dest
+}
+
+function Cleanup($Path, $Result = $null) {
+    if (Test-Path -LiteralPath $Path) {
+        Remove-Item -LiteralPath $Path
+    }
+}
+
+if (-not (Test-Path -Path $src)) {
+    Fail-Json $result "Source ($src) does not exist"
+}
+
+$path = Assemble-Fragments -SrcPath $src -Delimiter $delimiter -Regexp $regexp -IgnoreHidden $ignore_hidden -Header $header -Footer $footer -Remote $remote_src
+$checksum = Get-FileChecksum -path $path
+$copy = $true
+
+if (Test-Path -LiteralPath $dest) {
+    $target_checksum = Get-FileChecksum -path $dest
+    if ($target_checksum -eq $checksum) {
+        $copy = $false
+    }
+}
+
+if ($copy) {
+    $before_contents = $null
+    $after_contents = $null
+
+    if ($diff_mode) {
+        if (Test-Path -LiteralPath $dest) {
+            $before_contents = Get-Content -LiteralPath $dest -Raw | Out-String
+        }
+        $after_contents = Get-Content -LiteralPath $path -Raw | Out-String
+    }
+    if ($backup) {
+        $result.backup_file = Backup-File -path $dest -WhatIf:$check_mode
+    }
+
+    Copy-Item -LiteralPath $path -Destination $dest -Force -WhatIf:$check_mode | Out-Null
+    $result.changed = $true
+
+    if ($diff_mode) {
+        $result.diff = @{
+            before = $before_contents
+            before_header = $dest
+            after = $after_contents
+            after_header = $dest
+        }
+    }
+}
+
+$result.checksum = $checksum
+$result.dest = $dest
+$result.size = (Get-Item -LiteralPath $path).Length
+$result.msg = "OK"
+
+Cleanup -Path $path -Result $result
+
+Exit-Json $result

--- a/plugins/modules/win_assemble.py
+++ b/plugins/modules/win_assemble.py
@@ -1,0 +1,139 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2012, Stephen Fromm <sfromm@gmail.com>
+# Copyright: (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r'''
+---
+module: win_assemble
+short_description: Assemble configuration files from fragments
+description:
+- Assembles a configuration file from fragments.
+- Often a particular program will take a single configuration file and does not support a
+  C(conf.d) style structure where it is easy to build up the configuration
+  from multiple sources. M(ansible.windows.win_assemble) will take a directory of files that can be
+  local or have already been transferred to the system, and concatenate them
+  together to produce a destination file.
+- Files are assembled in string sorting order.
+- Puppet calls this idea I(fragments).
+version_added: '2.3.0'
+options:
+  src:
+    description:
+    - An already existing directory full of source files.
+    type: path
+    required: true
+  dest:
+    description:
+    - A file to create using the concatenation of all of the source files.
+    type: path
+    required: true
+  backup:
+    description:
+    - Create a backup file (if V(true)), including the timestamp information so
+      you can get the original file back if you somehow clobbered it
+      incorrectly.
+    type: bool
+    default: false
+  delimiter:
+    description:
+    - A delimiter to separate the file contents.
+    type: str
+  remote_src:
+    description:
+    - If V(false), it will search for src at originating/master machine.
+    - If V(true), it will go to the remote/target machine for the src.
+    type: bool
+    default: true
+  regexp:
+    description:
+    - Assemble files only if the given regular expression matches the filename.
+    - If not set, all files are assembled.
+    - Every V(\\) (backslash) must be escaped as V(\\\\) to comply to YAML syntax.
+    - If O(remote_src=false), uses L(Python regular expressions,https://docs.python.org/3/library/re.html).
+    - If O(remote_src=true), uses L(.NET regular expressions,https://learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expressions).
+    type: str
+  ignore_hidden:
+    description:
+    - A boolean that controls if hidden files will be included or not.
+    - Which files are considered hidden depends on the source location.
+    - If O(remote_src=false), files that start with a '.' are considered hidden.
+    - If O(remote_src=true), files that have the hidden attribute on supported 
+      filesystems on the remote/target system are considered hidden.
+    type: bool
+    default: false
+  header:
+    description:
+    - Content to place at the top of the generated file.
+    type: str
+  footer:
+    description:
+    - Content to place at the bottom of the generated file.
+    type: str
+  decrypt:
+    description:
+    - This option controls the autodecryption of source files using vault.
+    - This is ignored if O(remote_src=true).
+    type: bool
+    default: true
+attributes:
+    action:
+      support: full
+    check_mode:
+      support: full
+    diff_mode:
+      support: full
+    platform:
+      platforms: windows
+    vault:
+      support: partial
+      details: Only supported when O(remote_src=false).
+notes:
+- It is recommended that backslashes C(\) are used instead of C(/) when dealing
+  with remote paths.
+seealso:
+- module: ansible.builtin.assemble
+- module: ansible.windows.win_copy
+author:
+- Daniel Osborne
+'''
+
+EXAMPLES = r'''
+- name: Assemble from fragments from a directory
+  ansible.windows.win_assemble:
+    src: conf/
+    dest: C:\\ProgramData\\Foo\\conf.ini
+
+- name: Insert the provided delimiter between fragments
+  ansible.windows.win_assemble:
+    src: conf/
+    dest: C:\\ProgramData\\Foo\\conf.ini
+    delimiter: '### START FRAGMENT ###'
+'''
+
+RETURN = r'''
+backup_file:
+    description: Name of the backup file that was created.
+    returned: if O(backup=true) and destination was pre-existing.
+    type: str
+    sample: C:\\Path\\To\\File.txt.11540.20150212-220915.bak
+dest:
+    description: Destination file/path.
+    returned: success
+    type: str
+    sample: C:\\Temp\\assembled.txt
+checksum:
+    description: SHA1 checksum of the file after running copy.
+    returned: success
+    type: str
+    sample: 6e642bb8dd5c2e027bf21dd923337cbb4214f827
+size:
+    description: Size of the target, after execution.
+    returned: success
+    type: int
+    sample: 1220
+'''
+

--- a/tests/integration/targets/win_assemble/aliases
+++ b/tests/integration/targets/win_assemble/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group2

--- a/tests/integration/targets/win_assemble/files/fragment1
+++ b/tests/integration/targets/win_assemble/files/fragment1
@@ -1,0 +1,1 @@
+this is fragment 1

--- a/tests/integration/targets/win_assemble/files/fragment2
+++ b/tests/integration/targets/win_assemble/files/fragment2
@@ -1,0 +1,1 @@
+this is fragment 2

--- a/tests/integration/targets/win_assemble/files/fragment3
+++ b/tests/integration/targets/win_assemble/files/fragment3
@@ -1,0 +1,1 @@
+this is fragment 3

--- a/tests/integration/targets/win_assemble/files/fragment4
+++ b/tests/integration/targets/win_assemble/files/fragment4
@@ -1,0 +1,1 @@
+this is fragment 4

--- a/tests/integration/targets/win_assemble/files/fragment5
+++ b/tests/integration/targets/win_assemble/files/fragment5
@@ -1,0 +1,1 @@
+this is fragment 5

--- a/tests/integration/targets/win_assemble/meta/main.yml
+++ b/tests/integration/targets/win_assemble/meta/main.yml
@@ -1,0 +1,20 @@
+# test code for the assemble module
+# (c) 2014, James Cammarata <jcammarata@ansible.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+dependencies:
+  - setup_remote_tmp_dir

--- a/tests/integration/targets/win_assemble/tasks/main.yml
+++ b/tests/integration/targets/win_assemble/tasks/main.yml
@@ -1,0 +1,203 @@
+# test code for the assemble module
+# (c) 2014, James Cammarata <jcammarata@ansible.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: copy the files to a new directory
+  win_copy: src="./" dest="{{remote_tmp_dir}}\\src"
+  register: result
+
+- name: create unicode file for test
+  win_shell: echo "π" > {{remote_tmp_dir}}\\src\\ßΩ.txt
+  register: result
+
+- name: assert that the new file was created
+  assert:
+    that:
+    - "result.changed == True"
+
+- name: test assemble with all fragments
+  win_assemble: src="{{remote_tmp_dir}}\\src" dest="{{remote_tmp_dir}}\\assembled1"
+  register: result
+
+- name: assert the fragments were assembled
+  assert:
+    that:
+    - "result.changed == True"
+    - "result.checksum == '3d7adf8f3a3c1506fbf0b6328d775191565e9e63'"
+
+- name: test assemble with all fragments
+  win_assemble: src="{{remote_tmp_dir}}\\src" dest="{{remote_tmp_dir}}\\assembled1"
+  register: result
+
+- name: assert that the same assemble made no changes
+  assert:
+    that:
+    - "result.changed == False"
+    - "result.checksum == '3d7adf8f3a3c1506fbf0b6328d775191565e9e63'"
+
+- name: test assemble with all fragments and backup=True
+  win_assemble: src="{{remote_tmp_dir}}\\src" dest="{{remote_tmp_dir}}\\assembled2" backup=yes
+  register: result
+
+- name: assert the fragments were assembled with backup=True
+  assert:
+    that:
+    - "result.backup_file is defined"
+    - "result.changed == True"
+    - "result.checksum == '3d7adf8f3a3c1506fbf0b6328d775191565e9e63'"
+
+- name: test assemble with fragments matching a regex
+  win_assemble: src="{{remote_tmp_dir}}\\src" dest="{{remote_tmp_dir}}\\assembled3" regexp="^fragment[1-3]$"
+  register: result
+
+- name: assert the fragments were assembled with a regex
+  assert:
+    that:
+    - "result.changed == True"
+    - "result.checksum == 'c250a155a37473d660aab69feb45b803d4c0bf1f'"
+
+- name: test assemble with a delimiter
+  win_assemble: src="{{remote_tmp_dir}}\\src" dest="{{remote_tmp_dir}}\\assembled4" delimiter="#--- delimiter ---#"
+  register: result
+
+- name: assert the fragments were assembled with a delimiter
+  assert:
+    that:
+    - "result.changed == True"
+    - "result.checksum == 'e524780178d7dac08368c348bb90991922aa9d3d'"
+
+- name: test assemble with a header
+  win_assemble: src="{{remote_tmp_dir}}\\src" dest="{{remote_tmp_dir}}\\assembled5" header="#--- header ---#"
+  register: result
+
+- name: assert the fragments were assembled with a header
+  assert:
+    that:
+    - "result.changed == True"
+    - "result.checksum == '26b255c8ceea2b5c91ab9840b51d064240eb881f'"
+
+- name: test assemble with a footer
+  win_assemble: src="{{remote_tmp_dir}}\\src" dest="{{remote_tmp_dir}}\\assembled6" footer="#--- footer ---#"
+  register: result
+
+- name: assert the fragments were assembled with a footer
+  assert:
+    that:
+    - "result.changed == True"
+    - "result.checksum == 'ec62ba81cd4b0b09a7a5fa50aae9fbf9e6d3a2f3'"
+
+- name: test assemble with escaped delimiter
+  win_assemble: src="{{remote_tmp_dir}}\\src" dest="{{remote_tmp_dir}}\\assembled7" delimiter="#--- delimiter --#\\n#--- newline ---#"
+  register: result
+
+- name: assert the fragments were assembled with a decoded delimiter
+  assert:
+    that:
+    - "result.changed == True"
+    - "result.checksum == 'f9792ad5cd4680262cfbe42e08484235d4a3b255'"
+
+- name: test assemble without remote
+  win_assemble: src="./" dest="{{remote_tmp_dir}}\\assembled8" remote_src=no
+  register: result
+
+- name: assert the fragments were assembled without remote
+  assert:
+    that:
+    - "result.changed == True"
+    - "result.checksum == '1948b7247e9eb682f1f440d88fc400c579ea622c'"
+
+- name: test assemble without remote
+  win_assemble: src="./" dest="{{remote_tmp_dir}}\\assembled8" remote_src=no
+  register: result
+
+- name: assert the same assemble made no changes without remote
+  assert:
+    that:
+    - "result.changed == False"
+    - "result.checksum == '1948b7247e9eb682f1f440d88fc400c579ea622c'"
+
+- name: test assemble with remote_src=False and backup=True
+  win_assemble: src="./" dest="{{remote_tmp_dir}}\\assembled8" remote_src=no backup=yes delimiter="#"
+  register: result
+
+- name: assert the fragments were assembled with backup without remote
+  assert:
+    that:
+    - "result.backup_file is defined"
+    - "result.changed == True"
+    - "result.checksum == 'd1425ee0c81d5caf01ad346e51e9fe03aac5b891'"
+
+- name: test assemble with remote_src=False and decrypt=True
+  win_assemble: src="./" dest="{{remote_tmp_dir}}\\assembled9" remote_src=no decrypt=yes
+  register: result
+
+- name: assert the fragments were assembled without remote and decrypt=True
+  assert:
+    that:
+    - "result.changed == True"
+    - "result.checksum == '1948b7247e9eb682f1f440d88fc400c579ea622c'"
+
+- name: test assemble with remote_src=False and a delimiter
+  win_assemble: src="./" dest="{{remote_tmp_dir}}\\assembled10" remote_src=no delimiter="#--- delimiter ---#"
+  register: result
+
+- name: assert the fragments were assembled without remote
+  assert:
+    that:
+    - "result.changed == True"
+    - "result.checksum == 'a17aa14bafa9bae1bba0ae9364c8d6230486a558'"
+
+- name: test assemble with remote_src=False and a delimiter and decrypt=True
+  win_assemble: src="./" dest="{{remote_tmp_dir}}\\assembled11" remote_src=no delimiter="#--- delimiter ---#" decrypt=yes
+  register: result
+
+- name: assert the fragments were assembled without remote
+  assert:
+    that:
+    - "result.changed == True"
+    - "result.checksum == 'a17aa14bafa9bae1bba0ae9364c8d6230486a558'"
+
+- name: test assemble with a header without remote
+  win_assemble: src="./" dest="{{remote_tmp_dir}}\\assembled12" remote_src="no" header="#--- header ---#"
+  register: result
+
+- name: assert the fragments were assembled with a header without remote
+  assert:
+    that:
+    - "result.changed == True"
+    - "result.checksum == '61b1b680ae21beec79c12236ac9908713e20b18b'"
+
+- name: test assemble with a footer without remote
+  win_assemble: src="./" dest="{{remote_tmp_dir}}\\assembled13" remote_src="no" footer="#--- footer ---#"
+  register: result
+
+- name: assert the fragments were assembled with a footer without remote
+  assert:
+    that:
+    - "result.changed == True"
+    - "result.checksum == '1cab2b9552a582051af829d9d0487be9e775856d'"
+
+- name: test assemble with escaped delimiter without remote
+  win_assemble: src="./" dest="{{remote_tmp_dir}}\\assembled14" remote_src="no" delimiter="#--- delimiter --#\\n#--- newline ---#"
+  register: result
+
+- name: assert the fragments were assembled with a decoded delimiter without remote
+  assert:
+    that:
+    - "result.changed == True"
+    - "result.checksum == '8defca0dce177fa00b4c70932d96221503447a00'"
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I've created a module to combine multiple text files into a single one, like assemble.

We have an application that uses INI files for managing its configuration with many field deployments. I wanted to centrally manage their configuration, with each INI section contained in its own file centrally, but combined into a single file when deployed.

The ansible.builtin.assemble module accomplishes this goal, but only for unix targets. Our use case uses Windows targets, so a new module needed to be written to accomplish this.

The goal was to implement a module with feature parity to ansible.built.in.assemble, mimicking its behavior and config options, as closely as possible.

One area where I diverged from the builtin.assemble, was I added the option for a header and footer in the generated output. This is useful to indicate to readers that the file is generated and edits can be lost. See my example below.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_assemble

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
  - name: test
    ansible.windows.win_assemble:
      remote_src: false
      src: "conf/DCPs/{{inventory_hostname}}"
      dest: "{{dcs_root}}\\config.test.ini"
      delimiter: '#'
      backup: true
      decrypt: true
      regexp: "ini$"
      header: '#### THIS FILE IS GENERATED. CHANGES MAY BE LOST! ####'
```
