### PR TITLE
setup - Provider SMBIOS fact fallback

### DIFF
--- a/changelogs/fragments/setup-smbios.yml
+++ b/changelogs/fragments/setup-smbios.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - setup - Provide WMI/CIM fallback for facts that rely on SMBIOS when that is unavailable


### PR DESCRIPTION
##### SUMMARY
Provide a fallback when gathering the SMBIOS facts fails. The fallback uses the original code that retrieved the values from CIM. While this is slower it should only happen in case the SMBIOS call fails for whatever reason.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.windows.setup