### PR TITLE
async_status - add check mode support

### DIFF
--- a/plugins/modules/async_status.ps1
+++ b/plugins/modules/async_status.ps1
@@ -6,7 +6,7 @@
 
 $results = @{ changed = $false }
 
-$parsed_args = Parse-Args $args
+$parsed_args = Parse-Args $args -supports_check_mode $true
 $jid = Get-AnsibleParam $parsed_args "jid" -failifempty $true -resultobj $results
 $mode = Get-AnsibleParam $parsed_args "mode" -Default "status" -ValidateSet "status", "cleanup"
 

--- a/plugins/modules/async_status.yml
+++ b/plugins/modules/async_status.yml
@@ -21,6 +21,24 @@ DOCUMENTATION:
       type: str
       choices: [cleanup, status]
       default: status
+  extends_documentation_fragment:
+    - action_common_attributes
+    - action_common_attributes.flow
+  attributes:
+    action:
+      support: full
+    async:
+      support: none
+    check_mode:
+      support: full
+      version_added: '2.4.0'
+    diff_mode:
+      support: none
+    bypass_host_loop:
+      support: none
+    platform:
+      support: full
+      platforms: windows
   author:
     - Ansible Core Team
 

--- a/tests/integration/targets/async_status/aliases
+++ b/tests/integration/targets/async_status/aliases
@@ -1,0 +1,2 @@
+windows
+shippable/windows/group1

--- a/tests/integration/targets/async_status/tasks/main.yml
+++ b/tests/integration/targets/async_status/tasks/main.yml
@@ -1,0 +1,29 @@
+- name: run async task
+  win_ping:
+  async: 30
+  poll: 2
+  register: async_res
+
+- name: assert run async task
+  assert:
+    that:
+    - async_res is finished
+    - async_res is successful
+    - async_res.ping == 'pong'
+
+- name: check mode support was added in ansible 2.18
+  when: ansible_version.full is version('2.18', '>=')
+  block:
+  - name: run async task - check mode
+    win_ping:
+    async: 30
+    poll: 2
+    register: async_res_check
+    check_mode: true
+
+  - name: assert run async task - check mode
+    assert:
+      that:
+      - async_res_check is finished
+      - async_res_check is successful
+      - async_res_check.ping == 'pong'


### PR DESCRIPTION
##### SUMMARY
Add support for running async_status in check mode. This reflects recent changes in Ansible devel that enabled this on the engine side.

Support was added with the PR https://github.com/ansible/ansible/pull/82901.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible.windows.async_status