### PR TITLE
Fix win_group_membership integration tests

### DIFF
--- a/tests/integration/targets/win_group_membership/tasks/main.yml
+++ b/tests/integration/targets/win_group_membership/tasks/main.yml
@@ -1,47 +1,46 @@
 - name: Gather facts
-  setup:
+  ansible.builtin.setup:
 
 - name: Remove potentially leftover test group
-  win_group: &wg_absent
+  ansible.windows.win_group: &wg_absent
     name: WinGroupMembershipTest
     state: absent
 
 - name: Remove potentially leftover test user
-  win_user: &wu_absent
+  ansible.windows.win_user: &wu_absent
     name: WinTestUser
     state: absent
 
 - name: Add new test group
-  win_group:
+  ansible.windows.win_group:
     name: WinGroupMembershipTest
     state: present
 
 - name: Add new test user
-  win_user:
+  ansible.windows.win_user:
     name: WinTestUser
     password: "W1nGr0upM3mb3rsh1pT3$tP@$$w0rd"
     state: present
 
 - name: Run tests for win_group_membership
   block:
+    - name: Test in normal mode
+      ansible.builtin.import_tasks: tests.yml
+      vars:
+        win_local_group: WinGroupMembershipTest
+        win_local_user: WinTestUser
+        in_check_mode: false
 
-  - name: Test in normal mode
-    import_tasks: tests.yml
-    vars:
-      win_local_group: WinGroupMembershipTest
-      win_local_user: WinTestUser
-      in_check_mode: no
-
-  - name: Test in check-mode
-    import_tasks: tests.yml
-    vars:
-      win_local_group: WinGroupMembershipTest
-      win_local_user: WinTestUser
-      in_check_mode: yes
-    check_mode: yes
+    - name: Test in check-mode
+      ansible.builtin.import_tasks: tests.yml
+      vars:
+        win_local_group: WinGroupMembershipTest
+        win_local_user: WinTestUser
+        in_check_mode: true
+      check_mode: true
 
 - name: Remove test group
-  win_group: *wg_absent
+  ansible.windows.win_group: *wg_absent
 
 - name: Remove test user
-  win_group: *wu_absent
+  ansible.windows.win_group: *wu_absent

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -4,15 +4,20 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: Look up built-in Administrator account name (-500 user whose domain == computer name)
-  raw: $machine_sid = (Get-CimInstance Win32_UserAccount -Filter "Domain='$env:COMPUTERNAME'")[0].SID -replace '(S-1-5-21-\d+-\d+-\d+)-\d+', '$1'; (Get-CimInstance Win32_UserAccount -Filter "SID='$machine_sid-500'").Name
-  check_mode: no
+  ansible.builtin.raw: |
+    $machine_sid = (Get-CimInstance Win32_UserAccount -Filter "Domain='$env:COMPUTERNAME'")[0].SID `
+      -replace '(S-1-5-21-\d+-\d+-\d+)-\d+', '$1';
+    (Get-CimInstance Win32_UserAccount -Filter "SID='$machine_sid-500'").Name
+  check_mode: false
   register: admin_account_result
+  changed_when: false
 
-- set_fact:
+- name: Set Admin account name
+  ansible.builtin.set_fact:
     admin_account_name: "{{ admin_account_result.stdout_lines[0] }}"
 
 - name: Remove potentially leftover group members
-  win_group_membership:
+  ansible.windows.win_group_membership:
     name: "{{ win_local_group }}"
     members:
       - "{{ admin_account_name }}"
@@ -23,7 +28,7 @@
 
 
 - name: Add user to fake group
-  win_group_membership:
+  ansible.windows.win_group_membership:
     name: FakeGroup
     members:
       - "{{ admin_account_name }}"
@@ -33,7 +38,7 @@
 
 
 - name: Add fake local user
-  win_group_membership:
+  ansible.windows.win_group_membership:
     name: "{{ win_local_group }}"
     members:
       - FakeUser
@@ -43,7 +48,7 @@
 
 
 - name: Add users to group
-  win_group_membership: &wgm_present
+  ansible.windows.win_group_membership: &wgm_present
     name: "{{ win_local_group }}"
     members:
       - "{{ admin_account_name }}"
@@ -53,44 +58,44 @@
   register: add_users_to_group
 
 - name: Test add_users_to_group (normal mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - add_users_to_group.changed == true
-    - add_users_to_group.added == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
-    - add_users_to_group.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+      - add_users_to_group.changed == true
+      - add_users_to_group.added == [ansible_hostname + "\\" + admin_account_name, ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM"]
+      - add_users_to_group.members == [ansible_hostname + "\\" + admin_account_name, ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM"]
   when: not in_check_mode
 
 - name: Test add_users_to_group (check-mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - add_users_to_group.changed == true
-    - add_users_to_group.added == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
-    - add_users_to_group.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+      - add_users_to_group.changed == true
+      - add_users_to_group.added == [ansible_hostname + "\\" + admin_account_name, ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM"]
+      - add_users_to_group.members == [ansible_hostname + "\\" + admin_account_name, ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM"]
   when: in_check_mode
 
 
 - name: Add users to group (again)
-  win_group_membership: *wgm_present
+  ansible.windows.win_group_membership: *wgm_present
   register: add_users_to_group_again
 
 - name: Test add_users_to_group_again (normal mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - add_users_to_group_again.changed == false
-    - add_users_to_group_again.added == []
-    - add_users_to_group_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+      - add_users_to_group_again.changed == false
+      - add_users_to_group_again.added == []
+      - add_users_to_group_again.members == [ansible_hostname + "\\" + admin_account_name, ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM"]
   when: not in_check_mode
 
 - name: Test add_users_to_group_again (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - add_users_to_group_again.changed == true
-    - add_users_to_group_again.added == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
-    - add_users_to_group_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+      - add_users_to_group_again.changed == true
+      - add_users_to_group.added == [ansible_hostname + "\\" + admin_account_name, ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM"]
+      - add_users_to_group_again.members == [ansible_hostname + "\\" + admin_account_name, ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM"]
   when: in_check_mode
 
 - name: Add different syntax users to group (again)
-  win_group_membership:
+  ansible.windows.win_group_membership:
     <<: *wgm_present
     members:
       - '{{ ansible_hostname }}\{{ admin_account_name }}'
@@ -98,104 +103,107 @@
   register: add_different_syntax_users_to_group_again
 
 - name: Test add_different_syntax_users_to_group_again (normal mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - add_different_syntax_users_to_group_again.changed == false
-    - add_different_syntax_users_to_group_again.added == []
-    - add_different_syntax_users_to_group_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+      - add_different_syntax_users_to_group_again.changed == false
+      - add_different_syntax_users_to_group_again.added == []
+      - add_different_syntax_users_to_group_again.members == [ansible_hostname + "\\" + admin_account_name,
+        ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM"]
   when: not in_check_mode
 
 - name: Test add_different_syntax_users_to_group_again (check-mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - add_different_syntax_users_to_group_again.changed == true
-    - add_different_syntax_users_to_group_again.added == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}"]
-    - add_different_syntax_users_to_group_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}"]
+      - add_different_syntax_users_to_group_again.changed == true
+      - add_different_syntax_users_to_group_again.added == [ansible_hostname + "\\" + admin_account_name, ansible_hostname + "\\" + win_local_user]
+      - add_different_syntax_users_to_group_again.members == [ansible_hostname + "\\" + admin_account_name, ansible_hostname + "\\" + win_local_user]
   when: in_check_mode
 
 
 - name: Add another user to group
-  win_group_membership: &wgma_present
+  ansible.windows.win_group_membership: &wgma_present
     <<: *wgm_present
     members:
       - NT AUTHORITY\NETWORK SERVICE
   register: add_another_user_to_group
 
 - name: Test add_another_user_to_group (normal mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - add_another_user_to_group.changed == true
-    - add_another_user_to_group.added == ["NT AUTHORITY\\NETWORK SERVICE"]
-    - add_another_user_to_group.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM", "NT AUTHORITY\\NETWORK SERVICE"]
+      - add_another_user_to_group.changed == true
+      - add_another_user_to_group.added == ["NT AUTHORITY\\NETWORK SERVICE"]
+      - add_another_user_to_group.members == [ansible_hostname + "\\" + admin_account_name,
+        ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM", "NT AUTHORITY\\NETWORK SERVICE"]
   when: not in_check_mode
 
 - name: Test add_another_user_to_group (check-mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - add_another_user_to_group.changed == true
-    - add_another_user_to_group.added == ["NT AUTHORITY\\NETWORK SERVICE"]
-    - add_another_user_to_group.members == ["NT AUTHORITY\\NETWORK SERVICE"]
+      - add_another_user_to_group.changed == true
+      - add_another_user_to_group.added == ["NT AUTHORITY\\NETWORK SERVICE"]
+      - add_another_user_to_group.members == ["NT AUTHORITY\\NETWORK SERVICE"]
   when: in_check_mode
 
 
 - name: Add another user to group (again)
-  win_group_membership: *wgma_present
+  ansible.windows.win_group_membership: *wgma_present
   register: add_another_user_to_group_again
 
 - name: Test add_another_user_to_group_1_again (normal mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - add_another_user_to_group_again.changed == false
-    - add_another_user_to_group_again.added == []
-    - add_another_user_to_group_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM", "NT AUTHORITY\\NETWORK SERVICE"]
+      - add_another_user_to_group_again.changed == false
+      - add_another_user_to_group_again.added == []
+      - add_another_user_to_group_again.members == [ansible_hostname + "\\" + admin_account_name,
+        ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM", "NT AUTHORITY\\NETWORK SERVICE"]
   when: not in_check_mode
-    
+
 - name: Test add_another_user_to_group_1_again (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - add_another_user_to_group_again.changed == true
-    - add_another_user_to_group_again.added == ["NT AUTHORITY\\NETWORK SERVICE"]
-    - add_another_user_to_group_again.members == ["NT AUTHORITY\\NETWORK SERVICE"]
+      - add_another_user_to_group_again.changed == true
+      - add_another_user_to_group_again.added == ["NT AUTHORITY\\NETWORK SERVICE"]
+      - add_another_user_to_group_again.members == ["NT AUTHORITY\\NETWORK SERVICE"]
   when: in_check_mode
 
 - name: Remove users from group
-  win_group_membership: &wgm_absent
+  ansible.windows.win_group_membership: &wgm_absent
     <<: *wgm_present
     state: absent
   register: remove_users_from_group
 
 - name: Test remove_users_from_group (normal mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - remove_users_from_group.changed == true
-    - remove_users_from_group.removed == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
-    - remove_users_from_group.members == ["NT AUTHORITY\\NETWORK SERVICE"]
+      - remove_users_from_group.changed == true
+      - remove_users_from_group.removed == [ansible_hostname + "\\" + admin_account_name, ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM"]
+      - remove_users_from_group.members == ["NT AUTHORITY\\NETWORK SERVICE"]
   when: not in_check_mode
 
 - name: Test remove_users_from_group (check-mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - remove_users_from_group.changed == false
-    - remove_users_from_group.removed == []
-    - remove_users_from_group.members == []
+      - remove_users_from_group.changed == false
+      - remove_users_from_group.removed == []
+      - remove_users_from_group.members == []
   when: in_check_mode
 
 
 - name: Remove users from group (again)
-  win_group_membership: *wgm_absent
+  ansible.windows.win_group_membership: *wgm_absent
   register: remove_users_from_group_again
 
 - name: Test remove_users_from_group_again (normal mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - remove_users_from_group_again.changed == false
-    - remove_users_from_group_again.removed == []
-    - remove_users_from_group_again.members == ["NT AUTHORITY\\NETWORK SERVICE"]
+      - remove_users_from_group_again.changed == false
+      - remove_users_from_group_again.removed == []
+      - remove_users_from_group_again.members == ["NT AUTHORITY\\NETWORK SERVICE"]
   when: not in_check_mode
 
 
 - name: Remove different syntax users from group (again)
-  win_group_membership:
+  ansible.windows.win_group_membership:
     <<: *wgm_absent
     members:
       - '{{ ansible_hostname }}\{{ admin_account_name }}'
@@ -203,62 +211,62 @@
   register: remove_different_syntax_users_from_group_again
 
 - name: Test remove_different_syntax_users_from_group_again (normal mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - remove_different_syntax_users_from_group_again.changed == false
-    - remove_different_syntax_users_from_group_again.removed == []
-    - remove_different_syntax_users_from_group_again.members == ["NT AUTHORITY\\NETWORK SERVICE"]
+      - remove_different_syntax_users_from_group_again.changed == false
+      - remove_different_syntax_users_from_group_again.removed == []
+      - remove_different_syntax_users_from_group_again.members == ["NT AUTHORITY\\NETWORK SERVICE"]
   when: not in_check_mode
 
 - name: Test remove_different_syntax_users_to_group_again (check-mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - remove_different_syntax_users_from_group_again.changed == false
-    - remove_different_syntax_users_from_group_again.removed == []
-    - remove_different_syntax_users_from_group_again.members == []
+      - remove_different_syntax_users_from_group_again.changed == false
+      - remove_different_syntax_users_from_group_again.removed == []
+      - remove_different_syntax_users_from_group_again.members == []
   when: in_check_mode
 
 
 - name: Remove another user from group
-  win_group_membership: &wgma_absent
+  ansible.windows.win_group_membership: &wgma_absent
     <<: *wgm_absent
     members:
       - NT AUTHORITY\NETWORK SERVICE
   register: remove_another_user_from_group
 
 - name: Test remove_another_user_from_group (normal mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - remove_another_user_from_group.changed == true
-    - remove_another_user_from_group.removed == ["NT AUTHORITY\\NETWORK SERVICE"]
-    - remove_another_user_from_group.members == []
+      - remove_another_user_from_group.changed == true
+      - remove_another_user_from_group.removed == ["NT AUTHORITY\\NETWORK SERVICE"]
+      - remove_another_user_from_group.members == []
   when: not in_check_mode
 
 - name: Test remove_another_user_from_group (check-mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - remove_another_user_from_group.changed == false
-    - remove_another_user_from_group.removed == []
-    - remove_another_user_from_group.members == []
+      - remove_another_user_from_group.changed == false
+      - remove_another_user_from_group.removed == []
+      - remove_another_user_from_group.members == []
   when: in_check_mode
 
 
 - name: Remove another user from group (again)
-  win_group_membership: *wgma_absent
+  ansible.windows.win_group_membership: *wgma_absent
   register: remove_another_user_from_group_again
 
 - name: Test remove_another_user_from_group_again (normal mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - remove_another_user_from_group_again.changed == false
-    - remove_another_user_from_group_again.removed == []
-    - remove_another_user_from_group_again.members == []
+      - remove_another_user_from_group_again.changed == false
+      - remove_another_user_from_group_again.removed == []
+      - remove_another_user_from_group_again.members == []
   when: not in_check_mode
 
 
 # Explicitly disable check_mode when seting up users for pure testing
 - name: Setup users for pure testing
-  win_group_membership:
+  ansible.windows.win_group_membership:
     <<: *wgm_present
     members:
       - "{{ admin_account_name }}"
@@ -266,54 +274,54 @@
   check_mode: false
 
 - name: Define users as pure
-  win_group_membership: &wgm_pure
+  ansible.windows.win_group_membership: &wgm_pure
     <<: *wgm_present
     state: pure
   register: define_users_as_pure
 
 - name: Test define_users_as_pure (normal mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - define_users_as_pure.changed == true
-    - define_users_as_pure.added == ["{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
-    - define_users_as_pure.removed == ["NT AUTHORITY\\NETWORK SERVICE"]
-    - define_users_as_pure.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+      - define_users_as_pure.changed == true
+      - define_users_as_pure.added == [ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM"]
+      - define_users_as_pure.removed == ["NT AUTHORITY\\NETWORK SERVICE"]
+      - define_users_as_pure.members == [ansible_hostname + "\\" + admin_account_name, ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM"]
   when: not in_check_mode
 
 - name: Test define_users_as_pure (check-mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - define_users_as_pure.changed == true
-    - define_users_as_pure.added == ["{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
-    - define_users_as_pure.removed == ["NT AUTHORITY\\NETWORK SERVICE"]
-    - define_users_as_pure.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+      - define_users_as_pure.changed == true
+      - define_users_as_pure.added == [ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM"]
+      - define_users_as_pure.removed == ["NT AUTHORITY\\NETWORK SERVICE"]
+      - define_users_as_pure.members == [ansible_hostname + "\\" + admin_account_name, ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM"]
   when: in_check_mode
 
 
 - name: Define users as pure (again)
-  win_group_membership: *wgm_pure
+  ansible.windows.win_group_membership: *wgm_pure
   register: define_users_as_pure_again
 
 - name: Test define_users_as_pure_again (normal mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - define_users_as_pure_again.changed == false
-    - define_users_as_pure_again.added == []
-    - define_users_as_pure_again.removed == []
-    - define_users_as_pure_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+      - define_users_as_pure_again.changed == false
+      - define_users_as_pure_again.added == []
+      - define_users_as_pure_again.removed == []
+      - define_users_as_pure_again.members == [ansible_hostname + "\\" + admin_account_name, ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM"]
   when: not in_check_mode
 
 - name: Test define_users_as_pure_again (check mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - define_users_as_pure_again.changed == true
-    - define_users_as_pure_again.added == ["{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
-    - define_users_as_pure_again.removed == ["NT AUTHORITY\\NETWORK SERVICE"]
-    - define_users_as_pure_again.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}", "NT AUTHORITY\\SYSTEM"]
+      - define_users_as_pure_again.changed == true
+      - define_users_as_pure_again.added == [ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM"]
+      - define_users_as_pure_again.removed == ["NT AUTHORITY\\NETWORK SERVICE"]
+      - define_users_as_pure_again.members == [ansible_hostname + "\\" + admin_account_name, ansible_hostname + "\\" + win_local_user, "NT AUTHORITY\\SYSTEM"]
   when: in_check_mode
 
 - name: Define different syntax users as pure
-  win_group_membership:
+  ansible.windows.win_group_membership:
     <<: *wgm_pure
     members:
       - '{{ ansible_hostname }}\{{ admin_account_name }}'
@@ -321,23 +329,23 @@
   register: define_different_syntax_users_as_pure
 
 - name: Test define_different_syntax_users_as_pure (normal mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - define_different_syntax_users_as_pure.changed == true
-    - define_different_syntax_users_as_pure.added == []
-    - define_different_syntax_users_as_pure.removed == ["NT AUTHORITY\\SYSTEM"]
-    - define_different_syntax_users_as_pure.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}"]
+      - define_different_syntax_users_as_pure.changed == true
+      - define_different_syntax_users_as_pure.added == []
+      - define_different_syntax_users_as_pure.removed == ["NT AUTHORITY\\SYSTEM"]
+      - define_different_syntax_users_as_pure.members == [ansible_hostname + "\\" + admin_account_name, ansible_hostname + "\\" + win_local_user]
   when: not in_check_mode
 
 - name: Test define_different_syntax_users_as_pure (check-mode)
-  assert:
+  ansible.builtin.assert:
     that:
-    - define_different_syntax_users_as_pure.changed == true
-    - define_different_syntax_users_as_pure.added == ["{{ ansible_hostname }}\\{{ win_local_user }}"]
-    - define_different_syntax_users_as_pure.removed == ["NT AUTHORITY\\NETWORK SERVICE"]
-    - define_different_syntax_users_as_pure.members == ["{{ ansible_hostname }}\\{{ admin_account_name }}", "{{ ansible_hostname }}\\{{ win_local_user }}"]
+      - define_different_syntax_users_as_pure.changed == true
+      - define_different_syntax_users_as_pure.added == [ansible_hostname + "\\" + win_local_user]
+      - define_different_syntax_users_as_pure.removed == ["NT AUTHORITY\\NETWORK SERVICE"]
+      - define_different_syntax_users_as_pure.members == [ansible_hostname + "\\" + admin_account_name, ansible_hostname + "\\" + win_local_user]
   when: in_check_mode
 
 
 - name: Teardown remaining pure users
-  win_group_membership: *wgm_absent
+  ansible.windows.win_group_membership: *wgm_absent


### PR DESCRIPTION
Integration test fix and adapt files to pass ansible-lint warning and errors

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
 - Fixed an issue in which integration test was failing on conditional check and it can’t be evaluated.
 - Fixed errors and warning that ansible-lint was showing.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Before My change the following error occured during the integration test run for win_group_membership integration test:
fatal: [windows_server]: FAILED! => {
    "msg": "The conditional check 'add_another_user_to_group_again.members == [\"{{ ansible_hostname }}\\\\{{ admin_account_name }}\", \"{{ ansible_hostname }}\\\\{{ win_local_user }}\", \"NT AUTHORITY\\\\SYSTEM\", \"NT AUTHORITY\\\\NETWORK SERVICE\"]' failed. The error was: Conditional is marked as unsafe, and cannot be evaluated."
}
```
