### PR TITLE
Remove ansbile-lint warnings/errors from win_dns_client

### DIFF
--- a/tests/integration/targets/win_dns_client/meta/main.yml
+++ b/tests/integration/targets/win_dns_client/meta/main.yml
@@ -1,2 +1,5 @@
 dependencies:
-- setup_win_device
+  - setup_win_device
+galaxy_info:
+  role_name: win_dns_client
+  namespace: win_dns_client_ns

--- a/tests/integration/targets/win_dns_client/tasks/main.yml
+++ b/tests/integration/targets/win_dns_client/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
-- set_fact:
+- name: Set a script to get ips for later calls
+  ansible.builtin.set_fact:
     get_ip_script: |
       $adapter = Get-CimInstance -ClassName Win32_NetworkAdapter -Filter "NetConnectionID='{{ network_adapter_name }}'"
       $config = Get-CimInstance -ClassName Win32_NetworkAdapterConfiguration -Filter "Index=$($adapter.DeviceID)"
@@ -9,226 +10,226 @@
           $config.DNSServerSearchOrder[1]
       }
 
-- name: set a single IPv4 address (check mode)
-  win_dns_client:
+- name: Set a single IPv4 address (check mode)
+  ansible.windows.win_dns_client:
     adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses: 192.168.34.5
   register: set_single_check
-  check_mode: yes
+  check_mode: true
 
-- name: get result of set a single IPv4 address (check mode)
-  win_shell: '{{ get_ip_script }}'
-  changed_when: no
+- name: Get result of set a single IPv4 address (check mode)
+  ansible.windows.win_shell: '{{ get_ip_script }}'
+  changed_when: false
   register: set_single_actual_check
 
-- name: assert set a single IPv4 address (check mode)
-  assert:
+- name: Assert set a single IPv4 address (check mode)
+  ansible.builtin.assert:
     that:
-    - set_single_check is changed
-    - set_single_actual_check.stdout_lines == []
+      - set_single_check is changed
+      - set_single_actual_check.stdout_lines == []
 
-- name: set a single IPv4 address
-  win_dns_client:
+- name: Set a single IPv4 address
+  ansible.windows.win_dns_client:
     adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses: 192.168.34.5
   register: set_single
 
-- name: get result of set a single IPv4 address
-  win_shell: '{{ get_ip_script }}'
-  changed_when: no
+- name: Get result of set a single IPv4 address
+  ansible.windows.win_shell: '{{ get_ip_script }}'
+  changed_when: false
   register: set_single_actual
 
-- name: assert set a single IPv4 address
-  assert:
+- name: Assert set a single IPv4 address
+  ansible.builtin.assert:
     that:
-    - set_single is changed
-    - set_single_actual.stdout_lines == ["192.168.34.5"]
+      - set_single is changed
+      - set_single_actual.stdout_lines == ["192.168.34.5"]
 
-- name: set a single IPv4 address (idempotent)
-  win_dns_client:
+- name: Set a single IPv4 address (idempotent)
+  ansible.windows.win_dns_client:
     adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses: 192.168.34.5
   register: set_single_again
 
-- name: assert set a single IPv4 address (idempotent)
-  assert:
+- name: Assert set a single IPv4 address (idempotent)
+  ansible.builtin.assert:
     that:
-    - not set_single_again is changed
+      - not set_single_again is changed
 
-- name: change IPv4 address to another value (check mode)
-  win_dns_client:
+- name: Change IPv4 address to another value (check mode)
+  ansible.windows.win_dns_client:
     adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses: 192.168.34.6
   register: change_single_check
-  check_mode: yes
+  check_mode: true
 
-- name: get result of change IPv4 address to another value (check mode)
-  win_shell: '{{ get_ip_script }}'
-  changed_when: no
+- name: Get result of change IPv4 address to another value (check mode)
+  ansible.windows.win_shell: '{{ get_ip_script }}'
+  changed_when: false
   register: check_single_actual_check
 
-- name: assert change IPv4 address to another value (check mode)
-  assert:
+- name: Assert change IPv4 address to another value (check mode)
+  ansible.builtin.assert:
     that:
-    - change_single_check is changed
-    - check_single_actual_check.stdout_lines == ["192.168.34.5"]
+      - change_single_check is changed
+      - check_single_actual_check.stdout_lines == ["192.168.34.5"]
 
-- name: change IPv4 address to another value
-  win_dns_client:
+- name: Change IPv4 address to another value
+  ansible.windows.win_dns_client:
     adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses: 192.168.34.6
   register: change_single
 
-- name: get result of change IPv4 address to another value
-  win_shell: '{{ get_ip_script }}'
-  changed_when: no
+- name: Get result of change IPv4 address to another value
+  ansible.windows.win_shell: '{{ get_ip_script }}'
+  changed_when: false
   register: check_single_actual
 
-- name: assert change IPv4 address to another value
-  assert:
+- name: Assert change IPv4 address to another value
+  ansible.builtin.assert:
     that:
-    - change_single is changed
-    - check_single_actual.stdout_lines == ["192.168.34.6"]
+      - change_single is changed
+      - check_single_actual.stdout_lines == ["192.168.34.6"]
 
-- name: set multiple IPv4 addresses (check mode)
-  win_dns_client:
+- name: Set multiple IPv4 addresses (check mode)
+  ansible.windows.win_dns_client:
     adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses:
-    - 192.168.34.7
-    - 192.168.34.8
+      - 192.168.34.7
+      - 192.168.34.8
   register: set_multiple_check
-  check_mode: yes
+  check_mode: true
 
-- name: get result of set multiple IPv4 addresses (check mode)
-  win_shell: '{{ get_ip_script }}'
-  changed_when: no
+- name: Get result of set multiple IPv4 addresses (check mode)
+  ansible.windows.win_shell: '{{ get_ip_script }}'
+  changed_when: false
   register: set_multiple_actual_check
 
-- name: assert set multiple IPv4 addresses (check mode)
-  assert:
+- name: Assert set multiple IPv4 addresses (check mode)
+  ansible.builtin.assert:
     that:
-    - set_multiple_check is changed
-    - set_multiple_actual_check.stdout_lines == ["192.168.34.6"]
+      - set_multiple_check is changed
+      - set_multiple_actual_check.stdout_lines == ["192.168.34.6"]
 
-- name: set multiple IPv4 addresses
-  win_dns_client:
+- name: Set multiple IPv4 addresses
+  ansible.windows.win_dns_client:
     adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses:
-    - 192.168.34.7
-    - 192.168.34.8
+      - 192.168.34.7
+      - 192.168.34.8
   register: set_multiple
 
-- name: get result of set multiple IPv4 addresses
-  win_shell: '{{ get_ip_script }}'
-  changed_when: no
+- name: Get result of set multiple IPv4 addresses
+  ansible.windows.win_shell: '{{ get_ip_script }}'
+  changed_when: false
   register: set_multiple_actual
 
-- name: assert set multiple IPv4 addresses
-  assert:
+- name: Assert set multiple IPv4 addresses
+  ansible.builtin.assert:
     that:
-    - set_multiple is changed
-    - set_multiple_actual.stdout_lines == ["192.168.34.7", "192.168.34.8"]
+      - set_multiple is changed
+      - set_multiple_actual.stdout_lines == ["192.168.34.7", "192.168.34.8"]
 
-- name: set multiple IPv4 addresses (idempotent)
-  win_dns_client:
+- name: Set multiple IPv4 addresses (idempotent)
+  ansible.windows.win_dns_client:
     adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses:
-    - 192.168.34.7
-    - 192.168.34.8
+      - 192.168.34.7
+      - 192.168.34.8
   register: set_multiple_again
 
-- name: assert set multiple IPv4 addresses (idempotent)
-  assert:
+- name: Assert set multiple IPv4 addresses (idempotent)
+  ansible.builtin.assert:
     that:
-    - not set_multiple_again is changed
+      - not set_multiple_again is changed
 
-- name: reset IPv4 DNS back to DHCP (check mode)
-  win_dns_client:
+- name: Reset IPv4 DNS back to DHCP (check mode)
+  ansible.windows.win_dns_client:
     adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses: []
   register: set_dhcp_check
-  check_mode: yes
+  check_mode: true
 
-- name: get result of reset IPv4 DNS back to DHCP (check mode)
-  win_shell: '{{ get_ip_script }}'
-  changed_when: no
+- name: Get result of reset IPv4 DNS back to DHCP (check mode)
+  ansible.windows.win_shell: '{{ get_ip_script }}'
+  changed_when: false
   register: set_dhcp_actual_check
 
-- name: assert reset IPv4 DNS back to DHCP (check mode)
-  assert:
+- name: Assert reset IPv4 DNS back to DHCP (check mode)
+  ansible.builtin.assert:
     that:
-    - set_dhcp_check is changed
-    - set_dhcp_actual_check.stdout_lines == ["192.168.34.7", "192.168.34.8"]
+      - set_dhcp_check is changed
+      - set_dhcp_actual_check.stdout_lines == ["192.168.34.7", "192.168.34.8"]
 
-- name: reset IPv4 DNS back to DHCP
-  win_dns_client:
+- name: Reset IPv4 DNS back to DHCP
+  ansible.windows.win_dns_client:
     adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses: []
   register: set_dhcp
 
-- name: get result of reset IPv4 DNS back to DHCP
-  win_shell: '{{ get_ip_script }}'
-  changed_when: no
+- name: Get result of reset IPv4 DNS back to DHCP
+  ansible.windows.win_shell: '{{ get_ip_script }}'
+  changed_when: false
   register: set_dhcp_actual
 
-- name: assert reset IPv4 DNS back to DHCP
-  assert:
+- name: Assert reset IPv4 DNS back to DHCP
+  ansible.builtin.assert:
     that:
-    - set_dhcp is changed
-    - set_dhcp_actual.stdout_lines == []
+      - set_dhcp is changed
+      - set_dhcp_actual.stdout_lines == []
 
-- name: reset IPv4 DNS back to DHCP (idempotent)
-  win_dns_client:
+- name: Reset IPv4 DNS back to DHCP (idempotent)
+  ansible.windows.win_dns_client:
     adapter_names: '{{ network_adapter_name }}'
     ipv4_addresses: []
   register: set_dhcp_again
 
-- name: assert reset IPv4 DNS back to DHCP (idempotent)
-  assert:
+- name: Assert reset IPv4 DNS back to DHCP (idempotent)
+  ansible.builtin.assert:
     that:
       - set_dhcp_again is not changed
 
 # Legacy WMI does not support setting IPv6 addresses so we can only test this on newer hosts that have the new cmdlets
-- name: check if server supports IPv6
-  win_shell: if (Get-Command -Name Get-NetAdapter -ErrorAction SilentlyContinue) { $true } else { $false }
-  changed_when: no
+- name: Check if server supports IPv6
+  ansible.windows.win_shell: if (Get-Command -Name Get-NetAdapter -ErrorAction SilentlyContinue) { $true } else { $false }
+  changed_when: false
   register: new_os
 
-- name: run IPv6 tests
+- name: Run IPv6 tests in a block
   when: new_os.stdout | trim | bool
   block:
-  - name: set IPv6 DNS address
-    win_dns_client:
-      adapter_names: '{{ network_adapter_name }}'
-      dns_servers:
-      - 192.168.34.7
-      - 192.168.34.8
-      - 2001:db8::1
-      - 2001:db8::2
-    register: set_ipv6
+    - name: Set IPv6 DNS address
+      ansible.windows.win_dns_client:
+        adapter_names: '{{ network_adapter_name }}'
+        dns_servers:
+          - 192.168.34.7
+          - 192.168.34.8
+          - 2001:db8::1
+          - 2001:db8::2
+      register: set_ipv6
 
-  - name: get result of set IPv6 DNS address
-    win_shell: (Get-DnsClientServerAddress -InterfaceAlias '{{ network_adapter_name }}').ServerAddresses
-    changed_when: no
-    register: set_ipv6_actual
+    - name: Get result of set IPv6 DNS address
+      ansible.windows.win_shell: (Get-DnsClientServerAddress -InterfaceAlias '{{ network_adapter_name }}').ServerAddresses
+      changed_when: false
+      register: set_ipv6_actual
 
-  - name: assert set IPv6 DNS address
-    assert:
-      that:
-      - set_ipv6 is changed
-      - set_ipv6_actual.stdout_lines == ['192.168.34.7', '192.168.34.8', '2001:db8::1', '2001:db8::2']
+    - name: Assert set IPv6 DNS address
+      ansible.builtin.assert:
+        that:
+          - set_ipv6 is changed
+          - set_ipv6_actual.stdout_lines == ['192.168.34.7', '192.168.34.8', '2001:db8::1', '2001:db8::2']
 
-  - name: set IPv6 DNS address (idempotent)
-    win_dns_client:
-      adapter_names: '{{ network_adapter_name }}'
-      dns_servers:
-      - 192.168.34.7
-      - 192.168.34.8
-      - 2001:db8::1
-      - 2001:db8::2
-    register: set_ipv6_again
+    - name: Set IPv6 DNS address (idempotent)
+      ansible.windows.win_dns_client:
+        adapter_names: '{{ network_adapter_name }}'
+        dns_servers:
+          - 192.168.34.7
+          - 192.168.34.8
+          - 2001:db8::1
+          - 2001:db8::2
+      register: set_ipv6_again
 
-  - name: assert set IPv6 DNS address (idempotent)
-    assert:
-      that:
-      - not set_ipv6_again is changed
+    - name: Assert set IPv6 DNS address (idempotent)
+      ansible.builtin.assert:
+        that:
+          - not set_ipv6_again is changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed the errors and warning that came from ansible-lint for win_dns_client integration test
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_dns_client
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
Ref:
Partially fixes #671 