### PR TITLE
Expand connection plugins used in CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -104,9 +104,11 @@ stages:
           nameFormat: Server {0}
           testFormat: devel/windows/{0}
           targets:
-            - test: 2016
-            - test: 2019
-            - test: 2022
+            - test: 2016/winrm/http
+            - test: 2019/winrm/https
+            - test: 2022/winrm/https
+            - test: 2022/psrp/https
+            - test: 2022/ssh/key
           groups:
             - 1
             - 2

--- a/tests/integration/targets/win_certificate_store/tasks/test.yml
+++ b/tests/integration/targets/win_certificate_store/tasks/test.yml
@@ -388,7 +388,7 @@
     ansible_become: yes
     ansible_become_method: runas
     ansible_become_user: '{{ansible_user}}'
-    ansible_become_pass: '{{ansible_password}}'
+    ansible_become_pass: '{{ ansible_password | default(ansible_test_connection_password) }}'
   register: import_pfx_without_pass_check
   check_mode: yes
 

--- a/tests/integration/targets/win_dsc/tasks/main.yml
+++ b/tests/integration/targets/win_dsc/tasks/main.yml
@@ -1,18 +1,5 @@
 ---
-- name: get powershell version
-  win_shell: $PSVersionTable.PSVersion.Major
-  register: powershell_version
-
-- name: expect failure when running on old PS hosts
-  win_dsc:
-    resource_name: File
-  register: fail_dsc_old
-  failed_when: '"This module cannot run as it requires a minimum PowerShell version of 5.0" not in fail_dsc_old.msg'
-  when: powershell_version.stdout_lines[0]|int < 5
-
-- name: run tests when PSv5+
-  when: powershell_version.stdout_lines[0]|int >= 5
-  block:
+- block:
   - name: add remote temp dir to PSModulePath
     win_path:
       name: PSModulePath
@@ -20,6 +7,15 @@
       scope: machine
       elements:
       - '{{ remote_tmp_dir }}'
+
+  # Needed so subsequent SSH session see the new PSModulePath env var
+  - name: restart sshd service
+    win_service:
+      name: sshd
+      state: restarted
+    when: ansible_connection == 'ssh'
+
+  - meta: reset_connection
 
   - name: copy custom DSC resources to remote temp dir
     win_copy:

--- a/tests/integration/targets/win_dsc/tasks/tests.yml
+++ b/tests/integration/targets/win_dsc/tasks/tests.yml
@@ -225,7 +225,7 @@
       Set-Content -Path "{{ remote_tmp_dir }}\runas.txt" -Value $sid
     TestScript: $false
     PsDscRunAsCredential_username: '{{ ansible_user }}'
-    PsDscRunAsCredential_password: '{{ ansible_password }}'
+    PsDscRunAsCredential_password: '{{ ansible_password | default(ansible_test_connection_password) }}'
   register: runas_user
 
 - name: get result of run DSC process as another user

--- a/tests/integration/targets/win_owner/tasks/tests.yml
+++ b/tests/integration/targets/win_owner/tasks/tests.yml
@@ -174,7 +174,7 @@
   become_method: runas
   vars:
     ansible_become_user: '{{ ansible_user }}'
-    ansible_become_password: '{{ ansible_password }}'
+    ansible_become_password: '{{ ansible_password | default(ansible_test_connection_password) }}'
 
 - name: get result of set owner recursively on limited access dir
   win_powershell:

--- a/tests/integration/targets/win_package/tasks/msix_tests.yml
+++ b/tests/integration/targets/win_package/tasks/msix_tests.yml
@@ -73,7 +73,7 @@
   become_method: runas
   vars:
     ansible_become_user: '{{ ansible_user }}'
-    ansible_become_pass: '{{ ansible_password }}'
+    ansible_become_pass: '{{ ansible_password | default(ansible_test_connection_password) }}'
   register: test_win_package_msix_packages
   notify: remove trusted root cert
 

--- a/tests/integration/targets/win_path/tasks/main.yml
+++ b/tests/integration/targets/win_path/tasks/main.yml
@@ -2,7 +2,7 @@
     varname: WINPATH_TEST
 
 - name: Remove {{ varname }} vars from user and machine scope
-  raw: '[Environment]::SetEnvironmentVariable("{{ varname }}", $null, "User"); [Environment]::SetEnvironmentVariable("{{ varname }}", $null, "Machine")'
+  win_shell: '[Environment]::SetEnvironmentVariable("{{ varname }}", $null, "User"); [Environment]::SetEnvironmentVariable("{{ varname }}", $null, "Machine")'
 
 - name: Set a var at the machine and user levels
   win_path:
@@ -15,7 +15,7 @@
   register: pathout
 
 - name: Get path value from machine and user levels
-  raw: '[Environment]::GetEnvironmentVariable("{{ varname }}","{{ item.item }}")'
+  win_shell: '[Environment]::GetEnvironmentVariable("{{ varname }}","{{ item.item }}")'
   with_items: "{{ pathout.results }}"
   register: varout
 
@@ -30,7 +30,7 @@
   - "{{ varout.results }}"
 
 - name: Remove {{ varname }} vars from user and machine scope
-  raw: '[Environment]::SetEnvironmentVariable("{{ varname }}", $null, "User"); [Environment]::SetEnvironmentVariable("{{ varname }}", $null, "Machine")'
+  win_shell: '[Environment]::SetEnvironmentVariable("{{ varname }}", $null, "User"); [Environment]::SetEnvironmentVariable("{{ varname }}", $null, "Machine")'
 
 - name: Create multi-element path
   win_path:
@@ -41,7 +41,7 @@
   register: multiout
 
 - name: Get path value
-  raw: $env:{{ varname }}
+  win_shell: (Get-Item "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment").GetValue('{{ varname }}', '')
   register: varout
 
 - name: Ensure output
@@ -63,7 +63,7 @@
   register: addout
 
 - name: Get path value
-  raw: $env:{{ varname }}
+  win_shell: (Get-Item "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment").GetValue('{{ varname }}', '')
   register: varout
 
 - name: Test idempotence- retry values to middle and end, test case-insensitive comparison, backslash canonicalization
@@ -78,7 +78,7 @@
   register: idemout
 
 - name: Get path value
-  raw: $env:{{ varname }}
+  win_shell: (Get-Item "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment").GetValue('{{ varname }}', '')
   register: idemvarout
 
 - name: Ensure output
@@ -99,7 +99,7 @@
   register: removeout
 
 - name: Get path value
-  raw: $env:{{ varname }}
+  win_shell: (Get-Item "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment").GetValue('{{ varname }}', '')
   register: varout
 
 - name: Test idempotence- retry remove single element
@@ -110,7 +110,7 @@
   register: idemremoveout
 
 - name: Get path value
-  raw: $env:{{ varname }}
+  win_shell: (Get-Item "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment").GetValue('{{ varname }}', '')
   register: idemvarout
 
 - name: Ensure output
@@ -135,7 +135,7 @@
   register: removeout
 
 - name: Get path value
-  raw: $env:{{ varname }}
+  win_shell: (Get-Item "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment").GetValue('{{ varname }}', '')
   register: varout
 
 - name: Ensure output
@@ -154,7 +154,7 @@
   register: checkadd
 
 - name: Get path value
-  raw: $env:{{ varname }}
+  win_shell: (Get-Item "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment").GetValue('{{ varname }}', '')
   register: checkaddvarout
 
 - name: Test check mode remove
@@ -166,7 +166,7 @@
   register: checkremove
 
 - name: Get path value
-  raw: $env:{{ varname }}
+  win_shell: (Get-Item "HKLM:\System\CurrentControlSet\Control\Session Manager\Environment").GetValue('{{ varname }}', '')
   register: checkremovevarout
 
 - name: Ensure output
@@ -180,4 +180,4 @@
     - checkremovevarout.stdout_lines[0] == "C:\\PathA" # shouldn't have actually changed the value
 
 - name: Remove {{ varname }} vars from user and machine scope
-  raw: '[Environment]::SetEnvironmentVariable("{{ varname }}", $null, "User"); [Environment]::SetEnvironmentVariable("{{ varname }}", $null, "Machine")'
+  win_shell: '[Environment]::SetEnvironmentVariable("{{ varname }}", $null, "User"); [Environment]::SetEnvironmentVariable("{{ varname }}", $null, "Machine")'

--- a/tests/integration/targets/win_reboot/tasks/main.yml
+++ b/tests/integration/targets/win_reboot/tasks/main.yml
@@ -43,6 +43,9 @@
   register: removed_shutdown_privilege
 
 - block:
+  - name: reset connection to ensure privilege change takes effect
+    meta: reset_connection
+
   - name: try and reboot without required privilege
     win_reboot:
     register: fail_privilege
@@ -56,6 +59,9 @@
       name: SeRemoteShutdownPrivilege
       users: '{{ removed_shutdown_privilege.removed }}'
       action: add
+
+  - name: reset connection after adding privileges back in
+    meta: reset_connection
 
 - name: Use invalid parameter
   win_reboot:

--- a/tests/integration/targets/win_service/tasks/tests.yml
+++ b/tests/integration/targets/win_service/tasks/tests.yml
@@ -488,7 +488,7 @@
   win_service:
     name: "{{test_win_service_name}}"
     username: "{{ansible_user}}"
-    password: "{{ansible_password}}"
+    password: "{{ansible_password | default(ansible_test_connection_password)}}"
   register: win_service_change_password_current_user
 
 - name: check that the service user has been set to current user
@@ -502,7 +502,7 @@
   win_service:
     name: "{{test_win_service_name}}"
     username: "{{ansible_user}}"
-    password: "{{ansible_password}}"
+    password: "{{ansible_password | default(ansible_test_connection_password)}}"
   register: win_service_change_password_current_user_again
 
 - name: check that the service user has been set to current user and nothing changed
@@ -528,7 +528,7 @@
   win_service:
     name: '{{ test_win_service_name }}'
     username: '{{ ansible_user }}'
-    password: '{{ ansible_password }}'
+    password: '{{ ansible_password | default(ansible_test_connection_password) }}'
     update_password: always
   register: update_password_always
 

--- a/tests/utils/shippable/windows.sh
+++ b/tests/utils/shippable/windows.sh
@@ -6,9 +6,11 @@ declare -a args
 IFS='/:' read -ra args <<< "$1"
 
 version="${args[1]}"
+connection="${args[2]}"
+connection_setting="${args[3]}"
 
-if [ "${#args[0]}" -gt 2 ]; then
-    target="shippable/windows/group${args[2]}/"
+if [ "${#args[0]}" -gt 4 ]; then
+    target="shippable/windows/group${args[4]}/"
 else
     target="shippable/windows/"
 fi
@@ -18,4 +20,7 @@ provider="${P:-default}"
 
 # shellcheck disable=SC2086
 ansible-test windows-integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
-    --windows "${version}" --docker default --remote-terminate always --remote-stage "${stage}" --remote-provider "${provider}"
+    --controller "docker:default" \
+    --target "remote:windows/${version},connection=${connection}+${connection_setting},provider=${provider}" \
+    --remote-terminate always --remote-stage "${stage}"
+


### PR DESCRIPTION
##### SUMMARY
Expands the testing matrix of the Windows connection plugins used in CI to cover all the supported connections of Windows.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
testing