### PR TITLE
Remove ansbile-lint warnings/errors from win_copy

### DIFF
--- a/tests/integration/targets/win_copy/tasks/main.yml
+++ b/tests/integration/targets/win_copy/tasks/main.yml
@@ -1,34 +1,36 @@
 ---
-- name: create empty folder
-  file:
-    path: '{{role_path}}/files/subdir/empty'
+- name: Create empty folder
+  ansible.builtin.file:
+    path: '{{ role_path }}/files/subdir/empty'
     state: directory
+    mode: '0644'
   delegate_to: localhost
 
 # removes the cached zip module from the previous task so we can replicate
 # the below issue where win_copy would delete DEFAULT_LOCAL_TMP if it
 # had permission to
 # https://github.com/ansible/ansible/issues/35613
-- name: clear the local ansiballz cache
-  file:
-    path: "{{lookup('config', 'DEFAULT_LOCAL_TMP')}}/ansiballz_cache"
+- name: Clear the local ansiballz cache
+  ansible.builtin.file:
+    path: "{{ lookup('config', 'DEFAULT_LOCAL_TMP') }}/ansiballz_cache"
     state: absent
   delegate_to: localhost
 
-- name: create test folder
-  win_file:
-    path: '{{test_win_copy_path}}'
+- name: Create test folder
+  ansible.windows.win_file:
+    path: '{{ test_win_copy_path }}'
     state: directory
 
-- block:
-  - name: run tests for local to remote
-    include_tasks: tests.yml
-  
-  - name: run tests for remote to remote
-    include_tasks: remote_tests.yml
+- name: Run tests for win_copy module
+  block:
+    - name: Run tests for local to remote
+      ansible.builtin.include_tasks: tests.yml
+
+    - name: Run tests for remote to remote
+      ansible.builtin.include_tasks: remote_tests.yml
 
   always:
-  - name: remove test folder
-    win_file:
-      path: '{{test_win_copy_path}}'
-      state: absent
+    - name: Remove test folder
+      ansible.windows.win_file:
+        path: '{{ test_win_copy_path }}'
+        state: absent

--- a/tests/integration/targets/win_copy/tasks/remote_tests.yml
+++ b/tests/integration/targets/win_copy/tasks/remote_tests.yml
@@ -1,493 +1,493 @@
 ---
-- name: fail when source does not exist remote
-  win_copy:
+- name: Fail when source does not exist remote
+  ansible.windows.win_copy:
     src: fakesource
     dest: fakedest
-    remote_src: yes
+    remote_src: true
   register: fail_remote_invalid_source
   failed_when: "'it does not exist' not in fail_remote_invalid_source.msg"
 
-- name: setup source folder for remote tests
-  win_copy:
+- name: Setup source folder for remote tests
+  ansible.windows.win_copy:
     src: files/
-    dest: '{{test_win_copy_path}}\source\'
+    dest: '{{ test_win_copy_path }}\source\'
 
-- name: setup remote failure tests
-  win_file:
-    path: '{{item.path}}'
-    state: '{{item.state}}'
+- name: Setup remote failure tests
+  ansible.windows.win_file:
+    path: '{{ item.path }}'
+    state: '{{ item.state }}'
   with_items:
-  - { 'path': '{{test_win_copy_path}}\target\folder', 'state': 'directory' }
-  - { 'path': '{{test_win_copy_path}}\target\file', 'state': 'touch' }
-  - { 'path': '{{test_win_copy_path}}\target\subdir', 'state': 'touch' }
+    - { 'path': '{{ test_win_copy_path }}\target\folder', 'state': 'directory' }
+    - { 'path': '{{ test_win_copy_path }}\target\file', 'state': 'touch' }
+    - { 'path': '{{ test_win_copy_path }}\target\subdir', 'state': 'touch' }
 
-- name: fail source is a file but dest is a folder
-  win_copy:
-    src: '{{test_win_copy_path}}\source\'
-    dest: '{{test_win_copy_path}}\target\'
-    remote_src: yes
+- name: Fail source is a file but dest is a folder
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source\'
+    dest: '{{ test_win_copy_path }}\target\'
+    remote_src: true
   register: fail_remote_folder_to_file
   failed_when: "'dest is already a file' not in fail_remote_folder_to_file.msg"
 
-- name: fail source is a file dest parent dir is also a file
-  win_copy:
-    src: '{{test_win_copy_path}}\source\foo.txt'
-    dest: '{{test_win_copy_path}}\target\file\foo.txt'
-    remote_src: yes
+- name: Fail source is a file dest parent dir is also a file
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source\foo.txt'
+    dest: '{{ test_win_copy_path }}\target\file\foo.txt'
+    remote_src: true
   register: fail_remote_file_parent_dir_file
   failed_when: "'is currently a file' not in fail_remote_file_parent_dir_file.msg"
 
-- name: fail source is a folder dest parent dir is also a file
-  win_copy:
-    src: '{{test_win_copy_path}}\source\subdir'
-    dest: '{{test_win_copy_path}}\target\file'
-    remote_src: yes
+- name: Fail source is a folder dest parent dir is also a file
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source\subdir'
+    dest: '{{ test_win_copy_path }}\target\file'
+    remote_src: true
   register: fail_remote_folder_parent_dir_file
   failed_when: "'object at dest parent dir is not a folder' not in fail_remote_folder_parent_dir_file.msg"
 
-- name: fail to copy a remote file with parent dir that doesn't exist and filename is set
-  win_copy:
-    src: '{{test_win_copy_path}}\source\foo.txt'
-    dest: '{{test_win_copy_path}}\missing-dir\foo.txt'
-    remote_src: yes
+- name: Fail to copy a remote file with parent dir that doesn't exist and filename is set
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source\foo.txt'
+    dest: '{{ test_win_copy_path }}\missing-dir\foo.txt'
+    remote_src: true
   register: fail_remote_missing_parent_dir
   failed_when: "'does not exist' not in fail_remote_missing_parent_dir.msg"
 
-- name: remove target after remote failure tests
-  win_file:
-    path: '{{test_win_copy_path}}\target'
+- name: Remove target after remote failure tests
+  ansible.windows.win_file:
+    path: '{{ test_win_copy_path }}\target'
     state: absent
 
-- name: create remote target after cleaning
-  win_file:
-    path: '{{test_win_copy_path}}\target'
+- name: Create remote target after cleaning
+  ansible.windows.win_file:
+    path: '{{ test_win_copy_path }}\target'
     state: directory
 
-- name: copy single file remote (check mode)
-  win_copy:
-    src: '{{test_win_copy_path}}\source\foo.txt'
-    dest: '{{test_win_copy_path}}\target\foo-target.txt'
-    remote_src: yes
+- name: Copy single file remote (check mode)
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source\foo.txt'
+    dest: '{{ test_win_copy_path }}\target\foo-target.txt'
+    remote_src: true
   register: remote_copy_file_check
-  check_mode: yes
+  check_mode: true
 
-- name: get result of copy single file remote (check mode)
-  win_stat:
-    path: '{{test_win_copy_path}}\target\foo-target.txt'
+- name: Get result of copy single file remote (check mode)
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\target\foo-target.txt'
   register: remote_copy_file_actual_check
 
-- name: assert copy single file remote (check mode)
-  assert:
+- name: Assert copy single file remote (check mode)
+  ansible.builtin.assert:
     that:
-    - remote_copy_file_check is changed
-    - remote_copy_file_actual_check.stat.exists == False
+      - remote_copy_file_check is changed
+      - remote_copy_file_actual_check.stat.exists == False
 
-- name: copy single file remote
-  win_copy:
-    src: '{{test_win_copy_path}}\source\foo.txt'
-    dest: '{{test_win_copy_path}}\target\foo-target.txt'
-    remote_src: yes
+- name: Copy single file remote
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source\foo.txt'
+    dest: '{{ test_win_copy_path }}\target\foo-target.txt'
+    remote_src: true
   register: remote_copy_file
 
-- name: get result of copy single file remote
-  win_stat:
-    path: '{{test_win_copy_path}}\target\foo-target.txt'
+- name: Get result of copy single file remote
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\target\foo-target.txt'
   register: remote_copy_file_actual
 
-- name: assert copy single file remote
-  assert:
+- name: Assert copy single file remote
+  ansible.builtin.assert:
     that:
-    - remote_copy_file is changed
-    - remote_copy_file.operation == 'file_copy'
-    - remote_copy_file.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
-    - remote_copy_file.size == 8
-    - remote_copy_file.original_basename == 'foo.txt'
-    - remote_copy_file_actual.stat.exists == True
-    - remote_copy_file_actual.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - remote_copy_file is changed
+      - remote_copy_file.operation == 'file_copy'
+      - remote_copy_file.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - remote_copy_file.size == 8
+      - remote_copy_file.original_basename == 'foo.txt'
+      - remote_copy_file_actual.stat.exists == True
+      - remote_copy_file_actual.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
 
-- name: copy single file remote (idempotent)
-  win_copy:
-    src: '{{test_win_copy_path}}\source\foo.txt'
-    dest: '{{test_win_copy_path}}\target\foo-target.txt'
-    remote_src: yes
+- name: Copy single file remote (idempotent)
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source\foo.txt'
+    dest: '{{ test_win_copy_path }}\target\foo-target.txt'
+    remote_src: true
   register: remote_copy_file_again
 
-- name: assert copy single file remote (idempotent)
-  assert:
+- name: Assert copy single file remote (idempotent)
+  ansible.builtin.assert:
     that:
-    - remote_copy_file_again is not changed
+      - remote_copy_file_again is not changed
 
-- name: remote source is a file to a folder
-  win_copy:
-    src: '{{test_win_copy_path}}\source\foo.txt'
-    dest: '{{test_win_copy_path}}\target'
-    remote_src: yes
+- name: Remote source is a file to a folder
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source\foo.txt'
+    dest: '{{ test_win_copy_path }}\target'
+    remote_src: true
   register: remote_file_to_folder
 
-- name: get result of remote source is a file to a folder
-  win_stat:
-    path: '{{test_win_copy_path}}\target\foo.txt'
+- name: Get result of remote source is a file to a folder
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\target\foo.txt'
   register: remote_file_to_folder_actual
 
-- name: assert remote source is a file to a folder
-  assert:
+- name: Assert remote source is a file to a folder
+  ansible.builtin.assert:
     that:
-    - remote_file_to_folder is changed
-    - remote_file_to_folder_actual.stat.exists
+      - remote_file_to_folder is changed
+      - remote_file_to_folder_actual.stat.exists
 
-- name: remove test file
-  win_file:
-    path: '{{test_win_copy_path}}\target\foo.txt'
+- name: Remove test file
+  ansible.windows.win_file:
+    path: '{{ test_win_copy_path }}\target\foo.txt'
     state: absent
 
-- name: copy single file into folder remote (check mode)
-  win_copy:
-    src: '{{test_win_copy_path}}\source\foo.txt'
-    dest: '{{test_win_copy_path}}\target\'
-    remote_src: yes
+- name: Copy single file into folder remote (check mode)
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source\foo.txt'
+    dest: '{{ test_win_copy_path }}\target\'
+    remote_src: true
   register: remote_copy_file_to_folder_check
-  check_mode: yes
+  check_mode: true
 
-- name: get result of copy single file into folder remote (check mode)
-  win_stat:
-    path: '{{test_win_copy_path}}\target\foo.txt'
+- name: Get result of copy single file into folder remote (check mode)
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\target\foo.txt'
   register: remote_copy_file_to_folder_actual_check
 
-- name: assert copy single file into folder remote (check mode)
-  assert:
+- name: Assert copy single file into folder remote (check mode)
+  ansible.builtin.assert:
     that:
-    - remote_copy_file_to_folder_check is changed
-    - remote_copy_file_to_folder_actual_check.stat.exists == False
+      - remote_copy_file_to_folder_check is changed
+      - remote_copy_file_to_folder_actual_check.stat.exists == False
 
-- name: copy single file into folder remote
-  win_copy:
-    src: '{{test_win_copy_path}}\source\foo.txt'
-    dest: '{{test_win_copy_path}}\target\'
-    remote_src: yes
+- name: Copy single file into folder remote
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source\foo.txt'
+    dest: '{{ test_win_copy_path }}\target\'
+    remote_src: true
   register: remote_copy_file_to_folder
 
-- name: get result of copy single file into folder remote
-  win_stat:
-    path: '{{test_win_copy_path}}\target\foo.txt'
+- name: Get result of copy single file into folder remote
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\target\foo.txt'
   register: remote_copy_file_to_folder_actual
 
-- name: assert copy single file into folder remote
-  assert:
+- name: Assert copy single file into folder remote
+  ansible.builtin.assert:
     that:
-    - remote_copy_file_to_folder is changed
-    - remote_copy_file_to_folder.operation == 'file_copy'
-    - remote_copy_file_to_folder.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
-    - remote_copy_file_to_folder.size == 8
-    - remote_copy_file_to_folder.original_basename == 'foo.txt'
-    - remote_copy_file_to_folder_actual.stat.exists == True
-    - remote_copy_file_to_folder_actual.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - remote_copy_file_to_folder is changed
+      - remote_copy_file_to_folder.operation == 'file_copy'
+      - remote_copy_file_to_folder.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - remote_copy_file_to_folder.size == 8
+      - remote_copy_file_to_folder.original_basename == 'foo.txt'
+      - remote_copy_file_to_folder_actual.stat.exists == True
+      - remote_copy_file_to_folder_actual.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
 
-- name: copy single file into folder remote (idempotent)
-  win_copy:
-    src: '{{test_win_copy_path}}\source\foo.txt'
-    dest: '{{test_win_copy_path}}\target\'
-    remote_src: yes
+- name: Copy single file into folder remote (idempotent)
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source\foo.txt'
+    dest: '{{ test_win_copy_path }}\target\'
+    remote_src: true
   register: remote_copy_file_to_folder_again
 
-- name: assert copy single file into folder remote
-  assert:
+- name: Assert copy single file into folder remote
+  ansible.builtin.assert:
     that:
-    - remote_copy_file_to_folder_again is not changed
+      - remote_copy_file_to_folder_again is not changed
 
-- name: copy single file to missing folder (check mode)
-  win_copy:
-    src: '{{test_win_copy_path}}\source\foo.txt'
-    dest: '{{test_win_copy_path}}\target\missing\'
-    remote_src: yes
+- name: Copy single file to missing folder (check mode)
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source\foo.txt'
+    dest: '{{ test_win_copy_path }}\target\missing\'
+    remote_src: true
   register: remote_copy_file_to_missing_folder_check
-  check_mode: yes
+  check_mode: true
 
-- name: get result of copy single file to missing folder remote (check mode)
-  win_stat:
-    path: '{{test_win_copy_path}}\target\missing\foo.txt'
+- name: Get result of copy single file to missing folder remote (check mode)
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\target\missing\foo.txt'
   register: remote_copy_file_to_missing_folder_actual_check
 
-- name: assert copy single file to missing folder remote (check mode)
-  assert:
+- name: Assert copy single file to missing folder remote (check mode)
+  ansible.builtin.assert:
     that:
-    - remote_copy_file_to_missing_folder_check is changed
-    - remote_copy_file_to_missing_folder_check.operation == 'file_copy'
-    - remote_copy_file_to_missing_folder_actual_check.stat.exists == False
+      - remote_copy_file_to_missing_folder_check is changed
+      - remote_copy_file_to_missing_folder_check.operation == 'file_copy'
+      - remote_copy_file_to_missing_folder_actual_check.stat.exists == False
 
-- name: copy single file to missing folder remote
-  win_copy:
-    src: '{{test_win_copy_path}}\source\foo.txt'
-    dest: '{{test_win_copy_path}}\target\missing\'
-    remote_src: yes
+- name: Copy single file to missing folder remote
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source\foo.txt'
+    dest: '{{ test_win_copy_path }}\target\missing\'
+    remote_src: true
   register: remote_copy_file_to_missing_folder
 
-- name: get result of copy single file to missing folder remote
-  win_stat:
-    path: '{{test_win_copy_path}}\target\missing\foo.txt'
+- name: Get result of copy single file to missing folder remote
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\target\missing\foo.txt'
   register: remote_copy_file_to_missing_folder_actual
 
-- name: assert copy single file to missing folder remote
-  assert:
+- name: Assert copy single file to missing folder remote
+  ansible.builtin.assert:
     that:
-    - remote_copy_file_to_missing_folder is changed
-    - remote_copy_file_to_missing_folder.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
-    - remote_copy_file_to_missing_folder.operation == 'file_copy'
-    - remote_copy_file_to_missing_folder.size == 8
-    - remote_copy_file_to_missing_folder_actual.stat.exists == True
-    - remote_copy_file_to_missing_folder_actual.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - remote_copy_file_to_missing_folder is changed
+      - remote_copy_file_to_missing_folder.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - remote_copy_file_to_missing_folder.operation == 'file_copy'
+      - remote_copy_file_to_missing_folder.size == 8
+      - remote_copy_file_to_missing_folder_actual.stat.exists == True
+      - remote_copy_file_to_missing_folder_actual.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
 
-- name: clear target for folder to folder test
-  win_file:
-    path: '{{test_win_copy_path}}\target'
+- name: Clear target for folder to folder test
+  ansible.windows.win_file:
+    path: '{{ test_win_copy_path }}\target'
     state: absent
 
-- name: copy folder to folder remote (check mode)
-  win_copy:
-    src: '{{test_win_copy_path}}\source'
-    dest: '{{test_win_copy_path}}\target'
-    remote_src: yes
+- name: Copy folder to folder remote (check mode)
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source'
+    dest: '{{ test_win_copy_path }}\target'
+    remote_src: true
   register: remote_copy_folder_to_folder_check
-  check_mode: yes
+  check_mode: true
 
-- name: get result of copy folder to folder remote (check mode)
-  win_stat:
-    path: '{{test_win_copy_path}}\target'
+- name: Get result of copy folder to folder remote (check mode)
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\target'
   register: remote_copy_folder_to_folder_actual_check
 
-- name: assert copy folder to folder remote (check mode)
-  assert:
+- name: Assert copy folder to folder remote (check mode)
+  ansible.builtin.assert:
     that:
-    - remote_copy_folder_to_folder_check is changed
-    - remote_copy_folder_to_folder_check.operation == 'folder_copy'
-    - remote_copy_folder_to_folder_actual_check.stat.exists == False
+      - remote_copy_folder_to_folder_check is changed
+      - remote_copy_folder_to_folder_check.operation == 'folder_copy'
+      - remote_copy_folder_to_folder_actual_check.stat.exists == False
 
-- name: copy folder to folder remote
-  win_copy:
-    src: '{{test_win_copy_path}}\source'
-    dest: '{{test_win_copy_path}}\target'
-    remote_src: yes
+- name: Copy folder to folder remote
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source'
+    dest: '{{ test_win_copy_path }}\target'
+    remote_src: true
   register: remote_copy_folder_to_folder
 
-- name: get result of copy folder to folder remote
-  win_find:
-    paths: '{{test_win_copy_path}}\target'
-    recurse: yes
+- name: Get result of copy folder to folder remote
+  ansible.windows.win_find:
+    paths: '{{ test_win_copy_path }}\target'
+    recurse: true
     file_type: directory
   register: remote_copy_folder_to_folder_actual
 
-- name: assert copy folder to folder remote
-  assert:
+- name: Assert copy folder to folder remote
+  ansible.builtin.assert:
     that:
-    - remote_copy_folder_to_folder is changed
-    - remote_copy_folder_to_folder.operation == 'folder_copy'
-    - remote_copy_folder_to_folder_actual.examined == 11
-    - remote_copy_folder_to_folder_actual.matched == 6
-    - remote_copy_folder_to_folder_actual.files[0].filename == 'source'
-    - remote_copy_folder_to_folder_actual.files[1].filename == 'subdir'
-    - remote_copy_folder_to_folder_actual.files[2].filename == 'empty'
-    - remote_copy_folder_to_folder_actual.files[3].filename == 'subdir2'
-    - remote_copy_folder_to_folder_actual.files[4].filename == 'subdir3'
-    - remote_copy_folder_to_folder_actual.files[5].filename == 'subdir4'
+      - remote_copy_folder_to_folder is changed
+      - remote_copy_folder_to_folder.operation == 'folder_copy'
+      - remote_copy_folder_to_folder_actual.examined == 11
+      - remote_copy_folder_to_folder_actual.matched == 6
+      - remote_copy_folder_to_folder_actual.files[0].filename == 'source'
+      - remote_copy_folder_to_folder_actual.files[1].filename == 'subdir'
+      - remote_copy_folder_to_folder_actual.files[2].filename == 'empty'
+      - remote_copy_folder_to_folder_actual.files[3].filename == 'subdir2'
+      - remote_copy_folder_to_folder_actual.files[4].filename == 'subdir3'
+      - remote_copy_folder_to_folder_actual.files[5].filename == 'subdir4'
 
-- name: copy folder to folder remote (idempotent)
-  win_copy:
-    src: '{{test_win_copy_path}}\source'
-    dest: '{{test_win_copy_path}}\target'
-    remote_src: yes
+- name: Copy folder to folder remote (idempotent)
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source'
+    dest: '{{ test_win_copy_path }}\target'
+    remote_src: true
   register: remote_copy_folder_to_folder_again
 
-- name: assert copy folder to folder remote (idempotent)
-  assert:
+- name: Assert copy folder to folder remote (idempotent)
+  ansible.builtin.assert:
     that:
-    - remote_copy_folder_to_folder_again is not changed
+      - remote_copy_folder_to_folder_again is not changed
 
-- name: change remote file after folder to folder test
-  win_copy:
+- name: Change remote file after folder to folder test
+  ansible.windows.win_copy:
     content: bar.txt
-    dest: '{{test_win_copy_path}}\target\source\foo.txt'
+    dest: '{{ test_win_copy_path }}\target\source\foo.txt'
 
-- name: remote remote folder after folder to folder test
-  win_file:
-    path: '{{test_win_copy_path}}\target\source\subdir\subdir2\subdir3\subdir4'
+- name: Remote remote folder after folder to folder test
+  ansible.windows.win_file:
+    path: '{{ test_win_copy_path }}\target\source\subdir\subdir2\subdir3\subdir4'
     state: absent
 
-- name: copy folder to folder remote after change
-  win_copy:
-    src: '{{test_win_copy_path}}\source'
-    dest: '{{test_win_copy_path}}\target'
-    remote_src: yes
+- name: Copy folder to folder remote after change
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source'
+    dest: '{{ test_win_copy_path }}\target'
+    remote_src: true
   register: remote_copy_folder_to_folder_after_change
 
-- name: get result of copy folder to folder remote after change
-  win_find:
-    paths: '{{test_win_copy_path}}\target\source'
-    recurse: yes
+- name: Get result of copy folder to folder remote after change
+  ansible.windows.win_find:
+    paths: '{{ test_win_copy_path }}\target\source'
+    recurse: true
     patterns: ['foo.txt', 'qux.txt']
   register: remote_copy_folder_to_folder_after_change_actual
 
-- name: assert copy folder after changes
-  assert:
+- name: Assert copy folder after changes
+  ansible.builtin.assert:
     that:
-    - remote_copy_folder_to_folder_after_change is changed
-    - remote_copy_folder_to_folder_after_change_actual.matched == 2
-    - remote_copy_folder_to_folder_after_change_actual.files[0].checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
-    - remote_copy_folder_to_folder_after_change_actual.files[1].checksum == 'b54ba7f5621240d403f06815f7246006ef8c7d43'
+      - remote_copy_folder_to_folder_after_change is changed
+      - remote_copy_folder_to_folder_after_change_actual.matched == 2
+      - remote_copy_folder_to_folder_after_change_actual.files[0].checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - remote_copy_folder_to_folder_after_change_actual.files[1].checksum == 'b54ba7f5621240d403f06815f7246006ef8c7d43'
 
-- name: clear target folder before folder contents to remote test
-  win_file:
-    path: '{{test_win_copy_path}}\target'
+- name: Clear target folder before folder contents to remote test
+  ansible.windows.win_file:
+    path: '{{ test_win_copy_path }}\target'
     state: absent
 
-- name: copy folder contents to folder remote with backslash (check mode)
-  win_copy:
-    src: '{{test_win_copy_path}}\source\'
-    dest: '{{test_win_copy_path}}\target'
-    remote_src: yes
+- name: Copy folder contents to folder remote with backslash (check mode)
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source\'
+    dest: '{{ test_win_copy_path }}\target'
+    remote_src: true
   register: remote_copy_folder_content_backslash_check
-  check_mode: yes
+  check_mode: true
 
-- name: get result of copy folder contents to folder remote with backslash (check mode)
-  win_stat:
-    path: '{{test_win_copy_path}}\target'
+- name: Get result of copy folder contents to folder remote with backslash (check mode)
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\target'
   register: remote_copy_folder_content_backslash_actual_check
 
-- name: assert copy folder content to folder remote with backslash (check mode)
-  assert:
+- name: Assert copy folder content to folder remote with backslash (check mode)
+  ansible.builtin.assert:
     that:
-    - remote_copy_folder_content_backslash_check is changed
-    - remote_copy_folder_content_backslash_actual_check.stat.exists == False
+      - remote_copy_folder_content_backslash_check is changed
+      - remote_copy_folder_content_backslash_actual_check.stat.exists == False
 
-- name: copy folder contents to folder remote with backslash
-  win_copy:
-    src: '{{test_win_copy_path}}\source\'
-    dest: '{{test_win_copy_path}}\target'
-    remote_src: yes
+- name: Copy folder contents to folder remote with backslash
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source\'
+    dest: '{{ test_win_copy_path }}\target'
+    remote_src: true
   register: remote_copy_folder_content_backslash
 
-- name: get result of copy folder contents to folder remote with backslash
-  win_find:
-    paths: '{{test_win_copy_path}}\target'
-    recurse: yes
+- name: Get result of copy folder contents to folder remote with backslash
+  ansible.windows.win_find:
+    paths: '{{ test_win_copy_path }}\target'
+    recurse: true
     file_type: directory
   register: remote_copy_folder_content_backslash_actual
 
-- name: assert copy folder content to folder remote with backslash
-  assert:
+- name: Assert copy folder content to folder remote with backslash
+  ansible.builtin.assert:
     that:
-    - remote_copy_folder_content_backslash is changed
-    - remote_copy_folder_content_backslash.operation == 'folder_copy'
-    - remote_copy_folder_content_backslash_actual.examined == 10
-    - remote_copy_folder_content_backslash_actual.matched == 5
-    - remote_copy_folder_content_backslash_actual.files[0].filename == 'subdir'
-    - remote_copy_folder_content_backslash_actual.files[1].filename == 'empty'
-    - remote_copy_folder_content_backslash_actual.files[2].filename == 'subdir2'
-    - remote_copy_folder_content_backslash_actual.files[3].filename == 'subdir3'
-    - remote_copy_folder_content_backslash_actual.files[4].filename == 'subdir4'
+      - remote_copy_folder_content_backslash is changed
+      - remote_copy_folder_content_backslash.operation == 'folder_copy'
+      - remote_copy_folder_content_backslash_actual.examined == 10
+      - remote_copy_folder_content_backslash_actual.matched == 5
+      - remote_copy_folder_content_backslash_actual.files[0].filename == 'subdir'
+      - remote_copy_folder_content_backslash_actual.files[1].filename == 'empty'
+      - remote_copy_folder_content_backslash_actual.files[2].filename == 'subdir2'
+      - remote_copy_folder_content_backslash_actual.files[3].filename == 'subdir3'
+      - remote_copy_folder_content_backslash_actual.files[4].filename == 'subdir4'
 
-- name: copy folder contents to folder remote with backslash (idempotent)
-  win_copy:
-    src: '{{test_win_copy_path}}\source\'
-    dest: '{{test_win_copy_path}}\target'
-    remote_src: yes
+- name: Copy folder contents to folder remote with backslash (idempotent)
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}\source\'
+    dest: '{{ test_win_copy_path }}\target'
+    remote_src: true
   register: remote_copy_folder_content_backslash_again
 
-- name: assert copy folder content to folder remote with backslash (idempotent)
-  assert:
+- name: Assert copy folder content to folder remote with backslash (idempotent)
+  ansible.builtin.assert:
     that:
-    - remote_copy_folder_content_backslash_again is not changed
+      - remote_copy_folder_content_backslash_again is not changed
 
-- name: change remote file after folder content to folder test
-  win_copy:
+- name: Change remote file after folder content to folder test
+  ansible.windows.win_copy:
     content: bar.txt
-    dest: '{{test_win_copy_path}}\target\foo.txt'
+    dest: '{{ test_win_copy_path }}\target\foo.txt'
 
-- name: remote remote folder after folder content to folder test
-  win_file:
-    path: '{{test_win_copy_path}}\target\subdir\subdir2\subdir3\subdir4'
+- name: Remote remote folder after folder content to folder test
+  ansible.windows.win_file:
+    path: '{{ test_win_copy_path }}\target\subdir\subdir2\subdir3\subdir4'
     state: absent
 
-- name: copy folder content to folder remote after change
-  win_copy:
-    src: '{{test_win_copy_path}}/source/'
-    dest: '{{test_win_copy_path}}/target/'
-    remote_src: yes
+- name: Copy folder content to folder remote after change
+  ansible.windows.win_copy:
+    src: '{{ test_win_copy_path }}/source/'
+    dest: '{{ test_win_copy_path }}/target/'
+    remote_src: true
   register: remote_copy_folder_content_to_folder_after_change
 
-- name: get result of copy folder content to folder remote after change
-  win_find:
-    paths: '{{test_win_copy_path}}\target'
-    recurse: yes
+- name: Get result of copy folder content to folder remote after change
+  ansible.windows.win_find:
+    paths: '{{ test_win_copy_path }}\target'
+    recurse: true
     patterns: ['foo.txt', 'qux.txt']
   register: remote_copy_folder_content_to_folder_after_change_actual
 
-- name: assert copy folder content to folder after changes
-  assert:
+- name: Assert copy folder content to folder after changes
+  ansible.builtin.assert:
     that:
-    - remote_copy_folder_content_to_folder_after_change is changed
-    - remote_copy_folder_content_to_folder_after_change_actual.matched == 2
-    - remote_copy_folder_content_to_folder_after_change_actual.files[0].checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
-    - remote_copy_folder_content_to_folder_after_change_actual.files[1].checksum == 'b54ba7f5621240d403f06815f7246006ef8c7d43'
+      - remote_copy_folder_content_to_folder_after_change is changed
+      - remote_copy_folder_content_to_folder_after_change_actual.matched == 2
+      - remote_copy_folder_content_to_folder_after_change_actual.files[0].checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - remote_copy_folder_content_to_folder_after_change_actual.files[1].checksum == 'b54ba7f5621240d403f06815f7246006ef8c7d43'
 
 # https://github.com/ansible/ansible/issues/50077
-- name: create empty nested directory
-  win_file:
+- name: Create empty nested directory
+  ansible.windows.win_file:
     path: '{{ test_win_copy_path }}\source\empty-nested\nested-dir'
     state: directory
 
-- name: copy empty nested directory (check mode)
-  win_copy:
+- name: Copy empty nested directory (check mode)
+  ansible.windows.win_copy:
     src: '{{ test_win_copy_path }}\source\empty-nested'
     dest: '{{ test_win_copy_path }}\target'
-    remote_src: True
-  check_mode: True
+    remote_src: true
+  check_mode: true
   register: copy_empty_dir_check
 
-- name: get result of copy empty nested directory (check mode)
-  win_stat:
+- name: Get result of copy empty nested directory (check mode)
+  ansible.windows.win_stat:
     path: '{{ test_win_copy_path }}\target\empty-nested'
   register: copy_empty_dir_actual_check
 
-- name: assert copy empty nested directory (check mode)
-  assert:
+- name: Assert copy empty nested directory (check mode)
+  ansible.builtin.assert:
     that:
-    - copy_empty_dir_check is changed
-    - copy_empty_dir_check.operation == "folder_copy"
-    - not copy_empty_dir_actual_check.stat.exists
+      - copy_empty_dir_check is changed
+      - copy_empty_dir_check.operation == "folder_copy"
+      - not copy_empty_dir_actual_check.stat.exists
 
-- name: copy empty nested directory
-  win_copy:
+- name: Copy empty nested directory
+  ansible.windows.win_copy:
     src: '{{ test_win_copy_path }}\source\empty-nested'
     dest: '{{ test_win_copy_path }}\target'
-    remote_src: True
+    remote_src: true
   register: copy_empty_dir
 
-- name: get result of copy empty nested directory
-  win_stat:
+- name: Get result of copy empty nested directory
+  ansible.windows.win_stat:
     path: '{{ test_win_copy_path }}\target\empty-nested\nested-dir'
   register: copy_empty_dir_actual
 
-- name: assert copy empty nested directory
-  assert:
+- name: Assert copy empty nested directory
+  ansible.builtin.assert:
     that:
-    - copy_empty_dir is changed
-    - copy_empty_dir.operation == "folder_copy"
-    - copy_empty_dir_actual.stat.exists
+      - copy_empty_dir is changed
+      - copy_empty_dir.operation == "folder_copy"
+      - copy_empty_dir_actual.stat.exists
 
-- name: copy empty nested directory (idempotent)
-  win_copy:
+- name: Copy empty nested directory (idempotent)
+  ansible.windows.win_copy:
     src: '{{ test_win_copy_path }}\source\empty-nested'
     dest: '{{ test_win_copy_path }}\target'
-    remote_src: True
+    remote_src: true
   register: copy_empty_dir_again
 
-- name: assert copy empty nested directory (idempotent)
-  assert:
+- name: Assert copy empty nested directory (idempotent)
+  ansible.builtin.assert:
     that:
-    - not copy_empty_dir_again is changed
+      - not copy_empty_dir_again is changed
 
 # https://github.com/ansible-collections/ansible.windows/issues/298
-- name: create complex dest directory
-  win_powershell:
+- name: Create complex dest directory
+  ansible.windows.win_powershell:
     parameters:
       Path: '{{ test_win_copy_path }}\target\weird'
     error_action: stop
@@ -517,22 +517,22 @@
       $sd.SetOwner([System.Security.Principal.SecurityIdentifier]'S-1-5-18')
       $sd | Set-Acl -LiteralPath $lockedFolder
 
-- name: copy across file to complex dest
-  win_copy:
+- name: Copy across file to complex dest
+  ansible.windows.win_copy:
     src: '{{ test_win_copy_path }}\source\foo.txt'
     dest: '{{ test_win_copy_path }}\target\weird\'
-    remote_src: yes
+    remote_src: true
   register: copy_complex
 
-- name: get result of copy across file to complex dest
-  win_stat:
+- name: Get result of copy across file to complex dest
+  ansible.windows.win_stat:
     path: '{{ test_win_copy_path }}\target\weird\foo.txt'
   register: copy_complex_actual
 
-- name: assert copy across file to complex dest
-  assert:
+- name: Assert copy across file to complex dest
+  ansible.builtin.assert:
     that:
-    - copy_complex is changed
-    - copy_complex.size == 8  # 4 bytes for copy and (4 + 4) bytes for existing files in dest
-    - copy_complex_actual.stat.exists
-    - copy_complex_actual.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - copy_complex is changed
+      - copy_complex.size == 8  # 4 bytes for copy and (4 + 4) bytes for existing files in dest
+      - copy_complex_actual.stat.exists
+      - copy_complex_actual.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'

--- a/tests/integration/targets/win_copy/tasks/tests.yml
+++ b/tests/integration/targets/win_copy/tasks/tests.yml
@@ -1,573 +1,574 @@
 ---
-- name: fail no source or content
-  win_copy:
+- name: Fail no source or content
+  ansible.windows.win_copy:
     dest: dest
   register: fail_no_source_content
   failed_when: fail_no_source_content.msg != 'src (or content) and dest are required'
 
-- name: fail content but dest isn't a file, unix ending
-  win_copy:
+- name: Fail content but dest isn't a file, unix ending
+  ansible.windows.win_copy:
     content: a
     dest: a/
   register: fail_dest_not_file_unix
   failed_when: fail_dest_not_file_unix.msg != 'dest must be a file if content is defined'
 
-- name: fail content but dest isn't a file, windows ending
-  win_copy:
+- name: Fail content but dest isn't a file, windows ending
+  ansible.windows.win_copy:
     content: a
     dest: a\
   register: fail_dest_not_file_windows
   failed_when: fail_dest_not_file_windows.msg != 'dest must be a file if content is defined'
 
-- name: fail to copy a file with parent dir that doesn't exist and filename is set
-  win_copy:
+- name: Fail to copy a file with parent dir that doesn't exist and filename is set
+  ansible.windows.win_copy:
     src: foo.txt
-    dest: '{{test_win_copy_path}}\missing-dir\foo.txt'
+    dest: '{{ test_win_copy_path }}\missing-dir\foo.txt'
   register: fail_missing_parent_dir
   failed_when: "'does not exist' not in fail_missing_parent_dir.msg"
 
-- name: fail to copy an encrypted file without the password set
-  win_copy:
-    src: '{{role_path}}/files-different/vault/vault-file'
-    dest: '{{test_win_copy_path}}\file'
+- name: Fail to copy an encrypted file without the password set
+  ansible.windows.win_copy:
+    src: '{{ role_path }}/files-different/vault/vault-file'
+    dest: '{{ test_win_copy_path }}\file'
   register: fail_copy_encrypted_file
-  ignore_errors: yes # weird failed_when doesn't work in this case
+  ignore_errors: true # weird failed_when doesn't work in this case
 
-- name: assert failure message when copying an encrypted file without the password set
-  assert:
+- name: Assert failure message when copying an encrypted file without the password set
+  ansible.builtin.assert:
     that:
-    - fail_copy_encrypted_file is failed
-    - fail_copy_encrypted_file.msg == 'A vault password or secret must be specified to decrypt {{role_path}}/files-different/vault/vault-file'
+      - fail_copy_encrypted_file is failed
+      - fail_copy_encrypted_file.msg == 'A vault password or secret must be specified to decrypt {{ role_path }}/files-different/vault/vault-file'
 
-- name: fail to copy a directory with an encrypted file without the password
-  win_copy:
-    src: '{{role_path}}/files-different/vault'
-    dest: '{{test_win_copy_path}}'
+- name: Fail to copy a directory with an encrypted file without the password
+  ansible.windows.win_copy:
+    src: '{{ role_path }}/files-different/vault'
+    dest: '{{ test_win_copy_path }}'
   register: fail_copy_directory_with_enc_file
-  ignore_errors: yes
+  ignore_errors: true
 
-- name: assert failure message when copying a directory that contains an encrypted file without the password set
-  assert:
+- name: Assert failure message when copying a directory that contains an encrypted file without the password set
+  ansible.builtin.assert:
     that:
-    - fail_copy_directory_with_enc_file is failed
-    - fail_copy_directory_with_enc_file.msg == 'A vault password or secret must be specified to decrypt {{role_path}}/files-different/vault/vault-file'
+      - fail_copy_directory_with_enc_file is failed
+      - fail_copy_directory_with_enc_file.msg == 'A vault password or secret must be specified to decrypt {{ role_path }}/files-different/vault/vault-file'
 
-- name: copy with content (check mode)
-  win_copy:
+- name: Copy with content (check mode)
+  ansible.windows.win_copy:
     content: a
-    dest: '{{test_win_copy_path}}\file'
+    dest: '{{ test_win_copy_path }}\file'
   register: copy_content_check
-  check_mode: yes
+  check_mode: true
 
-- name: get result of copy with content (check mode)
-  win_stat:
-    path: '{{test_win_copy_path}}\file'
+- name: Get result of copy with content (check mode)
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\file'
   register: copy_content_actual_check
 
-- name: assert copy with content (check mode)
-  assert:
+- name: Assert copy with content (check mode)
+  ansible.builtin.assert:
     that:
-    - copy_content_check is changed
-    - copy_content_check.checksum == '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8'
-    - copy_content_check.operation == 'file_copy'
-    - copy_content_check.size == 1
-    - copy_content_actual_check.stat.exists == False
+      - copy_content_check is changed
+      - copy_content_check.checksum == '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8'
+      - copy_content_check.operation == 'file_copy'
+      - copy_content_check.size == 1
+      - copy_content_actual_check.stat.exists == False
 
-- name: copy with content
-  win_copy:
+- name: Copy with content
+  ansible.windows.win_copy:
     content: a
-    dest: '{{test_win_copy_path}}\file'
+    dest: '{{ test_win_copy_path }}\file'
   register: copy_content
 
-- name: get result of copy with content
-  win_stat:
-    path: '{{test_win_copy_path}}\file'
+- name: Get result of copy with content
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\file'
   register: copy_content_actual
 
-- name: assert copy with content
-  assert:
+- name: Assert copy with content
+  ansible.builtin.assert:
     that:
-    - copy_content is changed
-    - copy_content.checksum == '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8'
-    - copy_content.operation == 'file_copy'
-    - copy_content.size == 1
-    - copy_content_actual.stat.exists == True
-    - copy_content_actual.stat.checksum == '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8'
+      - copy_content is changed
+      - copy_content.checksum == '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8'
+      - copy_content.operation == 'file_copy'
+      - copy_content.size == 1
+      - copy_content_actual.stat.exists == True
+      - copy_content_actual.stat.checksum == '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8'
 
-- name: copy with content (idempotent)
-  win_copy:
+- name: Copy with content (idempotent)
+  ansible.windows.win_copy:
     content: a
-    dest: '{{test_win_copy_path}}\file'
+    dest: '{{ test_win_copy_path }}\file'
   register: copy_content_again
 
-- name: assert copy with content (idempotent)
-  assert:
+- name: Assert copy with content (idempotent)
+  ansible.builtin.assert:
     that:
-    - copy_content_again is not changed
+      - copy_content_again is not changed
 
-- name: copy with content change when missing
-  win_copy:
+- name: Copy with content change when missing
+  ansible.windows.win_copy:
     content: b
-    dest: '{{test_win_copy_path}}\file'
-    force: no
+    dest: '{{ test_win_copy_path }}\file'
+    force: false
   register: copy_content_when_missing
 
-- name: assert copy with content change when missing
-  assert:
+- name: Assert copy with content change when missing
+  ansible.builtin.assert:
     that:
-    - copy_content_when_missing is not changed
+      - copy_content_when_missing is not changed
 
-- name: copy single file (check mode)
-  win_copy:
+- name: Copy single file (check mode)
+  ansible.windows.win_copy:
     src: foo.txt
-    dest: '{{test_win_copy_path}}\foo-target.txt'
+    dest: '{{ test_win_copy_path }}\foo-target.txt'
   register: copy_file_check
-  check_mode: yes
+  check_mode: true
 
-- name: get result of copy single file (check mode)
-  win_stat:
-    path: '{{test_win_copy_path}}\foo-target.txt'
+- name: Get result of copy single file (check mode)
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\foo-target.txt'
   register: copy_file_actual_check
 
-- name: assert copy single file (check mode)
-  assert:
+- name: Assert copy single file (check mode)
+  ansible.builtin.assert:
     that:
-    - copy_file_check is changed
-    - copy_file_check.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
-    - copy_file_check.dest == test_win_copy_path + '\\foo-target.txt'
-    - copy_file_check.operation == 'file_copy'
-    - copy_file_check.size == 8
-    - copy_file_actual_check.stat.exists == False
+      - copy_file_check is changed
+      - copy_file_check.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - copy_file_check.dest == test_win_copy_path + '\\foo-target.txt'
+      - copy_file_check.operation == 'file_copy'
+      - copy_file_check.size == 8
+      - copy_file_actual_check.stat.exists == False
 
-- name: copy single file
-  win_copy:
+- name: Copy single file
+  ansible.windows.win_copy:
     src: foo.txt
-    dest: '{{test_win_copy_path}}\foo-target.txt'
+    dest: '{{ test_win_copy_path }}\foo-target.txt'
   register: copy_file
 
-- name: get result of copy single file
-  win_stat:
-    path: '{{test_win_copy_path}}\foo-target.txt'
+- name: Get result of copy single file
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\foo-target.txt'
   register: copy_file_actual
 
-- name: assert copy single file
-  assert:
+- name: Assert copy single file
+  ansible.builtin.assert:
     that:
-    - copy_file is changed
-    - copy_file.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
-    - copy_file.dest == test_win_copy_path + '\\foo-target.txt'
-    - copy_file.operation == 'file_copy'
-    - copy_file.size == 8
-    - copy_file_actual.stat.exists == True
-    - copy_file_actual.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - copy_file is changed
+      - copy_file.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - copy_file.dest == test_win_copy_path + '\\foo-target.txt'
+      - copy_file.operation == 'file_copy'
+      - copy_file.size == 8
+      - copy_file_actual.stat.exists == True
+      - copy_file_actual.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
 
-- name: copy single file (idempotent)
-  win_copy:
+- name: Copy single file (idempotent)
+  ansible.windows.win_copy:
     src: foo.txt
-    dest: '{{test_win_copy_path}}\foo-target.txt'
+    dest: '{{ test_win_copy_path }}\foo-target.txt'
   register: copy_file_again
 
-- name: assert copy single file (idempotent)
-  assert:
+- name: Assert copy single file (idempotent)
+  ansible.builtin.assert:
     that:
-    - copy_file_again is not changed
+      - copy_file_again is not changed
 
-- name: copy single file (backup)
-  win_copy:
+- name: Copy single file (backup)
+  ansible.windows.win_copy:
     content: "{{ lookup('file', 'foo.txt') }}\nfoo bar"
-    dest: '{{test_win_copy_path}}\foo-target.txt'
-    backup: yes
+    dest: '{{ test_win_copy_path }}\foo-target.txt'
+    backup: true
   register: copy_file_backup
 
-- name: check backup_file
-  win_stat:
+- name: Check backup_file
+  ansible.windows.win_stat:
     path: '{{ copy_file_backup.backup_file }}'
   register: backup_file
 
-- name: assert copy single file (backup)
-  assert:
+- name: Assert copy single file (backup)
+  ansible.builtin.assert:
     that:
-    - copy_file_backup is changed
-    - backup_file.stat.exists == true
+      - copy_file_backup is changed
+      - backup_file.stat.exists == true
 
-- name: copy single file to folder (check mode)
-  win_copy:
+- name: Copy single file to folder (check mode)
+  ansible.windows.win_copy:
     src: foo.txt
-    dest: '{{test_win_copy_path}}\'
+    dest: '{{ test_win_copy_path }}\'
   register: copy_file_to_folder_check
-  check_mode: yes
+  check_mode: true
 
-- name: get result of copy single file to folder (check mode)
-  win_stat:
-    path: '{{test_win_copy_path}}\foo.txt'
+- name: Get result of copy single file to folder (check mode)
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\foo.txt'
   register: copy_file_to_folder_actual_check
 
-- name: assert copy single file to folder (check mode)
-  assert:
+- name: Assert copy single file to folder (check mode)
+  ansible.builtin.assert:
     that:
-    - copy_file_to_folder_check is changed
-    - copy_file_to_folder_check.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
-    - copy_file_to_folder_check.dest == test_win_copy_path + '\\foo.txt'
-    - copy_file_to_folder_check.operation == 'file_copy'
-    - copy_file_to_folder_check.size == 8
-    - copy_file_to_folder_actual_check.stat.exists == False
+      - copy_file_to_folder_check is changed
+      - copy_file_to_folder_check.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - copy_file_to_folder_check.dest == test_win_copy_path + '\\foo.txt'
+      - copy_file_to_folder_check.operation == 'file_copy'
+      - copy_file_to_folder_check.size == 8
+      - copy_file_to_folder_actual_check.stat.exists == False
 
-- name: copy single file to folder
-  win_copy:
+- name: Copy single file to folder
+  ansible.windows.win_copy:
     src: foo.txt
-    dest: '{{test_win_copy_path}}\'
+    dest: '{{ test_win_copy_path }}\'
   register: copy_file_to_folder
 
-- name: get result of copy single file to folder
-  win_stat:
-    path: '{{test_win_copy_path}}\foo.txt'
+- name: Get result of copy single file to folder
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\foo.txt'
   register: copy_file_to_folder_actual
 
-- name: assert copy single file to folder
-  assert:
+- name: Assert copy single file to folder
+  ansible.builtin.assert:
     that:
-    - copy_file_to_folder is changed
-    - copy_file_to_folder.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
-    - copy_file_to_folder.dest == test_win_copy_path + '\\foo.txt'
-    - copy_file_to_folder.operation == 'file_copy'
-    - copy_file_to_folder.size == 8
-    - copy_file_to_folder_actual.stat.exists == True
-    - copy_file_to_folder_actual.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - copy_file_to_folder is changed
+      - copy_file_to_folder.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - copy_file_to_folder.dest == test_win_copy_path + '\\foo.txt'
+      - copy_file_to_folder.operation == 'file_copy'
+      - copy_file_to_folder.size == 8
+      - copy_file_to_folder_actual.stat.exists == True
+      - copy_file_to_folder_actual.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
 
-- name: copy single file to folder (idempotent)
-  win_copy:
+- name: Copy single file to folder (idempotent)
+  ansible.windows.win_copy:
     src: foo.txt
-    dest: '{{test_win_copy_path}}\'
+    dest: '{{ test_win_copy_path }}\'
   register: copy_file_to_folder_again
 
-- name: assert copy single file to folder (idempotent)
-  assert:
+- name: Assert copy single file to folder (idempotent)
+  ansible.builtin.assert:
     that:
-    - copy_file_to_folder_again is not changed
+      - copy_file_to_folder_again is not changed
 
-- name: copy single file to missing folder (check mode)
-  win_copy:
+- name: Copy single file to missing folder (check mode)
+  ansible.windows.win_copy:
     src: foo.txt
-    dest: '{{test_win_copy_path}}\missing\'
+    dest: '{{ test_win_copy_path }}\missing\'
   register: copy_file_to_missing_folder_check
-  check_mode: yes
+  check_mode: true
 
-- name: get result of copy single file to missing folder (check mode)
-  win_stat:
-    path: '{{test_win_copy_path}}\missing\foo.txt'
+- name: Get result of copy single file to missing folder (check mode)
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\missing\foo.txt'
   register: copy_file_to_missing_folder_actual_check
 
-- name: assert copy single file to missing folder (check mode)
-  assert:
+- name: Assert copy single file to missing folder (check mode)
+  ansible.builtin.assert:
     that:
-    - copy_file_to_missing_folder_check is changed
-    - copy_file_to_missing_folder_check.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
-    - copy_file_to_missing_folder_check.operation == 'file_copy'
-    - copy_file_to_missing_folder_check.size == 8
-    - copy_file_to_missing_folder_actual_check.stat.exists == False
+      - copy_file_to_missing_folder_check is changed
+      - copy_file_to_missing_folder_check.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - copy_file_to_missing_folder_check.operation == 'file_copy'
+      - copy_file_to_missing_folder_check.size == 8
+      - copy_file_to_missing_folder_actual_check.stat.exists == False
 
-- name: copy single file to missing folder
-  win_copy:
+- name: Copy single file to missing folder
+  ansible.windows.win_copy:
     src: foo.txt
-    dest: '{{test_win_copy_path}}\missing\'
+    dest: '{{ test_win_copy_path }}\missing\'
   register: copy_file_to_missing_folder
 
-- name: get result of copy single file to missing folder
-  win_stat:
-    path: '{{test_win_copy_path}}\missing\foo.txt'
+- name: Get result of copy single file to missing folder
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\missing\foo.txt'
   register: copy_file_to_missing_folder_actual
 
-- name: assert copy single file to missing folder
-  assert:
+- name: Assert copy single file to missing folder
+  ansible.builtin.assert:
     that:
-    - copy_file_to_missing_folder is changed
-    - copy_file_to_missing_folder.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
-    - copy_file_to_missing_folder.operation == 'file_copy'
-    - copy_file_to_missing_folder.size == 8
-    - copy_file_to_missing_folder_actual.stat.exists == True
-    - copy_file_to_missing_folder_actual.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - copy_file_to_missing_folder is changed
+      - copy_file_to_missing_folder.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - copy_file_to_missing_folder.operation == 'file_copy'
+      - copy_file_to_missing_folder.size == 8
+      - copy_file_to_missing_folder_actual.stat.exists == True
+      - copy_file_to_missing_folder_actual.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
 
-- name: copy folder (check mode)
-  win_copy:
+- name: Copy folder (check mode)
+  ansible.windows.win_copy:
     src: files
-    dest: '{{test_win_copy_path}}\recursive\folder'
+    dest: '{{ test_win_copy_path }}\recursive\folder'
   register: copy_folder_check
-  check_mode: yes
+  check_mode: true
 
-- name: get result of copy folder (check mode)
-  win_stat:
-    path: '{{test_win_copy_path}}\recursive\folder'
+- name: Get result of copy folder (check mode)
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\recursive\folder'
   register: copy_folder_actual_check
 
-- name: assert copy folder (check mode)
-  assert:
+- name: Assert copy folder (check mode)
+  ansible.builtin.assert:
     that:
-    - copy_folder_check is changed
-    - copy_folder_check.operation == 'folder_copy'
-    - copy_folder_actual_check.stat.exists == False
+      - copy_folder_check is changed
+      - copy_folder_check.operation == 'folder_copy'
+      - copy_folder_actual_check.stat.exists == False
 
-- name: copy folder
-  win_copy:
+- name: Copy folder
+  ansible.windows.win_copy:
     src: files
-    dest: '{{test_win_copy_path}}\recursive\folder'
+    dest: '{{ test_win_copy_path }}\recursive\folder'
   register: copy_folder
 
-- name: get result of copy folder
-  win_find:
-    paths: '{{test_win_copy_path}}\recursive\folder'
-    recurse: yes
+- name: Get result of copy folder
+  ansible.windows.win_find:
+    paths: '{{ test_win_copy_path }}\recursive\folder'
+    recurse: true
     file_type: directory
   register: copy_folder_actual
 
-- name: assert copy folder
-  assert:
+- name: Assert copy folder
+  ansible.builtin.assert:
     that:
-    - copy_folder is changed
-    - copy_folder.operation == 'folder_copy'
-    - copy_folder_actual.examined == 11 # includes files and folders, the below is the nested order
-    - copy_folder_actual.matched == 6
-    - copy_folder_actual.files[0].filename == 'files'
-    - copy_folder_actual.files[1].filename == 'subdir'
-    - copy_folder_actual.files[2].filename == 'empty'
-    - copy_folder_actual.files[3].filename == 'subdir2'
-    - copy_folder_actual.files[4].filename == 'subdir3'
-    - copy_folder_actual.files[5].filename == 'subdir4'
+      - copy_folder is changed
+      - copy_folder.operation == 'folder_copy'
+      - copy_folder_actual.examined == 11 # includes files and folders, the below is the nested order
+      - copy_folder_actual.matched == 6
+      - copy_folder_actual.files[0].filename == 'files'
+      - copy_folder_actual.files[1].filename == 'subdir'
+      - copy_folder_actual.files[2].filename == 'empty'
+      - copy_folder_actual.files[3].filename == 'subdir2'
+      - copy_folder_actual.files[4].filename == 'subdir3'
+      - copy_folder_actual.files[5].filename == 'subdir4'
 
-- name: copy folder (idempotent)
-  win_copy:
+- name: Copy folder (idempotent)
+  ansible.windows.win_copy:
     src: files
-    dest: '{{test_win_copy_path}}\recursive\folder'
+    dest: '{{ test_win_copy_path }}\recursive\folder'
   register: copy_folder_again
 
-- name: assert copy folder (idempotent)
-  assert:
+- name: Assert copy folder (idempotent)
+  ansible.builtin.assert:
     that:
-    - copy_folder_again is not changed
+      - copy_folder_again is not changed
 
-- name: change the text of a file in the remote source
-  win_copy:
+- name: Change the text of a file in the remote source
+  ansible.windows.win_copy:
     content: bar.txt
-    dest: '{{test_win_copy_path}}\recursive\folder\files\foo.txt'
+    dest: '{{ test_win_copy_path }}\recursive\folder\files\foo.txt'
 
-- name: remove folder for test of recursive copy
-  win_file:
-    path: '{{test_win_copy_path}}\recursive\folder\files\subdir\subdir2\subdir3\subdir4'
+- name: Remove folder for test of recursive copy
+  ansible.windows.win_file:
+    path: '{{ test_win_copy_path }}\recursive\folder\files\subdir\subdir2\subdir3\subdir4'
     state: absent
 
-- name: copy folder after changes
-  win_copy:
+- name: Copy folder after changes
+  ansible.windows.win_copy:
     src: files
-    dest: '{{test_win_copy_path}}\recursive\folder'
+    dest: '{{ test_win_copy_path }}\recursive\folder'
   register: copy_folder_after_change
 
-- name: get result of copy folder after changes
-  win_find:
-    paths: '{{test_win_copy_path}}\recursive\folder\files'
-    recurse: yes
+- name: Get result of copy folder after changes
+  ansible.windows.win_find:
+    paths: '{{ test_win_copy_path }}\recursive\folder\files'
+    recurse: true
     patterns: ['foo.txt', 'qux.txt']
   register: copy_folder_after_changes_actual
 
-- name: assert copy folder after changes
-  assert:
+- name: Assert copy folder after changes
+  ansible.builtin.assert:
     that:
-    - copy_folder_after_change is changed
-    - copy_folder_after_changes_actual.matched == 2
-    - copy_folder_after_changes_actual.files[0].checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
-    - copy_folder_after_changes_actual.files[1].checksum == 'b54ba7f5621240d403f06815f7246006ef8c7d43'
+      - copy_folder_after_change is changed
+      - copy_folder_after_changes_actual.matched == 2
+      - copy_folder_after_changes_actual.files[0].checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+      - copy_folder_after_changes_actual.files[1].checksum == 'b54ba7f5621240d403f06815f7246006ef8c7d43'
 
-- name: copy folder's contents (check mode)
-  win_copy:
+- name: Copy folder's contents (check mode)
+  ansible.windows.win_copy:
     src: files/
-    dest: '{{test_win_copy_path}}\recursive-contents\'
+    dest: '{{ test_win_copy_path }}\recursive-contents\'
   register: copy_folder_contents_check
-  check_mode: yes
+  check_mode: true
 
-- name: get result of copy folder'scontents (check mode)
-  win_stat:
-    path: '{{test_win_copy_path}}\recursive-contents'
+- name: Get result of copy folder'scontents (check mode)
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\recursive-contents'
   register: copy_folder_contents_actual_check
 
-- name: assert copy folder's contents (check mode)
-  assert:
+- name: Assert copy folder's contents (check mode)
+  ansible.builtin.assert:
     that:
-    - copy_folder_contents_check is changed
-    - copy_folder_contents_check.operation == 'folder_copy'
-    - copy_folder_contents_actual_check.stat.exists == False
+      - copy_folder_contents_check is changed
+      - copy_folder_contents_check.operation == 'folder_copy'
+      - copy_folder_contents_actual_check.stat.exists == False
 
-- name: copy folder's contents
-  win_copy:
+- name: Copy folder's contents
+  ansible.windows.win_copy:
     src: files/
-    dest: '{{test_win_copy_path}}\recursive-contents\'
+    dest: '{{ test_win_copy_path }}\recursive-contents\'
   register: copy_folder_contents
 
-- name: get result of copy folder
-  win_find:
-    paths: '{{test_win_copy_path}}\recursive-contents'
-    recurse: yes
+- name: Get result of copy folder
+  ansible.windows.win_find:
+    paths: '{{ test_win_copy_path }}\recursive-contents'
+    recurse: true
     file_type: directory
   register: copy_folder_contents_actual
 
-- name: assert copy folder
-  assert:
+- name: Assert copy folder
+  ansible.builtin.assert:
     that:
-    - copy_folder_contents is changed
-    - copy_folder_contents.operation == 'folder_copy'
-    - copy_folder_contents_actual.examined == 10 # includes files and folders, the below is the nested order
-    - copy_folder_contents_actual.matched == 5
-    - copy_folder_contents_actual.files[0].filename == 'subdir'
-    - copy_folder_contents_actual.files[1].filename == 'empty'
-    - copy_folder_contents_actual.files[2].filename == 'subdir2'
-    - copy_folder_contents_actual.files[3].filename == 'subdir3'
-    - copy_folder_contents_actual.files[4].filename == 'subdir4'
+      - copy_folder_contents is changed
+      - copy_folder_contents.operation == 'folder_copy'
+      - copy_folder_contents_actual.examined == 10 # includes files and folders, the below is the nested order
+      - copy_folder_contents_actual.matched == 5
+      - copy_folder_contents_actual.files[0].filename == 'subdir'
+      - copy_folder_contents_actual.files[1].filename == 'empty'
+      - copy_folder_contents_actual.files[2].filename == 'subdir2'
+      - copy_folder_contents_actual.files[3].filename == 'subdir3'
+      - copy_folder_contents_actual.files[4].filename == 'subdir4'
 
-- name: remove single file in folder before next test
-  win_file:
+- name: Remove single file in folder before next test
+  ansible.windows.win_file:
     path: '{{ test_win_copy_path }}\recursive-contents\subdir\bar.txt'
     state: absent
 
-- name: copy folder contents with single file changed to folder
-  win_copy:
+- name: Copy folder contents with single file changed to folder
+  ansible.windows.win_copy:
     src: files/
     dest: '{{ test_win_copy_path }}\recursive-contents\'
   register: copy_folder_single_change
 
-- name: get result of copy folder contents with single file changed to folder
-  win_stat:
+- name: Get result of copy folder contents with single file changed to folder
+  ansible.windows.win_stat:
     path: '{{ test_win_copy_path }}\recursive-contents\subdir\bar.txt'
   register: copy_folder_single_change_actual
 
-- name: assert copy folder contents with single file changed to folder
-  assert:
+- name: Assert copy folder contents with single file changed to folder
+  ansible.builtin.assert:
     that:
-    - copy_folder_single_change is changed
-    - copy_folder_single_change.operation == 'folder_copy'
-    - copy_folder_single_change_actual.stat.exists
+      - copy_folder_single_change is changed
+      - copy_folder_single_change.operation == 'folder_copy'
+      - copy_folder_single_change_actual.stat.exists
 
-- name: remove foo.txt before next test
-  win_file:
-    path: '{{test_win_copy_path}}\recursive-contents\foo.txt'
+- name: Remove foo.txt before next test
+  ansible.windows.win_file:
+    path: '{{ test_win_copy_path }}\recursive-contents\foo.txt'
     state: absent
 
-- name: copy file to a folder
-  win_copy:
+- name: Copy file to a folder
+  ansible.windows.win_copy:
     src: foo.txt
-    dest: '{{test_win_copy_path}}\recursive-contents'
+    dest: '{{ test_win_copy_path }}\recursive-contents'
   register: file_to_folder
 
-- name: get result of copy file to folder
-  win_stat:
-    path: '{{test_win_copy_path}}\recursive-contents\foo.txt'
+- name: Get result of copy file to folder
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\recursive-contents\foo.txt'
   register: file_to_folder_actual
 
-- name: assert copy file to a folder
-  assert:
+- name: Assert copy file to a folder
+  ansible.builtin.assert:
     that:
-    - file_to_folder is changed
-    - file_to_folder_actual.stat.exists
+      - file_to_folder is changed
+      - file_to_folder_actual.stat.exists
 
-- name: fail to copy folder to a file
-  win_copy:
+- name: Fail to copy folder to a file
+  ansible.windows.win_copy:
     src: subdir/
-    dest: '{{test_win_copy_path}}\recursive-contents\foo.txt'
+    dest: '{{ test_win_copy_path }}\recursive-contents\foo.txt'
   register: fail_folder_to_file
   failed_when: "'object at parent directory path is already a file' not in fail_folder_to_file.msg"
 
 # https://github.com/ansible/ansible/issues/31336
-- name: create file with colon in the name
-  copy:
-    dest: '{{role_path}}/files-different/colon:file'
+- name: Create file with colon in the name
+  ansible.builtin.copy:
+    dest: '{{ role_path }}/files-different/colon:file'
     content: test
+    mode: '0644'
   delegate_to: localhost
 
-- name: copy a file with colon as a source
-  win_copy:
-    src: '{{role_path}}/files-different/colon:file'
-    dest: '{{test_win_copy_path}}\colon.file'
+- name: Copy a file with colon as a source
+  ansible.windows.win_copy:
+    src: '{{ role_path }}/files-different/colon:file'
+    dest: '{{ test_win_copy_path }}\colon.file'
   register: copy_file_with_colon
 
-- name: get result of file with colon as a source
-  win_stat:
-    path: '{{test_win_copy_path}}\colon.file'
+- name: Get result of file with colon as a source
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\colon.file'
   register: copy_file_with_colon_result
 
-- name: assert results of copy a file with colon as a source
-  assert:
+- name: Assert results of copy a file with colon as a source
+  ansible.builtin.assert:
     that:
-    - copy_file_with_colon is changed
-    - copy_file_with_colon_result.stat.exists == True
-    - copy_file_with_colon_result.stat.checksum == "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3" 
+      - copy_file_with_colon is changed
+      - copy_file_with_colon_result.stat.exists == True
+      - copy_file_with_colon_result.stat.checksum == "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"
 
-- name: remove file with colon in the name
-  file:
-    path: '{{role_path}}/files-different/colon:file'
+- name: Remove file with colon in the name
+  ansible.builtin.file:
+    path: '{{ role_path }}/files-different/colon:file'
     state: absent
   delegate_to: localhost
 
-- name: copy an encrypted file without decrypting
-  win_copy:
-    src: '{{role_path}}/files-different/vault/vault-file'
-    dest: '{{test_win_copy_path}}\vault-file'
-    decrypt: no
+- name: Copy an encrypted file without decrypting
+  ansible.windows.win_copy:
+    src: '{{ role_path }}/files-different/vault/vault-file'
+    dest: '{{ test_win_copy_path }}\vault-file'
+    decrypt: false
   register: copy_encrypted_file
 
-- name: get stat of copied encrypted file without decrypting
-  win_stat:
-    path: '{{test_win_copy_path}}\vault-file'
+- name: Get stat of copied encrypted file without decrypting
+  ansible.windows.win_stat:
+    path: '{{ test_win_copy_path }}\vault-file'
   register: copy_encrypted_file_result
 
-- name: assert result of copy an encrypted file without decrypting
-  assert:
+- name: Assert result of copy an encrypted file without decrypting
+  ansible.builtin.assert:
     that:
-    - copy_encrypted_file is changed
-    - copy_encrypted_file_result.stat.checksum == "74a89620002d253f38834ee5b06cddd28956a43d"
+      - copy_encrypted_file is changed
+      - copy_encrypted_file_result.stat.checksum == "74a89620002d253f38834ee5b06cddd28956a43d"
 
-- name: copy an encrypted file without decrypting (idempotent)
-  win_copy:
-    src: '{{role_path}}/files-different/vault/vault-file'
-    dest: '{{test_win_copy_path}}\vault-file'
-    decrypt: no
+- name: Copy an encrypted file without decrypting (idempotent)
+  ansible.windows.win_copy:
+    src: '{{ role_path }}/files-different/vault/vault-file'
+    dest: '{{ test_win_copy_path }}\vault-file'
+    decrypt: false
   register: copy_encrypted_file_again
 
-- name: assert result of copy an encrypted file without decrypting (idempotent)
-  assert:
+- name: Assert result of copy an encrypted file without decrypting (idempotent)
+  ansible.builtin.assert:
     that:
-    - copy_encrypted_file_again is not changed
+      - copy_encrypted_file_again is not changed
 
-- name: copy folder with encrypted files without decrypting
-  win_copy:
-    src: '{{role_path}}/files-different/vault/'
-    dest: '{{test_win_copy_path}}\encrypted-test'
-    decrypt: no
+- name: Copy folder with encrypted files without decrypting
+  ansible.windows.win_copy:
+    src: '{{ role_path }}/files-different/vault/'
+    dest: '{{ test_win_copy_path }}\encrypted-test'
+    decrypt: false
   register: copy_encrypted_file
 
-- name: get result of copy folder with encrypted files without decrypting
-  win_find:
-    paths: '{{test_win_copy_path}}\encrypted-test'
-    recurse: yes
+- name: Get result of copy folder with encrypted files without decrypting
+  ansible.windows.win_find:
+    paths: '{{ test_win_copy_path }}\encrypted-test'
+    recurse: true
     patterns: '*vault*'
   register: copy_encrypted_file_result
 
-- name: assert result of copy folder with encrypted files without decrypting
-  assert:
+- name: Assert result of copy folder with encrypted files without decrypting
+  ansible.builtin.assert:
     that:
-    - copy_encrypted_file is changed
-    - copy_encrypted_file_result.files|count == 2
-    - copy_encrypted_file_result.files[0].checksum == "834563c94127730ecfa42dfc1e1821bbda2e51da"
-    - copy_encrypted_file_result.files[1].checksum == "74a89620002d253f38834ee5b06cddd28956a43d"
+      - copy_encrypted_file is changed
+      - copy_encrypted_file_result.files|count == 2
+      - copy_encrypted_file_result.files[0].checksum == "834563c94127730ecfa42dfc1e1821bbda2e51da"
+      - copy_encrypted_file_result.files[1].checksum == "74a89620002d253f38834ee5b06cddd28956a43d"
 
-- name: copy folder with encrypted files without decrypting (idempotent)
-  win_copy:
-    src: '{{role_path}}/files-different/vault/'
-    dest: '{{test_win_copy_path}}\encrypted-test'
-    decrypt: no
+- name: Copy folder with encrypted files without decrypting (idempotent)
+  ansible.windows.win_copy:
+    src: '{{ role_path }}/files-different/vault/'
+    dest: '{{ test_win_copy_path }}\encrypted-test'
+    decrypt: false
   register: copy_encrypted_file_again
 
-- name: assert result of copy folder with encrypted files without decrypting (idempotent)
-  assert:
+- name: Assert result of copy folder with encrypted files without decrypting (idempotent)
+  ansible.builtin.assert:
     that:
-    - copy_encrypted_file_again is not changed
+      - copy_encrypted_file_again is not changed
 
-- name: remove test folder after local to remote tests
-  win_file:
-    path: '{{test_win_copy_path}}'
+- name: Remove test folder after local to remote tests
+  ansible.windows.win_file:
+    path: '{{ test_win_copy_path }}'
     state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed the errors and warning that came from ansible-lint for win_copy integration test
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_copy
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
Ref:
Partially fixes #671 