### PR TITLE
Remove ansbile-lint warnings/errors from win_command

### DIFF
--- a/tests/integration/targets/win_command/meta/main.yml
+++ b/tests/integration/targets/win_command/meta/main.yml
@@ -1,2 +1,6 @@
 dependencies:
-- setup_win_printargv
+  - setup_win_printargv
+
+galaxy_info:
+  role_name: win_command
+  namespace: win_command_ns

--- a/tests/integration/targets/win_command/tasks/main.yml
+++ b/tests/integration/targets/win_command/tasks/main.yml
@@ -1,84 +1,84 @@
-- name: execute a command
-  win_command: whoami /groups
+- name: Execute a command
+  ansible.windows.win_command: whoami /groups
   register: cmdout
 
-- name: validate result
-  assert:
+- name: Validate result
+  ansible.builtin.assert:
     that:
-    - cmdout is successful
-    - cmdout is changed
-    - cmdout.cmd == 'whoami /groups'
-    - cmdout.delta is match('^\d:(\d){2}:(\d){2}.(\d){6}$')
-    - cmdout.end is match('^(\d){4}\-(\d){2}\-(\d){2} (\d){2}:(\d){2}:(\d){2}.(\d){6}$')
-    - cmdout.rc == 0
-    - cmdout.start is match('^(\d){4}\-(\d){2}\-(\d){2} (\d){2}:(\d){2}:(\d){2}.(\d){6}$')
-    - cmdout.stderr == ""
-    - cmdout.stdout is search('GROUP INFORMATION')
-    - '"GROUP INFORMATION" in cmdout.stdout_lines'
+      - cmdout is successful
+      - cmdout is changed
+      - cmdout.cmd == 'whoami /groups'
+      - cmdout.delta is match('^\d:(\d){2}:(\d){2}.(\d){6}$')
+      - cmdout.end is match('^(\d){4}\-(\d){2}\-(\d){2} (\d){2}:(\d){2}:(\d){2}.(\d){6}$')
+      - cmdout.rc == 0
+      - cmdout.start is match('^(\d){4}\-(\d){2}\-(\d){2} (\d){2}:(\d){2}:(\d){2}.(\d){6}$')
+      - cmdout.stderr == ""
+      - cmdout.stdout is search('GROUP INFORMATION')
+      - '"GROUP INFORMATION" in cmdout.stdout_lines'
 
-- name: execute something nonexistent
-  win_command: bogus_command1234
+- name: Execute something nonexistent
+  ansible.windows.win_command: bogus_command1234
   register: cmdout
   ignore_errors: true
 
-- name: validate result
-  assert:
+- name: Validate result
+  ansible.builtin.assert:
     that:
-    - cmdout is failed
-    - cmdout is not changed
-    - cmdout.cmd == 'bogus_command1234'
-    - cmdout.rc == 2
-    - '"The system cannot find the file specified" in cmdout.msg'
+      - cmdout is failed
+      - cmdout is not changed
+      - cmdout.cmd == 'bogus_command1234'
+      - cmdout.rc == 2
+      - '"The system cannot find the file specified" in cmdout.msg'
 
-- name: execute something with error output
-  win_command: cmd /c "echo some output & echo some error 1>&2"
+- name: Execute something with error output
+  ansible.windows.win_command: cmd /c "echo some output & echo some error 1>&2"
   register: cmdout
 
-- name: validate result
-  assert:
+- name: Validate result
+  ansible.builtin.assert:
     that:
-    - cmdout is successful
-    - cmdout is changed
-    - cmdout.cmd == 'cmd /c "echo some output & echo some error 1>&2"'
-    - cmdout.delta is match('^\d:(\d){2}:(\d){2}.(\d){6}$')
-    - cmdout.end is match('^(\d){4}\-(\d){2}\-(\d){2} (\d){2}:(\d){2}:(\d){2}.(\d){6}$')
-    - cmdout.rc == 0
-    - cmdout.start is match('^(\d){4}\-(\d){2}\-(\d){2} (\d){2}:(\d){2}:(\d){2}.(\d){6}$')
-    - cmdout.stderr is search('some error')
-    - cmdout.stdout == "some output \r\n"
-    - cmdout.stdout_lines == ["some output "]
+      - cmdout is successful
+      - cmdout is changed
+      - cmdout.cmd == 'cmd /c "echo some output & echo some error 1>&2"'
+      - cmdout.delta is match('^\d:(\d){2}:(\d){2}.(\d){6}$')
+      - cmdout.end is match('^(\d){4}\-(\d){2}\-(\d){2} (\d){2}:(\d){2}:(\d){2}.(\d){6}$')
+      - cmdout.rc == 0
+      - cmdout.start is match('^(\d){4}\-(\d){2}\-(\d){2} (\d){2}:(\d){2}:(\d){2}.(\d){6}$')
+      - cmdout.stderr is search('some error')
+      - cmdout.stdout == "some output \r\n"
+      - cmdout.stdout_lines == ["some output "]
 
-- name: ensure test file is absent
-  win_file:
+- name: Ensure test file is absent
+  ansible.windows.win_file:
     path: c:\testfile.txt
     state: absent
 
-- name: run with creates, should create
-  win_command: cmd /c "echo $null >> c:\testfile.txt"
+- name: Run with creates, should create
+  ansible.windows.win_command: cmd /c "echo $null >> c:\testfile.txt"
   args:
     creates: c:\testfile.txt
   register: cmdout
 
-- name: validate result
-  assert:
+- name: Validate result
+  ansible.builtin.assert:
     that:
-    - cmdout is successful
-    - cmdout is changed
+      - cmdout is successful
+      - cmdout is changed
 
-- name: run again with creates, should skip
-  win_command: cmd /c "echo $null >> c:\testfile.txt"
+- name: Run again with creates, should skip
+  ansible.windows.win_command: cmd /c "echo $null >> c:\testfile.txt"
   args:
     creates: c:\testfile.txt
   register: cmdout
 
-- name: validate result
-  assert:
+- name: Validate result
+  ansible.builtin.assert:
     that:
-    - cmdout is skipped
-    - cmdout.msg is search('exists')
+      - cmdout is skipped
+      - cmdout.msg is search('exists')
 
-- name: get path of pagefile
-  win_shell: |
+- name: Get path of pagefile
+  ansible.windows.win_shell: |
     $pagefile = $null
     $cs = Get-CimInstance -ClassName Win32_ComputerSystem
     if ($cs.AutomaticManagedPagefile) {
@@ -92,115 +92,119 @@
     $pagefile
   register: pagefile_path
 
-- name: test creates with hidden system file, should skip
-  win_command: echo no
+- name: Test creates with hidden system file, should skip
+  ansible.windows.win_command: echo no
   args:
-    creates: '{{pagefile_path.stdout_lines[0]}}'
+    creates: '{{ pagefile_path.stdout_lines[0] }}'
   register: cmdout
   when: pagefile_path.stdout_lines|count != 0
 
-- name: validate result
-  assert:
+- name: Validate result
+  ansible.builtin.assert:
     that:
-    - cmdout is skipped
-    - cmdout.msg is search('exists')
+      - cmdout is skipped
+      - cmdout.msg is search('exists')
   when: pagefile_path.stdout_lines|count != 0
 
-- name: ensure testfile is still present
-  win_stat:
+- name: Ensure testfile is still present
+  ansible.windows.win_stat:
     path: c:\testfile.txt
   register: statout
 
-- name: validate result
-  assert:
+- name: Validate result
+  ansible.builtin.assert:
     that:
-    - statout.stat.exists == true
+      - statout.stat.exists == true
 
-- name: run with removes, should remove
-  win_command: cmd /c "del c:\testfile.txt"
+- name: Run with removes, should remove
+  ansible.windows.win_command: cmd /c "del c:\testfile.txt"
   args:
     removes: c:\testfile.txt
   register: cmdout
 
-- name: validate result
-  assert:
+- name: Validate result
+  ansible.builtin.assert:
     that:
-    - cmdout is successful
-    - cmdout is changed
+      - cmdout is successful
+      - cmdout is changed
 
-- name: run again with removes, should skip
-  win_command: cmd /c "del c:\testfile.txt"
+- name: Run again with removes, should skip
+  ansible.windows.win_command: cmd /c "del c:\testfile.txt"
   args:
     removes: c:\testfile.txt
   register: cmdout
 
-- name: validate result
-  assert:
+- name: Validate result
+  ansible.builtin.assert:
     that:
-    - cmdout is skipped
-    - cmdout.msg is search('does not exist')
+      - cmdout is skipped
+      - cmdout.msg is search('does not exist')
 
-- name: run something with known nonzero exit code
-  win_command: cmd /c "exit 254"
+- name: Run something with known nonzero exit code
+  ansible.windows.win_command: cmd /c "exit 254"
   register: cmdout
   ignore_errors: true
 
-- name: validate result
-  assert:
+- name: Validate result
+  ansible.builtin.assert:
     that:
-    - cmdout is failed
-    - cmdout.failed == True # check the failure key explicitly, since failed does magic with RC
-    - cmdout.rc == 254
+      - cmdout is failed
+      - cmdout.failed == True # check the failure key explicitly, since failed does magic with RC
+      - cmdout.rc == 254
 
-- name: interleave large writes between stdout/stderr (check for buffer consumption deadlock)
-  win_command: powershell /c "$ba = New-Object byte[] 4096; (New-Object System.Random 32).NextBytes($ba); $text = [Convert]::ToBase64String($ba); Write-Output startout; Write-Error starterror; Write-Error $text; Write-Output $text; Write-Error $text; Write-Output $text; Write-Error $text; Write-Output $text; Write-Output doneout Write-Error doneerror"
+- name: Interleave large writes between stdout/stderr (check for buffer consumption deadlock)
+  ansible.windows.win_command: powershell /c "$ba = New-Object byte[] 4096; (New-Object System.Random 32).NextBytes($ba);`
+    $text = [Convert]::ToBase64String($ba); Write-Output startout; Write-Error starterror; Write-Error $text;`
+    Write-Output $text; Write-Error $text; Write-Output $text; Write-Error $text; Write-Output $text; Write-Output doneout Write-Error doneerror"
   register: cmdout
 
-- name: ensure that the entirety of both streams were read
-  assert:
+- name: Ensure that the entirety of both streams were read
+  ansible.builtin.assert:
     that:
-    - cmdout.stdout is search("startout")
-    - cmdout.stdout is search("doneout")
-    - cmdout.stderr is search("starterror")
-    - cmdout.stderr is search("doneerror")
+      - cmdout.stdout is search("startout")
+      - cmdout.stdout is search("doneout")
+      - cmdout.stderr is search("starterror")
+      - cmdout.stderr is search("doneerror")
 
-- name: call argv binary with absolute path
-  win_command: '"{{ win_printargv_path }}" arg1 "arg 2" C:\path\arg "\"quoted arg\""'
+- name: Call argv binary with absolute path
+  ansible.windows.win_command: '"{{ win_printargv_path }}" arg1 "arg 2" C:\path\arg "\"quoted arg\""'
   register: cmdout
 
-- set_fact:
+- name: Convert args to dictionary
+  ansible.builtin.set_fact:
     cmdout_argv: '{{ cmdout.stdout | trim | from_json }}'
 
-- name: assert call to argv binary with absolute path
-  assert:
+- name: Assert call to argv binary with absolute path
+  ansible.builtin.assert:
     that:
-    - cmdout is changed
-    - cmdout.rc == 0
-    - cmdout_argv.args[0] == 'arg1'
-    - cmdout_argv.args[1] == 'arg 2'
-    - cmdout_argv.args[2] == 'C:\\path\\arg'
-    - cmdout_argv.args[3] == '"quoted arg"'
+      - cmdout is changed
+      - cmdout.rc == 0
+      - cmdout_argv.args[0] == 'arg1'
+      - cmdout_argv.args[1] == 'arg 2'
+      - cmdout_argv.args[2] == 'C:\\path\\arg'
+      - cmdout_argv.args[3] == '"quoted arg"'
 
-- name: call argv binary with relative path
-  win_command: '{{ win_printargv_path | win_basename }} C:\path\end\slash\ ADDLOCAL="msi,example" two\\slashes'
+- name: Call argv binary with relative path
+  ansible.windows.win_command: '{{ win_printargv_path | win_basename }} C:\path\end\slash\ ADDLOCAL="msi,example" two\\slashes'
   args:
     chdir: '{{ win_printargv_path | win_dirname }}'
   register: cmdout
 
-- set_fact:
+- name: Convert args to dictionary
+  ansible.builtin.set_fact:
     cmdout_argv: '{{ cmdout.stdout | trim | from_json }}'
 
-- name: assert call to argv binary with relative path
-  assert:
+- name: Assert call to argv binary with relative path
+  ansible.builtin.assert:
     that:
-    - cmdout is changed
-    - cmdout.rc == 0
-    - cmdout_argv.args[0] == 'C:\\path\\end\\slash\\'
-    - cmdout_argv.args[1] == 'ADDLOCAL=msi,example'
-    - cmdout_argv.args[2] == 'two\\\\slashes'
+      - cmdout is changed
+      - cmdout.rc == 0
+      - cmdout_argv.args[0] == 'C:\\path\\end\\slash\\'
+      - cmdout_argv.args[1] == 'ADDLOCAL=msi,example'
+      - cmdout_argv.args[2] == 'two\\\\slashes'
 
-- name: download binary that output shift_jis chars to console
-  win_get_url:
+- name: Download binary that output shift_jis chars to console
+  ansible.windows.win_get_url:
     url: https://ansible-ci-files.s3.amazonaws.com/test/integration/targets/win_command/OutputEncodingOverride.exe
     dest: '{{ remote_tmp_dir }}\OutputEncodingOverride.exe'
   register: download_res
@@ -208,181 +212,184 @@
   retries: 3
   delay: 5
 
-- name: call binary with shift_jis output encoding override
-  win_command: '"{{ remote_tmp_dir }}\OutputEncodingOverride.exe"'
+- name: Call binary with shift_jis output encoding override
+  ansible.windows.win_command: '"{{ remote_tmp_dir }}\OutputEncodingOverride.exe"'
   args:
     output_encoding_override: shift_jis
   register: cmdout
 
-- name: assert call to binary with shift_jis output
-  assert:
+- name: Assert call to binary with shift_jis output
+  ansible.builtin.assert:
     that:
-    - cmdout is changed
-    - cmdout.rc == 0
-    - cmdout.stdout_lines[0] == '日本 - Japan'
+      - cmdout is changed
+      - cmdout.rc == 0
+      - cmdout.stdout_lines[0] == '日本 - Japan'
 
-- name: remove testing folder
-  win_file:
+- name: Remove testing folder
+  ansible.windows.win_file:
     path: C:\ansible testing
     state: absent
 
-- name: run stdin test
-  win_command: powershell.exe -
+- name: Run stdin test
+  ansible.windows.win_command: powershell.exe -
   args:
     stdin: Write-Host "some input"
   register: cmdout
 
-- name: assert run stdin test
-  assert:
+- name: Assert run stdin test
+  ansible.builtin.assert:
     that:
-    - cmdout is changed
-    - cmdout.rc == 0
-    - cmdout.stdout_lines|count == 1
-    - cmdout.stdout_lines[0] == "some input"
-    - cmdout.stderr == ""
+      - cmdout is changed
+      - cmdout.rc == 0
+      - cmdout.stdout_lines|count == 1
+      - cmdout.stdout_lines[0] == "some input"
+      - cmdout.stderr == ""
 
-- name: echo some non ascii characters
-  win_command: cmd.exe /c echo über den Fußgängerübergang gehen
+- name: Echo some non ascii characters
+  ansible.windows.win_command: cmd.exe /c echo über den Fußgängerübergang gehen
   register: nonascii_output
 
-- name: assert echo some non ascii characters
-  assert:
+- name: Assert echo some non ascii characters
+  ansible.builtin.assert:
     that:
-    - nonascii_output is changed
-    - nonascii_output.rc == 0
-    - nonascii_output.stdout_lines|count == 1
-    - nonascii_output.stdout_lines[0] == 'über den Fußgängerübergang gehen'
-    - nonascii_output.stderr == ''
+      - nonascii_output is changed
+      - nonascii_output.rc == 0
+      - nonascii_output.stdout_lines|count == 1
+      - nonascii_output.stdout_lines[0] == 'über den Fußgängerübergang gehen'
+      - nonascii_output.stderr == ''
 
-- name: expect failure without defined cmd
-  win_command:
+- name: Expect failure without defined cmd
+  ansible.windows.win_command:
     chdir: '{{ win_printargv_path | win_dirname }}'
   register: failure_no_cmd
   failed_when:
-  - failure_no_cmd is not failed
-  - 'failure_no_cmd.msg != "one of the following is required: _raw_params, argv, cmd"'
+    - failure_no_cmd is not failed
+    - 'failure_no_cmd.msg != "one of the following is required: _raw_params, argv, cmd"'
 
-- name: expect failure when both cmd and argv are defined
-  win_command:
+- name: Expect failure when both cmd and argv are defined
+  ansible.windows.win_command:
     cmd: my cmd
     argv:
-    - my cmd
+      - my cmd
   register: failure_both_cmd_and_argv
   failed_when:
-  - failure_both_cmd_and_argv is not failed
-  - 'failure_both_cmd_and_argv.msg != "parameters are mutually exclusive: _raw_params, argv, cmd"'
+    - failure_both_cmd_and_argv is not failed
+    - 'failure_both_cmd_and_argv.msg != "parameters are mutually exclusive: _raw_params, argv, cmd"'
 
-- name: call binary with cmd
-  win_command:
+- name: Call binary with cmd
+  ansible.windows.win_command:
     cmd: '"{{ win_printargv_path }}" arg1 "arg 2" C:\path\arg "\"quoted arg\""'
   register: cmdout
 
-- set_fact:
+- name: Convert args to dictionary
+  ansible.builtin.set_fact:
     cmdout_argv: '{{ cmdout.stdout | trim | from_json }}'
 
-- name: assert call to argv binary with absolute path
-  assert:
+- name: Assert call to argv binary with absolute path
+  ansible.builtin.assert:
     that:
-    - cmdout is changed
-    - cmdout.rc == 0
-    - cmdout_argv.args[0] == 'arg1'
-    - cmdout_argv.args[1] == 'arg 2'
-    - cmdout_argv.args[2] == 'C:\\path\\arg'
-    - cmdout_argv.args[3] == '"quoted arg"'
+      - cmdout is changed
+      - cmdout.rc == 0
+      - cmdout_argv.args[0] == 'arg1'
+      - cmdout_argv.args[1] == 'arg 2'
+      - cmdout_argv.args[2] == 'C:\\path\\arg'
+      - cmdout_argv.args[3] == '"quoted arg"'
 
-- name: call binary with single argv entry
-  win_command:
+- name: Call binary with single argv entry
+  ansible.windows.win_command:
     argv:
-    - whoami
+      - whoami
   register: cmdout
 
-- name: assert call binary with single argv entry
-  assert:
+- name: Assert call binary with single argv entry
+  ansible.builtin.assert:
     that:
-    - cmdout is changed
-    - cmdout.rc == 0
-    - cmdout.stdout != ""
+      - cmdout is changed
+      - cmdout.rc == 0
+      - cmdout.stdout != ""
 
-- name: call binary with argv
-  win_command:
+- name: Call binary with argv
+  ansible.windows.win_command:
     argv:
-    - "{{ win_printargv_path }}"
-    - arg1
-    - "arg 2"
-    - C:\path\arg
-    - "\"quoted arg\""
+      - "{{ win_printargv_path }}"
+      - arg1
+      - "arg 2"
+      - C:\path\arg
+      - "\"quoted arg\""
   register: cmdout
 
-- set_fact:
+- name: Convert args to dictionary
+  ansible.builtin.set_fact:
     cmdout_argv: '{{ cmdout.stdout | trim | from_json }}'
 
-- name: assert call to argv binary with absolute path
-  assert:
+- name: Assert call to argv binary with absolute path
+  ansible.builtin.assert:
     that:
-    - cmdout is changed
-    - cmdout.rc == 0
-    - cmdout_argv.args[0] == 'arg1'
-    - cmdout_argv.args[1] == 'arg 2'
-    - cmdout_argv.args[2] == 'C:\\path\\arg'
-    - cmdout_argv.args[3] == '"quoted arg"'
+      - cmdout is changed
+      - cmdout.rc == 0
+      - cmdout_argv.args[0] == 'arg1'
+      - cmdout_argv.args[1] == 'arg 2'
+      - cmdout_argv.args[2] == 'C:\\path\\arg'
+      - cmdout_argv.args[3] == '"quoted arg"'
 
-- name: call binary with argv with relative path
-  win_command:
+- name: Call binary with argv with relative path
+  ansible.windows.win_command:
     argv:
-    - '{{ win_printargv_path | win_basename }}'
-    - testing
+      - '{{ win_printargv_path | win_basename }}'
+      - testing
     chdir: '{{ win_printargv_path | win_dirname }}'
   register: cmdout
 
-- set_fact:
+- name: Convert args to dictionary
+  ansible.builtin.set_fact:
     cmdout_argv: '{{ cmdout.stdout | trim | from_json }}'
 
-- name: assert call to argv binary with relative path
-  assert:
+- name: Assert call to argv binary with relative path
+  ansible.builtin.assert:
     that:
-    - cmdout is changed
-    - cmdout.rc == 0
-    - cmdout.cmd == win_printargv_path ~ ' testing'
-    - cmdout_argv.args[0] == 'testing'
+      - cmdout is changed
+      - cmdout.rc == 0
+      - cmdout.cmd == win_printargv_path ~ ' testing'
+      - cmdout_argv.args[0] == 'testing'
 
-- name: create 2 dirs to contain the same executable
-  win_file:
+- name: Create 2 dirs to contain the same executable
+  ansible.windows.win_file:
     path: '{{ remote_tmp_dir }}\{{ item }}'
     state: directory
   loop:
-  - path1
-  - path2
+    - path1
+    - path2
 
-- name: copy printargv to 2 dirs
-  win_copy:
+- name: Copy printargv to 2 dirs
+  ansible.windows.win_copy:
     src: '{{ win_printargv_path }}'
     dest: '{{ remote_tmp_dir }}\{{ item }}\printargv.exe'
     remote_src: true
   loop:
-  - path1
-  - path2
+    - path1
+    - path2
 
-- name: run exe that is located in 2 PATH directories
-  win_command: printargv test
+- name: Run exe that is located in 2 PATH directories
+  ansible.windows.win_command: printargv test
   environment:
     PATH: '{{ remote_tmp_dir }}\path1;{{ remote_tmp_dir }}\path2'
   register: cmdout
 
-- name: assert call to run exe that is located in 2 PATH directories
-  assert:
+- name: Assert call to run exe that is located in 2 PATH directories
+  ansible.builtin.assert:
     that:
-    - cmdout.rc == 0
+      - cmdout.rc == 0
 
-- name: run exe that is located in 2 PATH directories with argv
-  win_command:
+- name: Run exe that is located in 2 PATH directories with argv
+  ansible.windows.win_command:
     argv:
-    - printargv
-    - test
+      - printargv
+      - test
   environment:
     PATH: '{{ remote_tmp_dir }}\path1;{{ remote_tmp_dir }}\path2'
   register: cmdout
 
-- name: assert call to run exe that is located in 2 PATH directories with argv
-  assert:
+- name: Assert call to run exe that is located in 2 PATH directories with argv
+  ansible.builtin.assert:
     that:
-    - cmdout.rc == 0
+      - cmdout.rc == 0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed the errors and warning that came from ansible-lint for win_command integration test
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_command
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
Ref:
Partially fixes #671 