### PR TITLE
setup - handle invalid group entries for machine_id

### DIFF
--- a/changelogs/fragments/606-setup-machine-sid.yml
+++ b/changelogs/fragments/606-setup-machine-sid.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    setup - Better handle orphaned users when attempting to retrieve ``ansible_machine_id`` -
+    https://github.com/ansible-collections/ansible.windows/issues/606


### PR DESCRIPTION
##### SUMMARY
Manually enumerates the local group membership to better handle the scenario when a SID cannot be resolved.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/606

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup