### PR TITLE
Update win_command and win_shell add `output_encoding_override` example

### DIFF
--- a/plugins/modules/win_command.py
+++ b/plugins/modules/win_command.py
@@ -117,8 +117,8 @@ EXAMPLES = r'''
       - argument 1
       - -force
 
-- name: Run a batch script with big5 encoding (fixing garbled text issue)
-  ansible.windows.win_command: C:\somescript.bat
+- name: Run an executable that outputs text with big5 encoding
+  ansible.windows.win_command: C:\someprog.exe
   args:
     output_encoding_override: big5
 '''

--- a/plugins/modules/win_command.py
+++ b/plugins/modules/win_command.py
@@ -116,6 +116,11 @@ EXAMPLES = r'''
       - C:\Program Files\My Application\run.exe
       - argument 1
       - -force
+
+- name: Run a batch script with big5 encoding (fixing garbled text issue)
+  ansible.windows.win_command: C:\somescript.bat
+  args:
+    output_encoding_override: big5
 '''
 
 RETURN = r'''

--- a/plugins/modules/win_shell.py
+++ b/plugins/modules/win_shell.py
@@ -115,6 +115,11 @@ EXAMPLES = r'''
   ansible.windows.win_shell: C:\somescript.ps1
   args:
     no_profile: true
+
+- name: Run a PowerShell script with big5 encoding (fixing garbled text issue)
+  ansible.windows.win_shell: C:\somescript.ps1
+  args:
+    output_encoding_override: big5
 '''
 
 RETURN = r'''

--- a/plugins/modules/win_shell.py
+++ b/plugins/modules/win_shell.py
@@ -116,7 +116,7 @@ EXAMPLES = r'''
   args:
     no_profile: true
 
-- name: Run a PowerShell script with big5 encoding (fixing garbled text issue)
+- name: Run a PowerShell script that outputs text with big5 encoding
   ansible.windows.win_shell: C:\somescript.ps1
   args:
     output_encoding_override: big5


### PR DESCRIPTION
##### SUMMARY

Update `win_command.py` and `win_shell.py` add `output_encoding_override` example
I'm fixing ansible output encoding issue recently. During google search and ai answers which is not accurate.
Adding some example and trying to complete manual.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

- `ansible.windows.win_command` module
- `ansible.windows.win_shell` module

##### ADDITIONAL INFORMATION

Some related issue
https://github.com/ansible/ansible/issues/54896
https://github.com/ansible/ansible/pull/54966