### PR TITLE
Added depth parameter to win_uri ConvertTo-Json call

### DIFF
--- a/changelogs/fragments/PR-587-Fix-win_uri-json-depth.yaml
+++ b/changelogs/fragments/PR-587-Fix-win_uri-json-depth.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - win_uri - Max depth for json object conversion used to be 2. Can now send json objects with up to 20 levels of nesting

--- a/plugins/modules/win_uri.ps1
+++ b/plugins/modules/win_uri.ps1
@@ -183,7 +183,7 @@ $response_script = {
 $body_st = $null
 if ($null -ne $body) {
     if ($body -is [System.Collections.IDictionary] -or $body -is [System.Collections.IList]) {
-        $body_string = ConvertTo-Json -InputObject $body -Compress
+        $body_string = ConvertTo-Json -InputObject $body -Compress -Depth 20
     }
     elseif ($body -isnot [String]) {
         $body_string = $body.ToString()

--- a/tests/integration/targets/win_uri/tasks/main.yml
+++ b/tests/integration/targets/win_uri/tasks/main.yml
@@ -325,7 +325,7 @@
     - not status_code_check.changed
     - status_code_check.status_code == 202
 
-  - name: send JSON body with dict type
+- name: send JSON body with dict type
   win_uri:
     url: https://{{httpbin_host}}/post
     method: POST
@@ -342,7 +342,7 @@
   register: json_as_dict
 
 
-  - name: send JSON body with multiple levels of nesting
+- name: send JSON body with multiple levels of nesting
   win_uri:
     url: https://{{httpbin_host}}/post
     method: POST

--- a/tests/integration/targets/win_uri/tasks/main.yml
+++ b/tests/integration/targets/win_uri/tasks/main.yml
@@ -341,7 +341,23 @@
     return_content: yes
   register: json_as_dict
 
+- name: set fact of expected json dict
+  set_fact:
+    json_as_dict_value:
+      foo: bar
+      list:
+      - 1
+      - 2
+      dict:
+        foo: bar
 
+- name: assert send JSON body with dict type
+  assert:
+    that:
+    - not json_as_dict.changed
+    - json_as_dict.json.json == json_as_dict_value
+    - json_as_dict.status_code == 200
+    
 - name: send JSON body with multiple levels of nesting
   win_uri:
     url: https://{{httpbin_host}}/post
@@ -362,24 +378,25 @@
     headers:
       'Content-Type': 'text/json'
     return_content: yes
-  register: json_as_dict
+  register: nested_json_as_dict
 
 - name: set fact of expected json dict
   set_fact:
-    json_as_dict_value:
+    nested_json_as_dict_value:
       foo: bar
       list:
       - 1
       - 2
       dict:
         foo: bar
-
-- name: assert send JSON body with dict type
+        
+- name: assert send JSON body with multiple levels of nesting
   assert:
     that:
-    - not json_as_dict.changed
-    - json_as_dict.json.json == json_as_dict_value
-    - json_as_dict.status_code == 200
+    - not nested_json_as_dict.changed
+    - nested_json_as_dict.json.json == nested_json_as_dict_value
+    - nested_json_as_dict.status_code == 200
+    
 
 - name: send JSON body with 1 item in list
   win_uri:

--- a/tests/integration/targets/win_uri/tasks/main.yml
+++ b/tests/integration/targets/win_uri/tasks/main.yml
@@ -389,6 +389,12 @@
       - 2
       dict:
         foo: bar
+        dict:
+          foo: bar
+          dict:
+            foo: bar
+            dict:
+              foo: bar
         
 - name: assert send JSON body with multiple levels of nesting
   assert:

--- a/tests/integration/targets/win_uri/tasks/main.yml
+++ b/tests/integration/targets/win_uri/tasks/main.yml
@@ -325,22 +325,6 @@
     - not status_code_check.changed
     - status_code_check.status_code == 202
 
-- name: send JSON body with dict type
-  win_uri:
-    url: https://{{httpbin_host}}/post
-    method: POST
-    body:
-      foo: bar
-      list:
-      - 1
-      - 2
-      dict:
-        foo: bar
-    headers:
-      'Content-Type': 'text/json'
-    return_content: yes
-  register: json_as_dict
-
   - name: send JSON body with dict type
   win_uri:
     url: https://{{httpbin_host}}/post

--- a/tests/integration/targets/win_uri/tasks/main.yml
+++ b/tests/integration/targets/win_uri/tasks/main.yml
@@ -341,6 +341,45 @@
     return_content: yes
   register: json_as_dict
 
+  - name: send JSON body with dict type
+  win_uri:
+    url: https://{{httpbin_host}}/post
+    method: POST
+    body:
+      foo: bar
+      list:
+      - 1
+      - 2
+      dict:
+        foo: bar
+    headers:
+      'Content-Type': 'text/json'
+    return_content: yes
+  register: json_as_dict
+
+
+  - name: send JSON body with multiple levels of nesting
+  win_uri:
+    url: https://{{httpbin_host}}/post
+    method: POST
+    body:
+      foo: bar
+      list:
+      - 1
+      - 2
+      dict:
+        foo: bar
+        dict:
+          foo: bar
+          dict:
+            foo: bar
+            dict:
+              foo: bar
+    headers:
+      'Content-Type': 'text/json'
+    return_content: yes
+  register: json_as_dict
+
 - name: set fact of expected json dict
   set_fact:
     json_as_dict_value:


### PR DESCRIPTION
Added depth parameter to win_uri ConvertTo-Json call

##### SUMMARY
When using the win_uri module to send a json object, win_uri uses the ConvertTo-Json method. 

This method has a currently  unused parameter called Depth which represents the maximum depth of nested children to parse.
(https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/convertto-json?view=powershell-7.4#-depth)

This parameter's default value is 2, so the method does not correctly convert json objects with a higher depth.

I set it to a default of 20 which should be enough for most cases, or at least more useful than the default of 2.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_uri.ps1

##### ADDITIONAL INFORMATION
To reproduce the bug : send a json object with more than 2 levels of nesting using win_uri. The method will seem to work but the sent object will be incomplete.

With this change, the module can correctly send json objects with up to 20 levels of nesting.


