### PR TITLE
Add ansible_win_rm_certificate_thumbprint to facts

### DIFF
--- a/changelogs/fragments/win_setup-fact.yml
+++ b/changelogs/fragments/win_setup-fact.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - >-
+    win_setup - Added the ``ansible_win_rm_certificate_thumbprint`` fact to display the thumbprint
+    of the certificate in use

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -1057,6 +1057,7 @@ $factMeta = @(
             $certs | Sort-Object -Property NotAfter | Select-Object -First 1 | ForEach-Object -Process {
                 # this fact was renamed from ansible_winrm_certificate_expires due to collision with ansible_winrm_X connection var pattern
                 $ansibleFacts.ansible_win_rm_certificate_expires = $_.NotAfter.ToString('yyyy-MM-dd HH:mm:ss')
+                $ansibleFacts.ansible_win_rm_certificate_thumbprint = $_.Thumbprint
             }
         }
     },

--- a/tests/integration/targets/win_setup/tasks/main.yml
+++ b/tests/integration/targets/win_setup/tasks/main.yml
@@ -58,6 +58,7 @@
   assert:
     that:
       - "setup_result.ansible_facts.ansible_win_rm_certificate_expires"
+      - "setup_result.ansible_facts.ansible_win_rm_certificate_thumbprint"
   when: ansible_ssh_port|default(5986) != 5985
 
 - name: test gather_subset "!all"


### PR DESCRIPTION
##### SUMMARY

Adds `ansible_win_rm_certificate_thumbprint` to the facts collected as part of the WinRM facts.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- ansible.windows

##### ADDITIONAL INFORMATION

Seeing as we're already collecting this data, it would be handy to expose it as a fact for use later (for certificate renewals/updates). Would there be any objections to adding it to the facts like I have implemented below?

```
PLAY [Test playbook] **********************************************************************************************************************************************************************************************************************************************
TASK [Gathering Facts] ********************************************************************************************************************************************************************************************************************************************
ok: [test-win-vm]

TASK [Print WinRM certificate expiry] *****************************************************************************************************************************************************************************************************************************
ok: [test-win-vm] => {
    "ansible_win_rm_certificate_expires": "2021-11-22 13:17:09"
}

TASK [Print WinRM certificate thumbprint] *************************************************************************************************************************************************************************************************************************
ok: [test-win-vm] => {
    "ansible_win_rm_certificate_thumbprint": "D96A5DC19B1DC6A939BF418B3F48756B0ECC636E"
}

PLAY RECAP ********************************************************************************************************************************************************************************************************************************************************
test-win-vm                 : ok=3    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```
