### PR TITLE
win_user - Added account_expires

### DIFF
--- a/changelogs/fragments/win_user-account-expires.yml
+++ b/changelogs/fragments/win_user-account-expires.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - >-
+    win_user - Added the ability to set an account expiration date using the ``account_expires`` option
+    - https://github.com/ansible-collections/ansible.windows/issues/610

--- a/plugins/modules/win_user.py
+++ b/plugins/modules/win_user.py
@@ -17,6 +17,15 @@ options:
     - C(true) will disable the user account.
     - C(false) will clear the disabled flag.
     type: bool
+  account_expires:
+    description:
+    - Set the account expiration date for the user.
+    - This value should be in the format C(%Y-%m-%d) or C(%Y-%m-%dT%H:%M:%S%z).
+      The timezone can be omitted in the long format and will default to UTC.
+      The format of C(%z) is C(±HHMM), C(±HH:MM), or C(Z) for UTC.
+    - Set the value to C(never) to remove the account expiration date.
+    type: str
+    version_added: 2.4.0
   account_locked:
     description:
     - Only C(false) can be set and it will unlock the user account if locked.
@@ -127,6 +136,24 @@ EXAMPLES = r'''
   ansible.windows.win_user:
     name: bob
     state: absent
+
+- name: Set an account expiration date to the 27th of October 2024 at 2:30PM UTC
+  ansible.windows.win_user:
+    name: bob
+    state: present
+    account_expires: '2024-10-27T14:30:00Z'
+
+- name: Set an account expiration 30 days in the future
+  ansible.windows.win_user:
+    name; bob
+    state: present
+    account_expires: '{{ "%Y-%m-%dT%H:%M:%S%z" | ansible.builtin.strftime(now().timestamp() + (60 * 60 * 24 * 30)) }}'
+
+- name: Remove account expiration date
+  ansible.windows.win_user:
+    name: bob
+    state: present
+    account_expires: never
 '''
 
 RETURN = r'''

--- a/plugins/modules/win_user.py
+++ b/plugins/modules/win_user.py
@@ -145,7 +145,7 @@ EXAMPLES = r'''
 
 - name: Set an account expiration 30 days in the future
   ansible.windows.win_user:
-    name; bob
+    name: bob
     state: present
     account_expires: '{{ "%Y-%m-%dT%H:%M:%S%z" | ansible.builtin.strftime(now().timestamp() + (60 * 60 * 24 * 30)) }}'
 

--- a/tests/integration/targets/win_user/tasks/tests.yml
+++ b/tests/integration/targets/win_user/tasks/tests.yml
@@ -424,6 +424,176 @@
       - "win_user_invalid_group_result.msg"
       - win_user_invalid_group_result.msg is match("group 'Userz' not found")
 
+- name: get expected dates based on remote timezone
+  win_powershell:
+    script: |
+      [DateTime]::new(2040, 10, 27, 0, 0, 0, [DateTimeKind]::Utc).ToLocalTime()
+      [DateTime]::new(2040, 10, 27, 14, 30, 0, [DateTimeKind]::Utc).ToLocalTime()
+      [DateTime]::new(2040, 10, 27, 13, 30, 0, [DateTimeKind]::Utc).ToLocalTime()
+      [DateTimeOffset]::new(
+        [DateTime]::new(2040, 10, 27, 14, 30, 0, [DateTimeKind]::Unspecified),
+        (New-TimeSpan -Hours 2)).UtcDateTime.ToLocalTime()
+  register: expected_dates
+
+- name: expect failure when account_expires is invalid
+  win_user:
+    name: '{{ test_win_user_name }}'
+    account_expires: invalid
+  register: account_expires_invalid
+  failed_when:
+  - >-
+    account_expires_invalid.msg != "Failed to parse account_expires as datetime string. Expecting datetime in yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss.FFFFFFFK format."
+
+- name: set account expiration date - short form
+  win_user:
+    name: '{{ test_win_user_name }}'
+    account_expires: '2040-10-27'
+  register: account_expires_short_result
+
+- name: get result of set account expiration date - short form
+  win_powershell:
+    script: param ($Name); Get-LocalUser -Name $Name | Select-Object -ExpandProperty AccountExpires
+    parameters:
+      Name: '{{ test_win_user_name }}'
+  register: account_expires_short_result_actual
+
+- name: assert set account expiration date - short form
+  assert:
+    that:
+    - account_expires_short_result is changed
+    - account_expires_short_result_actual.output == [expected_dates.output[0]]
+
+- name: set account expiration date - short form - idempotent
+  win_user:
+    name: '{{ test_win_user_name }}'
+    account_expires: '2040-10-27'
+  register: account_expires_short_result_again
+
+- name: assert set account expiration date - short form - idempotent
+  assert:
+    that:
+    - not account_expires_short_result_again is changed
+
+- name: set account expiration date - long form
+  win_user:
+    name: '{{ test_win_user_name }}'
+    account_expires: '2040-10-27T14:30:00'
+  register: account_expires_long_result
+
+- name: get result of set account expiration date - long form
+  win_powershell:
+    script: param ($Name); Get-LocalUser -Name $Name | Select-Object -ExpandProperty AccountExpires
+    parameters:
+      Name: '{{ test_win_user_name }}'
+  register: account_expires_long_result_actual
+
+- name: assert set account expiration date - long form
+  assert:
+    that:
+    - account_expires_long_result is changed
+    - account_expires_long_result_actual.output == [expected_dates.output[1]]
+
+- name: set account expiration date - long form - idempotent
+  win_user:
+    name: '{{ test_win_user_name }}'
+    account_expires: '2040-10-27T14:30:00'
+  register: account_expires_long_result_again
+
+- name: assert set account expiration date - long form - idempotent
+  assert:
+    that:
+    - not account_expires_long_result_again is changed
+
+- name: set account expiration date - long form with Z
+  win_user:
+    name: '{{ test_win_user_name }}'
+    account_expires: '2040-10-27T13:30:00Z'
+  register: account_expires_long_z_result
+
+- name: get result of set account expiration date - long form with Z
+  win_powershell:
+    script: param ($Name); Get-LocalUser -Name $Name | Select-Object -ExpandProperty AccountExpires
+    parameters:
+      Name: '{{ test_win_user_name }}'
+  register: account_expires_long_z_result_actual
+
+- name: assert set account expiration date - long form with Z
+  assert:
+    that:
+    - account_expires_long_z_result is changed
+    - account_expires_long_z_result_actual.output == [expected_dates.output[2]]
+
+- name: set account expiration date - long form with Z - idempotent
+  win_user:
+    name: '{{ test_win_user_name }}'
+    account_expires: '2040-10-27T13:30:00Z'
+  register: account_expires_long_z_result_again
+
+- name: assert set account expiration date - long form - idempotent
+  assert:
+    that:
+    - not account_expires_long_result_again is changed
+
+- name: set account expiration date - long form with tz
+  win_user:
+    name: '{{ test_win_user_name }}'
+    account_expires: '2040-10-27T14:30:00+0200'
+  register: account_expires_long_tz_result
+
+- name: get result of set account expiration date - long form with tz
+  win_powershell:
+    script: param ($Name); Get-LocalUser -Name $Name | Select-Object -ExpandProperty AccountExpires
+    parameters:
+      Name: '{{ test_win_user_name }}'
+  register: account_expires_long_tz_result_actual
+
+- name: assert set account expiration date - long form with tz
+  assert:
+    that:
+    - account_expires_long_tz_result is changed
+    - account_expires_long_tz_result_actual.output == [expected_dates.output[3]]
+
+- name: set account expiration date - long form with tz - idempotent
+  win_user:
+    name: '{{ test_win_user_name }}'
+    account_expires: '2040-10-27T14:30:00+02:00'
+  register: account_expires_long_tz_result_again
+
+- name: assert set account expiration date - long form with tz - idempotent
+  assert:
+    that:
+    - not account_expires_long_tz_result_again is changed
+
+- name: remove account expiration date
+  win_user:
+    name: '{{ test_win_user_name }}'
+    account_expires: never
+  register: account_expires_remove_result
+
+- name: get result of remove account expiration date
+  win_powershell:
+    script: param ($Name); Get-LocalUser -Name $Name | Select-Object -ExpandProperty AccountExpires
+    parameters:
+      Name: '{{ test_win_user_name }}'
+  register: account_expires_remove_result_actual
+
+- name: assert remove account expiration date
+  assert:
+    that:
+    - account_expires_remove_result is changed
+    - account_expires_remove_result_actual.output == []
+
+- name: remove account expiration date - idempotent
+  win_user:
+    name: '{{ test_win_user_name }}'
+    account_expires: never
+  register: account_expires_remove_result_again
+
+- name: assert remove account expiration date - idempotent
+  assert:
+    that:
+    - not account_expires_remove_result_again is changed
+
 - name: remove existing test user if present (check mode)
   win_user:
     name: '{{ test_win_user_name }}'


### PR DESCRIPTION
##### SUMMARY
Added account_expires option to win_user that allows the caller to set an expiration date of a local user account.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/610

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_user