### PR TITLE
Increase win_powershell executable timeout

### DIFF
--- a/changelogs/fragments/645-win_powershell-executable-timeout.yml
+++ b/changelogs/fragments/645-win_powershell-executable-timeout.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - win_powershell - increase open timeout for ``executable`` parameter to prevent exceptions on first-run or slower targets.
+    (https://github.com/ansible-collections/ansible.windows/issues/644).

--- a/plugins/modules/win_powershell.ps1
+++ b/plugins/modules/win_powershell.ps1
@@ -613,7 +613,7 @@ try {
 
         # In case a user specified an executable that does not support the PSHost named pipe that PowerShell uses we
         # specify a timeout so the module does not hang.
-        $connInfo.OpenTimeout = 5000
+        $connInfo.OpenTimeout = 60000
         $runspace = [RunspaceFactory]::CreateRunspace($runspaceHost, $connInfo)
     }
     else {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The 5s timeout seems too short. It has been witnessed that first-time startup for pwsh.exe (v7.4 at least) can take 20-30s on some platforms.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #644

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_powershell

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
