### PR TITLE
Ensure that the encoding of the win_updates scripts is not corrupted.

### DIFF
--- a/changelogs/fragments/636-preserve-update-script-encoding.yml
+++ b/changelogs/fragments/636-preserve-update-script-encoding.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - >-
+      win_updates - Base64 encode the update wrapper and payload to prevent locale-specific encoding issues.

--- a/plugins/modules/win_updates.ps1
+++ b/plugins/modules/win_updates.ps1
@@ -420,8 +420,11 @@ try {
     $execWrapper = $input | Out-String
     $splitParts = $execWrapper.Split(@(\"`0`0`0`0\"), 2, [StringSplitOptions]::RemoveEmptyEntries)
 
-    Invoke-Expression ('Function Invoke-InProcessStub { ' + $splitParts[0] + '}')
-    Invoke-InProcessStub $splitParts[1]
+    $runner = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($splitParts[0]))
+    $payload = [System.Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($splitParts[1]))
+
+    Invoke-Expression ('Function Invoke-InProcessStub { ' + $runner + '}')
+    Invoke-InProcessStub $payload
 }
 catch {
     $result = @{
@@ -520,7 +523,10 @@ catch {
             })
 
         try {
-            $stdin.WriteLine("$runner`0`0`0`0$runPayload")
+            $runnerEncoded = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($runner))
+            $runPayloadEncoded = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes($runPayload))
+
+            $stdin.WriteLine("$runnerEncoded`0`0`0`0$runPayloadEncoded")
             $stdin.Flush()
             $stdin.Dispose()
         }


### PR DESCRIPTION
##### SUMMARY
We run Windows updates on some machines with more "unusual" encodings such as Chinese machines.
At some point between Ansible 7.5.0 and 8.3.0, we started encountering encoding related issues (see below).

This change base64 encode/decodes the update script wrapper and contents to prevent this.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_updates

##### ADDITIONAL INFORMATION

Example error on a Chinese machine:

```
FAILED - RETRYING: [win2019_x64_std_zh_tw]: Check for updates (3 retries left).Result was: {
    "attempts": 1,
    "changed": false,
    "failed_update_count": 0,
    "filtered_updates": {},
    "found_update_count": 0,
    "installed_update_count": 0,
    "invocation": {
        "module_args": {
            "accept_list": null,
            "category_names": [
                ...
            ],
            "log_path": "c:\\windows_updates_pre.txt",
            "reboot": false,
            "reboot_timeout": 1200,
            "reject_list": [
		...
            ],
            "server_selection": "windows_update",
            "skip_optional": false,
            "state": "searched"
        }
    },
    "msg": "Unknown failure running win_updates bootstrap process:  H \"1\"  ޼ƩI s \"Deserialize\"  ɵo ͨҥ~   p: \"'Element'  O L Ī  XmlNodeType C\"",
    "retries": 4,
    "updates": {}
}
```
