### PR TITLE
Remove ansbile-lint warnings/errors from win_async

### DIFF
--- a/tests/integration/targets/win_async/tasks/main.yml
+++ b/tests/integration/targets/win_async/tasks/main.yml
@@ -1,10 +1,10 @@
-- name: check that a job can deserialize large data
-  win_shell: '"a" * 2097152'
+- name: Check that a job can deserialize large data
+  ansible.windows.win_shell: '"a" * 2097152'
   async: 60
   register: async_large_output
   no_log: true
 
-- name: assert output can deserialize large data
-  assert:
+- name: Assert output can deserialize large data
+  ansible.builtin.assert:
     that:
-    - async_large_output.stdout == ('a' * 2097152) + "\r\n"
+      - async_large_output.stdout == ('a' * 2097152) + "\r\n"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed the errors and warning that came from ansible-lint for win_async integration test
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_async
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
Ref:
Partially fixes #671 