### PR TITLE
Update slurp.yml to reference ansible.windows FQCN

### DIFF
--- a/plugins/modules/slurp.yml
+++ b/plugins/modules/slurp.yml
@@ -25,7 +25,7 @@ DOCUMENTATION:
 
 EXAMPLES: |
   - name: Retrieve remote ini file on a Windows host
-    ansible.builtin.slurp:
+    ansible.windows.slurp:
       src: C:\Program Files\Program\program.ini
     register: program_conf
 


### PR DESCRIPTION
##### SUMMARY
Fixes incorrect FQCN in the examples for the overloaded module slurp
Fixes #626 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible.windows.slurp

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
