### PR TITLE
Raise minimum supported Ansible version to 2.15

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -95,19 +95,6 @@ stages:
               test: sanity
             - name: Units
               test: units
-  - stage: Ansible_2_14
-    displayName: Ansible 2.14
-    dependsOn: []
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: '{0}'
-          testFormat: '2.14/{0}'
-          targets:
-            - name: Sanity
-              test: sanity
-            - name: Units
-              test: units
   - stage: Windows
     displayName: Windows
     dependsOn: []

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -118,7 +118,6 @@ stages:
       - Ansible_2_17
       - Ansible_2_16
       - Ansible_2_15
-      - Ansible_2_14
       - Windows
     jobs:
       - template: templates/coverage.yml

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The `ansible.windows` collection includes the core plugins supported by Ansible 
 
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.14**.
+This collection has been tested against following Ansible versions: **>=2.15**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.

--- a/changelogs/fragments/ansible-version.yml
+++ b/changelogs/fragments/ansible-version.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Set minimum supported Ansible version to 2.15 to align with the versions still supported by Ansible.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: ansible
 name: windows
-version: 2.4.0
+version: 2.5.0
 readme: README.md
 authors:
   - Jordan Borean @jborean93

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
-requires_ansible: ">=2.14"
+requires_ansible: ">=2.15"
 plugin_routing:
   modules:
     win_domain_controller:

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,1 +1,0 @@
-tests/integration/targets/win_dsc/files/xTestCompositeDsc/1.0.0/DSCResources/xTestComposite/xTestComposite.schema.psm1 pslint!skip # Pwsh cannot parse DSC to MOF on Linux


### PR DESCRIPTION
##### SUMMARY
Ansible 2.14 is EOL so the new minimum is 2.15.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible.windows