### PR TITLE
win_updates - Handle Wait-Process failing to find process

### DIFF
--- a/changelogs/fragments/623-updates-wait-error.yml
+++ b/changelogs/fragments/623-updates-wait-error.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    win_updates - Handle race condition when ``Wait-Process`` did not handle when the process had ended -
+    https://github.com/ansible-collections/ansible.windows/issues/623


### PR DESCRIPTION
##### SUMMARY
Better handle when Wait-Process failed to find the process we wanted to wait on. When looking at the decompiled code I can see that if the process existed when Wait-Process was in the process block to get the Process object but ended before the end block ran to then wait for the process to end it will throw an exception that was not converted to an error record. This just wraps the full command in try/catch instead of -ErrorAction SilentlyContinue to handle this scenario.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/623

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_updates