### PR TITLE
Use older encryption scheme for pfx tests on Server 2016

### DIFF
--- a/tests/integration/targets/win_certificate_store/tasks/main.yml
+++ b/tests/integration/targets/win_certificate_store/tasks/main.yml
@@ -39,15 +39,35 @@
   - '{{root_thumbprint}}'
 
 # these files are created on the fly so we don't store binary in the git repo
+- name: check if we can use default AES encryption
+  win_powershell:
+    script: |
+      $osVersion = [Version](Get-Item -LiteralPath "$env:SystemRoot\System32\kernel32.dll").VersionInfo.ProductVersion
+      $osVersion -ge [Version]"10.0.17763"
+  changed_when: false
+  register: aes256_support
+
 - name: create PKCS12 without password
-  command: 'openssl pkcs12 -export -out subj-cert-without-pass.pfx -inkey subj-key.pem -in subj-cert.pem -passout pass:'
+  command: >-
+    openssl pkcs12 -export
+    -out subj-cert-without-pass.pfx
+    -inkey subj-key.pem
+    -in subj-cert.pem
+    -passout pass:
+    {{ '' if aes256_support.output[0] else '-certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -macalg SHA1' }}
   args:
     chdir: '{{role_path}}/files'
   delegate_to: localhost
   run_once: yes
 
 - name: create PKCS12 with password
-  command: 'openssl pkcs12 -export -out subj-cert-with-pass.pfx -inkey subj-key.pem -in subj-cert.pem -passout pass:{{key_password}}'
+  command: >-
+    openssl pkcs12 -export
+    -out subj-cert-with-pass.pfx
+    -inkey subj-key.pem
+    -in subj-cert.pem
+    -passout pass:{{key_password}}
+    {{ '' if aes256_support.output[0] else '-certpbe PBE-SHA1-3DES -keypbe PBE-SHA1-3DES -macalg SHA1' }}
   args:
     chdir: '{{role_path}}/files'
   delegate_to: localhost


### PR DESCRIPTION
##### SUMMARY
The current tests fail on Server 2016 with.

```powershell
The full traceback is:
Exception calling "Import" with "3" argument(s): "The specified network password is not correct."
At line:216 char:9
    +         $certs.Import($path, $password, $store_flags)
    +         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : CryptographicException
```

Looks like the version of openssl has been updated which means openssl is generating a pfx encrypted with AES256. Windows only started supporting AES256 encryption for pfx in Server 2019 so we need to generate the pfx with some extra flags on older hosts like Server 2016.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_certificate_store