### PR TITLE
Added Zone.Identifier mark for file downloaded with win_get_url module

### DIFF
--- a/plugins/modules/win_get_url.ps1
+++ b/plugins/modules/win_get_url.ps1
@@ -158,7 +158,8 @@ Function Set-FileZoneStream {
     if (-not (Test-Path -LiteralPath $Dest)) {
         $module.FailJson("Cannt find '$Dest' for setting stream.")
     }
-    Set-Content -Path $Dest -Stream Zone.Identifier -Value '[ZoneTransfer]', 'ZoneId=3', "ReferrerUrl=$Url", "HostUrl=$Url"
+    $stream_dest = $Dest + ":Zone.Identifier"
+    Set-Content -Path $stream_dest -Value '[ZoneTransfer]', 'ZoneId=3', "ReferrerUrl=$Url", "HostUrl=$Url"
 
 }
 Function Invoke-DownloadFile {

--- a/plugins/modules/win_get_url.py
+++ b/plugins/modules/win_get_url.py
@@ -137,7 +137,7 @@ EXAMPLES = r'''
     url: http://www.example.com/earthrise.jpg
     dest: C:\temp\earthrise.jpg
     force: true
-    set_zone: yes
+    set_zone: true
 '''
 
 RETURN = r'''

--- a/plugins/modules/win_get_url.py
+++ b/plugins/modules/win_get_url.py
@@ -67,7 +67,7 @@ options:
   url_timeout:
     aliases:
     - timeout
-    set_zone:
+  set_zone:
     description:
     - Markes the file as a file downloaded from internet zone for security purpose
       using Zone.Identifier stream.

--- a/plugins/modules/win_get_url.py
+++ b/plugins/modules/win_get_url.py
@@ -69,8 +69,8 @@ options:
     - timeout
   set_zone:
     description:
-    - Markes the file as a file downloaded from internet zone for security purpose
-      using Zone.Identifier stream.
+      - Markes the file as a file downloaded from internet zone for security purpose
+        using Zone.Identifier stream.
     type: bool
     default: no
 notes:

--- a/plugins/modules/win_get_url.py
+++ b/plugins/modules/win_get_url.py
@@ -67,6 +67,12 @@ options:
   url_timeout:
     aliases:
     - timeout
+    set_zone:
+    description:
+    - Markes the file as a file downloaded from internet zone for security purpose
+      using Zone.Identifier stream.
+    type: bool
+    default: no
 notes:
 - If your URL includes an escaped slash character (%2F) this module will convert it to a real slash.
   This is a result of the behaviour of the System.Uri class as described in
@@ -125,6 +131,13 @@ EXAMPLES = r'''
     checksum: a97e6837f60cec6da4491bab387296bbcd72bdba
     checksum_algorithm: sha1
     force: true
+
+- name: Download src with set_zone on
+  ansible.windows.win_get_url:
+    url: http://www.example.com/earthrise.jpg
+    dest: C:\temp\earthrise.jpg
+    force: true
+    set_zone: yes
 '''
 
 RETURN = r'''

--- a/tests/integration/targets/win_get_url/tasks/tests_url.yml
+++ b/tests/integration/targets/win_get_url/tasks/tests_url.yml
@@ -242,3 +242,20 @@
     that:
     - no_redirection is changed
     - no_redirection.status_code == 302
+
+- name: download single file with zone insert
+  win_get_url:
+    url: https://{{ httpbin_host }}/base64/SG93IG5vdyBicm93biBjb3c=
+    dest: '{{ testing_dir }}\output_zone.txt'
+  check_mode: yes
+  register: http_download_check
+
+- name: check if zone file data written
+  win_shell: Get-Content {{ testing_dir }}\output_zone.txt:Zone.Identifier
+  register: zone_information
+
+- name: assert 
+  assert:
+    that:
+    - zone_infomation.stderr is null
+    - zone_information.stdout == "[ZoneTransfer]\nZoneId=3\nReferrerUrl=https://{{ httpbin_host }}/base64/SG93IG5vdyBicm93biBjb3c=\nHostUrl=https://{{ httpbin_host }}/base64/SG93IG5vdyBicm93biBjb3c="

--- a/tests/integration/targets/win_get_url/tasks/tests_url.yml
+++ b/tests/integration/targets/win_get_url/tasks/tests_url.yml
@@ -251,8 +251,8 @@
 
 - name: check if zone file data written
   win_shell: |
-    $path = '{{ testing_dir }}\output'
-    Get-Content -Path $path:Zone.Identifier
+    $path = '{{ testing_dir }}\output:Zone.Identifier'
+    Get-Content -Path $path
   register: zone_information
 
 - name: assert writing up zones was sucsess

--- a/tests/integration/targets/win_get_url/tasks/tests_url.yml
+++ b/tests/integration/targets/win_get_url/tasks/tests_url.yml
@@ -252,7 +252,7 @@
 - name: check if zone file data written
   win_shell: |
     $path = '{{ testing_dir }}\output'
-    Get-Content -Path $path -Stream Zone.Identifier
+    Get-Content -Path $path:Zone.Identifier
   register: zone_information
 
 - name: assert writing up zones was sucsess

--- a/tests/integration/targets/win_get_url/tasks/tests_url.yml
+++ b/tests/integration/targets/win_get_url/tasks/tests_url.yml
@@ -254,7 +254,7 @@
   win_shell: Get-Content {{ testing_dir }}\output_zone.txt:Zone.Identifier
   register: zone_information
 
-- name: assert 
+- name: assert writing up zones was sucsess
   assert:
     that:
     - zone_infomation.stderr is null

--- a/tests/integration/targets/win_get_url/tasks/tests_url.yml
+++ b/tests/integration/targets/win_get_url/tasks/tests_url.yml
@@ -251,7 +251,7 @@
   register: http_download_check
 
 - name: check if zone file data written
-  win_shell: Get-Content {{ testing_dir }}\output_zone.txt:Zone.Identifier
+  win_shell: 'Get-Content -Path {{ testing_dir }}\output_zone.txt:Zone.Identifier'
   register: zone_information
 
 - name: assert writing up zones was sucsess

--- a/tests/integration/targets/win_get_url/tasks/tests_url.yml
+++ b/tests/integration/targets/win_get_url/tasks/tests_url.yml
@@ -246,12 +246,13 @@
 - name: download single file with zone insert
   win_get_url:
     url: https://{{ httpbin_host }}/base64/SG93IG5vdyBicm93biBjb3c=
-    dest: '{{ testing_dir }}\output_zone.txt'
-  check_mode: yes
+    dest: '{{ testing_dir }}\output'
   register: http_download_check
 
 - name: check if zone file data written
-  win_shell: 'Get-Content -Path {{ testing_dir }}\output_zone.txt:Zone.Identifier'
+  win_shell: |
+    $path = '{{ testing_dir }}\output'
+    Get-Content -Path $path -Stream Zone.Identifier
   register: zone_information
 
 - name: assert writing up zones was sucsess


### PR DESCRIPTION
##### SUMMARY
Added the ability to set `Zone.Identifier` file stream for files downloaded using  _win_get_url_ .
This might be necessary for security purposes, file having this stream can be scanned using Windows Smartscreen and other malware analysis. Also, different policies can be set for files downloaded from the internet.  

Added the `set_zone` **optional** boolean parameter to the _win_get_url_ . Nothing changed on the output.

##### Example input
Before:
```
- name: Download src with sha256 checksum url
  ansible.windows.win_get_url:
    url: http://www.example.com/earthrise.jpg
    dest: C:\temp\earthrise.jpg
    checksum_url: http://www.example.com/sha256sum.txt
    checksum_algorithm: sha256
    force: true
```

After:
```
- name: Download src with sha256 checksum url
  ansible.windows.win_get_url:
    url: http://www.example.com/earthrise.jpg
    dest: C:\temp\earthrise.jpg
    checksum_url: http://www.example.com/sha256sum.txt
    checksum_algorithm: sha256
    force: true
    set_zone: true
```

