### PR TITLE
Fix win_user_right ansible module integration test assertions

### DIFF
--- a/tests/integration/targets/win_user_right/tasks/main.yml
+++ b/tests/integration/targets/win_user_right/tasks/main.yml
@@ -1,25 +1,26 @@
 ---
-- name: get current entries for right
+- name: Get current entries for right
   test_get_right:
-    name: '{{test_win_user_right_name}}'
+    name: '{{ test_win_user_right_name }}'
   register: actual_users
 
-- name: get facts
-  setup:
+- name: Get facts
+  ansible.builtin.setup:
 
-- block:
-  - name: ensure right is empty before test
-    win_user_right:
-      name: '{{test_win_user_right_name}}'
-      users: []
-      action: set
+- name: Ensure rights
+  block:
+    - name: Ensure right is empty before test
+      ansible.windows.win_user_right:
+        name: '{{ test_win_user_right_name }}'
+        users: []
+        action: set
 
-  - name: run tests
-    include_tasks: tests.yml
+    - name: Run tests
+      ansible.builtin.include_tasks: tests.yml
 
   always:
-  - name: reset entries for test right
-    win_user_right:
-      name: '{{test_win_user_right_name}}'
-      users: '{{actual_users.users}}'
-      action: set
+    - name: Reset entries for test right
+      ansible.windows.win_user_right:
+        name: '{{ test_win_user_right_name }}'
+        users: '{{ actual_users.users }}'
+        action: set

--- a/tests/integration/targets/win_user_right/tasks/tests.yml
+++ b/tests/integration/targets/win_user_right/tasks/tests.yml
@@ -1,429 +1,434 @@
 ---
 - name: Look up built-in Administrator account name (-500 user whose domain == computer name)
-  raw: $machine_sid = (Get-CimInstance Win32_UserAccount -Filter "Domain='$env:COMPUTERNAME'")[0].SID -replace '(S-1-5-21-\d+-\d+-\d+)-\d+', '$1'; (Get-CimInstance Win32_UserAccount -Filter "SID='$machine_sid-500'").Name
-  check_mode: no
+  ansible.builtin.raw: |
+    $machine_sid = (Get-CimInstance Win32_UserAccount -Filter "Domain='$env:COMPUTERNAME'")[0].SID -replace '(S-1-5-21-\d+-\d+-\d+)-\d+', '$1';
+    (Get-CimInstance Win32_UserAccount -Filter "SID='$machine_sid-500'").Name
+  check_mode: false
+  changed_when: false
   register: admin_account_result
 
-- set_fact:
+- name: Get admin account name
+  ansible.builtin.set_fact:
     admin_account_name: "{{ admin_account_result.stdout_lines[0] }}"
 
-- name: fail to set invalid right
-  win_user_right:
+- name: Fail to set invalid right
+  ansible.windows.win_user_right:
     name: FailRight
     users: '{{ admin_account_name }}'
   register: fail_invalid_right
   failed_when: fail_invalid_right.msg != 'the specified right FailRight is not a valid right'
 
-- name: fail with invalid username
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
+- name: Fail with invalid username
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
     users: FakeUser
   register: fail_invalid_user
   failed_when: fail_invalid_user.msg != "Failed to translate the account 'FakeUser' to a SID"
 
-- name: remove from empty right check
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
+- name: Remove from empty right check
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
     users: ['{{ admin_account_name }}', 'Administrators']
     action: remove
   register: remove_empty_right_check
-  check_mode: yes
+  check_mode: true
 
-- name: assert remove from empty right check
-  assert:
+- name: Assert remove from empty right check
+  ansible.builtin.assert:
     that:
-    - remove_empty_right_check is not changed
-    - remove_empty_right_check.added == []
-    - remove_empty_right_check.removed == []
+      - remove_empty_right_check is not changed
+      - remove_empty_right_check.added == []
+      - remove_empty_right_check.removed == []
 
-- name: remove from empty right
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
+- name: Remove from empty right
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
     users: ['{{ admin_account_name }}', 'Administrators']
     action: remove
   register: remove_empty_right
-  check_mode: yes
+  check_mode: true
 
-- name: assert remove from empty right
-  assert:
+- name: Assert remove from empty right
+  ansible.builtin.assert:
     that:
-    - remove_empty_right is not changed
-    - remove_empty_right.added == []
-    - remove_empty_right.removed == []
+      - remove_empty_right is not changed
+      - remove_empty_right.added == []
+      - remove_empty_right.removed == []
 
-- name: set administrator check
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
+- name: Set administrator check
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
     users: '{{ admin_account_name }}'
     action: set
   register: set_administrator_check
-  check_mode: yes
+  check_mode: true
 
-- name: get actual set administrator check
+- name: Get actual set administrator check
   test_get_right:
-    name: '{{test_win_user_right_name}}'
+    name: '{{ test_win_user_right_name }}'
   register: set_administrator_actual_check
 
-- name: assert set administrator check
-  assert:
+- name: Assert set administrator check
+  ansible.builtin.assert:
     that:
-    - set_administrator_check is changed
-    - set_administrator_check.added|count == 1
-    - set_administrator_check.added[0]|upper == '{{ansible_hostname|upper}}\{{ admin_account_name|upper }}'
-    - set_administrator_check.removed == []
-    - set_administrator_actual_check.users == []
+      - set_administrator_check is changed
+      - set_administrator_check.added|count == 1
+      - set_administrator_check.added[0]|upper == ansible_hostname|upper + "\\" + admin_account_name|upper
+      - set_administrator_check.removed == []
+      - set_administrator_actual_check.users == []
 
-- name: set administrator
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
+- name: Set administrator
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
     users: '{{ admin_account_name }}'
     action: set
   register: set_administrator
 
-- name: get actual set administrator
+- name: Get actual set administrator
   test_get_right:
-    name: '{{test_win_user_right_name}}'
+    name: '{{ test_win_user_right_name }}'
   register: set_administrator_actual
 
-- name: assert set administrator check
-  assert:
+- name: Assert set administrator check
+  ansible.builtin.assert:
     that:
-    - set_administrator is changed
-    - set_administrator.added|count == 1
-    - set_administrator.added[0]|upper == '{{ansible_hostname|upper}}\{{ admin_account_name|upper }}'
-    - set_administrator.removed == []
-    - set_administrator_actual.users == ['{{ admin_account_name }}']
+      - set_administrator is changed
+      - set_administrator.added|count == 1
+      - set_administrator.added[0]|upper == ansible_hostname|upper + "\\" + admin_account_name|upper
+      - set_administrator.removed == []
+      - set_administrator_actual.users == [admin_account_name]
 
-- name: set administrator again
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
+- name: Set administrator again
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
     users: '{{ admin_account_name }}'
     action: set
   register: set_administrator_again
 
-- name: assert set administrator check
-  assert:
+- name: Assert set administrator check
+  ansible.builtin.assert:
     that:
-    - set_administrator_again is not changed
-    - set_administrator_again.added == []
-    - set_administrator_again.removed == []
+      - set_administrator_again is not changed
+      - set_administrator_again.added == []
+      - set_administrator_again.removed == []
 
-- name: remove from right check
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
-    users: ['{{ admin_account_name }}', 'Guests', '{{ansible_hostname}}\Users', '.\Backup Operators']
+- name: Remove from right check
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
+    users: ['{{ admin_account_name }}', 'Guests', '{{ ansible_hostname }}\Users', '.\Backup Operators']
     action: remove
   register: remove_right_check
-  check_mode: yes
+  check_mode: true
 
-- name: get actual remove from right check
+- name: Get actual remove from right check
   test_get_right:
-    name: '{{test_win_user_right_name}}'
+    name: '{{ test_win_user_right_name }}'
   register: remove_right_actual_check
 
-- name: assert remove from right check
-  assert:
+- name: Assert remove from right check
+  ansible.builtin.assert:
     that:
-    - remove_right_check is changed
-    - remove_right_check.removed|count == 1
-    - remove_right_check.removed[0]|upper == '{{ansible_hostname|upper}}\{{ admin_account_name|upper }}'
-    - remove_right_check.added == []
-    - remove_right_actual_check.users == ['{{ admin_account_name }}']
+      - remove_right_check is changed
+      - remove_right_check.removed|count == 1
+      - remove_right_check.removed[0]|upper == ansible_hostname|upper + "\\" + admin_account_name|upper
+      - remove_right_check.added == []
+      - remove_right_actual_check.users == [admin_account_name]
 
-- name: remove from right
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
-    users: ['{{ admin_account_name }}', 'Guests', '{{ansible_hostname}}\Users', '.\Backup Operators']
+- name: Remove from right
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
+    users: ['{{ admin_account_name }}', 'Guests', '{{ ansible_hostname }}\Users', '.\Backup Operators']
     action: remove
   register: remove_right
 
-- name: get actual remove from right
+- name: Get actual remove from right
   test_get_right:
-    name: '{{test_win_user_right_name}}'
+    name: '{{ test_win_user_right_name }}'
   register: remove_right_actual
 
-- name: assert remove from right
-  assert:
+- name: Assert remove from right
+  ansible.builtin.assert:
     that:
-    - remove_right is changed
-    - remove_right.removed|count == 1
-    - remove_right.removed[0]|upper == '{{ansible_hostname|upper}}\{{ admin_account_name|upper }}'
-    - remove_right.added == []
-    - remove_right_actual.users == []
+      - remove_right is changed
+      - remove_right.removed|count == 1
+      - remove_right.removed[0]|upper == ansible_hostname|upper + "\\" + admin_account_name|upper
+      - remove_right.added == []
+      - remove_right_actual.users == []
 
-- name: remove from right again
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
-    users: ['{{ admin_account_name }}', 'Guests', '{{ansible_hostname}}\Users', '.\Backup Operators']
+- name: Remove from right again
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
+    users: ['{{ admin_account_name }}', 'Guests', '{{ ansible_hostname }}\Users', '.\Backup Operators']
     action: remove
   register: remove_right_again
 
-- name: assert remove from right
-  assert:
+- name: Assert remove from right
+  ansible.builtin.assert:
     that:
-    - remove_right_again is not changed
-    - remove_right_again.removed == []
-    - remove_right_again.added == []
+      - remove_right_again is not changed
+      - remove_right_again.removed == []
+      - remove_right_again.added == []
 
-- name: add to empty right check
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
+- name: Add to empty right check
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
     users: ['{{ admin_account_name }}', 'Administrators']
     action: add
   register: add_right_on_empty_check
-  check_mode: yes
+  check_mode: true
 
-- name: get actual add to empty right check
+- name: Get actual add to empty right check
   test_get_right:
-    name: '{{test_win_user_right_name}}'
+    name: '{{ test_win_user_right_name }}'
   register: add_right_on_empty_actual_check
 
-- name: assert add to empty right check
-  assert:
+- name: Assert add to empty right check
+  ansible.builtin.assert:
     that:
-    - add_right_on_empty_check is changed
-    - add_right_on_empty_check.removed == []
-    - add_right_on_empty_check.added|count == 2
-    - add_right_on_empty_check.added[0]|upper == '{{ansible_hostname|upper}}\{{ admin_account_name|upper }}'
-    - add_right_on_empty_check.added[1] == 'BUILTIN\Administrators'
-    - add_right_on_empty_actual_check.users == []
+      - add_right_on_empty_check is changed
+      - add_right_on_empty_check.removed == []
+      - add_right_on_empty_check.added|count == 2
+      - add_right_on_empty_check.added[0]|upper == ansible_hostname|upper + "\\" + admin_account_name|upper
+      - add_right_on_empty_check.added[1] == 'BUILTIN\Administrators'
+      - add_right_on_empty_actual_check.users == []
 
-- name: add to empty right
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
+- name: Add to empty right
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
     users: ['{{ admin_account_name }}', 'Administrators']
     action: add
   register: add_right_on_empty
 
-- name: get actual add to empty right
+- name: Get actual add to empty right
   test_get_right:
-    name: '{{test_win_user_right_name}}'
+    name: '{{ test_win_user_right_name }}'
   register: add_right_on_empty_actual
 
-- name: assert add to empty right
-  assert:
+- name: Assert add to empty right
+  ansible.builtin.assert:
     that:
-    - add_right_on_empty is changed
-    - add_right_on_empty.removed == []
-    - add_right_on_empty.added|count == 2
-    - add_right_on_empty.added[0]|upper == '{{ansible_hostname|upper}}\{{ admin_account_name|upper }}'
-    - add_right_on_empty.added[1] == 'BUILTIN\Administrators'
-    - add_right_on_empty_actual.users == ["{{ admin_account_name }}", "BUILTIN\\Administrators"]
+      - add_right_on_empty is changed
+      - add_right_on_empty.removed == []
+      - add_right_on_empty.added|count == 2
+      - add_right_on_empty.added[0]|upper == ansible_hostname|upper + "\\" + admin_account_name|upper
+      - add_right_on_empty.added[1] == 'BUILTIN\Administrators'
+      - add_right_on_empty_actual.users == [admin_account_name, "BUILTIN\\Administrators"]
 
-- name: add to empty right again
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
+- name: Add to empty right again
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
     users: ['{{ admin_account_name }}', 'Administrators']
     action: add
   register: add_right_on_empty_again
 
-- name: assert add to empty right
-  assert:
+- name: Assert add to empty right
+  ansible.builtin.assert:
     that:
-    - add_right_on_empty_again is not changed
-    - add_right_on_empty_again.removed == []
-    - add_right_on_empty_again.added == []
+      - add_right_on_empty_again is not changed
+      - add_right_on_empty_again.removed == []
+      - add_right_on_empty_again.added == []
 
-- name: add to existing right check
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
-    users: ['{{ admin_account_name }}', 'Guests', '{{ansible_hostname}}\Users']
+- name: Add to existing right check
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
+    users: ['{{ admin_account_name }}', 'Guests', '{{ ansible_hostname }}\Users']
     action: add
   register: add_right_on_existing_check
-  check_mode: yes
+  check_mode: true
 
-- name: get actual add to existing right check
+- name: Get actual add to existing right check
   test_get_right:
-    name: '{{test_win_user_right_name}}'
+    name: '{{ test_win_user_right_name }}'
   register: add_right_on_existing_actual_check
 
-- name: assert add to existing right check
-  assert:
+- name: Assert add to existing right check
+  ansible.builtin.assert:
     that:
-    - add_right_on_existing_check is changed
-    - add_right_on_existing_check.removed == []
-    - add_right_on_existing_check.added == ["BUILTIN\\Guests", "BUILTIN\\Users"]
-    - add_right_on_existing_actual_check.users == ["{{ admin_account_name }}", "BUILTIN\\Administrators"]
+      - add_right_on_existing_check is changed
+      - add_right_on_existing_check.removed == []
+      - add_right_on_existing_check.added == ["BUILTIN\\Guests", "BUILTIN\\Users"]
+      - add_right_on_existing_actual_check.users == [admin_account_name, "BUILTIN\\Administrators"]
 
-- name: add to existing right
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
-    users: ['{{ admin_account_name }}', 'Guests', '{{ansible_hostname}}\Users']
+- name: Add to existing right
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
+    users: ['{{ admin_account_name }}', 'Guests', '{{ ansible_hostname }}\Users']
     action: add
   register: add_right_on_existing
 
-- name: get actual add to existing right
+- name: Get actual add to existing right
   test_get_right:
-    name: '{{test_win_user_right_name}}'
+    name: '{{ test_win_user_right_name }}'
   register: add_right_on_existing_actual
 
-- name: assert add to existing right
-  assert:
+- name: Assert add to existing right
+  ansible.builtin.assert:
     that:
-    - add_right_on_existing is changed
-    - add_right_on_existing.removed == []
-    - add_right_on_existing.added == ["BUILTIN\\Guests", "BUILTIN\\Users"]
-    - add_right_on_existing_actual.users == ["{{ admin_account_name }}", "BUILTIN\\Administrators", "BUILTIN\\Users", "BUILTIN\\Guests"]
+      - add_right_on_existing is changed
+      - add_right_on_existing.removed == []
+      - add_right_on_existing.added == ["BUILTIN\\Guests", "BUILTIN\\Users"]
+      - add_right_on_existing_actual.users == [admin_account_name, "BUILTIN\\Administrators", "BUILTIN\\Users", "BUILTIN\\Guests"]
 
-- name: add to existing right again
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
-    users: ['{{ admin_account_name }}', 'Guests', '{{ansible_hostname}}\Users']
+- name: Add to existing right again
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
+    users: ['{{ admin_account_name }}', 'Guests', '{{ ansible_hostname }}\Users']
     action: add
   register: add_right_on_existing_again
 
-- name: assert add to existing right
-  assert:
+- name: Assert add to existing right
+  ansible.builtin.assert:
     that:
-    - add_right_on_existing_again is not changed
-    - add_right_on_existing_again.removed == []
-    - add_right_on_existing_again.added == []
+      - add_right_on_existing_again is not changed
+      - add_right_on_existing_again.removed == []
+      - add_right_on_existing_again.added == []
 
-- name: remove from existing check
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
+- name: Remove from existing check
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
     users: ['Guests', '{{ admin_account_name }}']
     action: remove
   register: remove_on_existing_check
-  check_mode: yes
+  check_mode: true
 
-- name: get actual remove from existing check
+- name: Get actual remove from existing check
   test_get_right:
-    name: '{{test_win_user_right_name}}'
+    name: '{{ test_win_user_right_name }}'
   register: remove_on_existing_actual_check
 
-- name: assert remove from existing check
-  assert:
+- name: Assert remove from existing check
+  ansible.builtin.assert:
     that:
-    - remove_on_existing_check is changed
-    - remove_on_existing_check.removed == ["BUILTIN\\Guests", "{{ansible_hostname}}\\{{ admin_account_name }}"]
-    - remove_on_existing_check.added == []
-    - remove_on_existing_actual_check.users == ["{{ admin_account_name }}", "BUILTIN\\Administrators", "BUILTIN\\Users", "BUILTIN\\Guests"]
+      - remove_on_existing_check is changed
+      - remove_on_existing_check.removed == ["BUILTIN\\Guests", ansible_hostname|upper + "\\" + admin_account_name]
+      - remove_on_existing_check.added == []
+      - remove_on_existing_actual_check.users == [admin_account_name, "BUILTIN\\Administrators", "BUILTIN\\Users", "BUILTIN\\Guests"]
 
-- name: remove from existing
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
+- name: Remove from existing
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
     users: ['Guests', '{{ admin_account_name }}']
     action: remove
   register: remove_on_existing
 
-- name: get actual remove from existing
+- name: Get actual remove from existing
   test_get_right:
-    name: '{{test_win_user_right_name}}'
+    name: '{{ test_win_user_right_name }}'
   register: remove_on_existing_actual
 
-- name: assert remove from existing
-  assert:
+- name: Assert remove from existing
+  ansible.builtin.assert:
     that:
-    - remove_on_existing is changed
-    - remove_on_existing.removed == ["BUILTIN\\Guests", "{{ansible_hostname}}\\{{ admin_account_name }}"]
-    - remove_on_existing.added == []
-    - remove_on_existing_actual.users == ["BUILTIN\\Administrators", "BUILTIN\\Users"]
+      - remove_on_existing is changed
+      - remove_on_existing.removed == ["BUILTIN\\Guests", ansible_hostname|upper + "\\" + admin_account_name]
+      - remove_on_existing.added == []
+      - remove_on_existing_actual.users == ["BUILTIN\\Administrators", "BUILTIN\\Users"]
 
-- name: remove from existing again
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
+- name: Remove from existing again
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
     users: ['Guests', '{{ admin_account_name }}']
     action: remove
   register: remove_on_existing_again
 
-- name: assert remove from existing again
-  assert:
+- name: Assert remove from existing again
+  ansible.builtin.assert:
     that:
-    - remove_on_existing_again is not changed
-    - remove_on_existing_again.removed == []
-    - remove_on_existing_again.added == []
+      - remove_on_existing_again is not changed
+      - remove_on_existing_again.removed == []
+      - remove_on_existing_again.added == []
 
-- name: set to existing check
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
+- name: Set to existing check
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
     users: ['Administrators', 'SYSTEM', 'Backup Operators']
     action: set
   register: set_on_existing_check
-  check_mode: yes
+  check_mode: true
 
-- name: get actual set to existing check
+- name: Get actual set to existing check
   test_get_right:
-    name: '{{test_win_user_right_name}}'
+    name: '{{ test_win_user_right_name }}'
   register: set_on_existing_actual_check
 
-- name: assert set to existing check
-  assert:
+- name: Assert set to existing check
+  ansible.builtin.assert:
     that:
-    - set_on_existing_check is changed
-    - set_on_existing_check.removed == ["BUILTIN\\Users"]
-    - set_on_existing_check.added == ["NT AUTHORITY\\SYSTEM", "BUILTIN\\Backup Operators"]
-    - set_on_existing_actual_check.users == ["BUILTIN\\Administrators", "BUILTIN\\Users"]
+      - set_on_existing_check is changed
+      - set_on_existing_check.removed == ["BUILTIN\\Users"]
+      - set_on_existing_check.added == ["NT AUTHORITY\\SYSTEM", "BUILTIN\\Backup Operators"]
+      - set_on_existing_actual_check.users == ["BUILTIN\\Administrators", "BUILTIN\\Users"]
 
-- name: set to existing
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
+- name: Set to existing
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
     users: ['Administrators', 'SYSTEM', 'Backup Operators']
     action: set
   register: set_on_existing
 
-- name: get actual set to existing
+- name: Get actual set to existing
   test_get_right:
-    name: '{{test_win_user_right_name}}'
+    name: '{{ test_win_user_right_name }}'
   register: set_on_existing_actual
 
-- name: assert set to existing
-  assert:
+- name: Assert set to existing
+  ansible.builtin.assert:
     that:
-    - set_on_existing is changed
-    - set_on_existing.removed == ["BUILTIN\\Users"]
-    - set_on_existing.added == ["NT AUTHORITY\\SYSTEM", "BUILTIN\\Backup Operators"]
-    - set_on_existing_actual.users == ["NT AUTHORITY\\SYSTEM", "BUILTIN\\Administrators", "BUILTIN\\Backup Operators"]
+      - set_on_existing is changed
+      - set_on_existing.removed == ["BUILTIN\\Users"]
+      - set_on_existing.added == ["NT AUTHORITY\\SYSTEM", "BUILTIN\\Backup Operators"]
+      - set_on_existing_actual.users == ["NT AUTHORITY\\SYSTEM", "BUILTIN\\Administrators", "BUILTIN\\Backup Operators"]
 
-- name: set to existing again
-  win_user_right:
-    name: '{{test_win_user_right_name}}'
+- name: Set to existing again
+  ansible.windows.win_user_right:
+    name: '{{ test_win_user_right_name }}'
     users: ['Administrators', 'SYSTEM', 'Backup Operators']
     action: set
   register: set_on_existing_again
 
-- name: assert set to existing
-  assert:
+- name: Assert set to existing
+  ansible.builtin.assert:
     that:
-    - set_on_existing_again is not changed
-    - set_on_existing_again.removed == []
-    - set_on_existing_again.added == []
+      - set_on_existing_again is not changed
+      - set_on_existing_again.removed == []
+      - set_on_existing_again.added == []
 
-- name: create test account
-  win_user:
+- name: Create test account
+  ansible.windows.win_user:
     name: test ansible
     password: Password123!
     state: present
     groups:
-    - Users
+      - Users
   register: test_user
 
-- block:
-  - name: add test account to right
-    win_user_right:
-      name: '{{ test_win_user_right_name }}'
-      users:
-      - test ansible
-      action: add
+- name: Add test account to right
+  block:
+    - name: Add test account to right
+      ansible.windows.win_user_right:
+        name: '{{ test_win_user_right_name }}'
+        users:
+          - test ansible
+        action: add
 
   always:
-  - name: remove test account
-    win_user:
-      name: test ansible
-      state: absent
+    - name: Remove test account
+      ansible.windows.win_user:
+        name: test ansible
+        state: absent
 
-- name: test that orphaned accounts can be manipulated without a failure
-  win_user_right:
+- name: Test that orphaned accounts can be manipulated without a failure
+  ansible.windows.win_user_right:
     name: '{{ test_win_user_right_name }}'
     users:
-    - Administrators
-    - SYSTEM
-    - Backup Operators
+      - Administrators
+      - SYSTEM
+      - Backup Operators
   register: remove_orphaned_account
 
-- name: assert orphaned account was removed
-  assert:
+- name: Assert orphaned account was removed
+  ansible.builtin.assert:
     that:
-    - remove_orphaned_account is changed
-    - remove_orphaned_account.added == []
-    - remove_orphaned_account.removed == [ test_user.sid ]
+      - remove_orphaned_account is changed
+      - remove_orphaned_account.added == []
+      - remove_orphaned_account.removed == [ test_user.sid ]


### PR DESCRIPTION
##### SUMMARY
- Fix win_user_right module integration test
- Fix win_user_right module ansible-lint warnings and errors 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_user_right ansible-test windows-integration

##### ADDITIONAL INFORMATION
Fix win_user_right variable extraction in ansible.builtin.assert tasks 
Fix ansible.lint static code test warnings and errors 
```
Fix the following test failures:

fatal: [windows_server]: FAILED! =>
{"msg": "The conditional check 'set_administrator_check.added[0]|upper == '{{ansible_hostname|upper}}\\{{ admin_account_name|upper }}'' failed. 
The error was: Conditional is marked as unsafe, and cannot be evaluated."}
```
