### PR TITLE
Update setup.yml docs to reference proper FQCN

### DIFF
--- a/plugins/modules/setup.yml
+++ b/plugins/modules/setup.yml
@@ -5,7 +5,7 @@ DOCUMENTATION:
   module: setup
   short_description: Gathers facts about remote hosts
   seealso:
-    - module: ansible.builtin.setup
+    - module: ansible.windows.setup
   options:
     gather_subset:
       description:
@@ -53,4 +53,4 @@ DOCUMENTATION:
 
 EXAMPLES: |
   - name: run the setup facts
-    ansible.builtin.setup:
+    ansible.windows.setup:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There's an error where the windows.setup module docs reference ansible.builtin instead of ansible.windows
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #624 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible.windows.setup

