### PR TITLE
Add 2.18 back into the Sanity versions for CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -56,6 +56,19 @@ stages:
               test: units
             - name: Lint
               test: lint
+  - stage: Ansible_2_18
+    displayName: Ansible 2.18
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: '{0}'
+          testFormat: '2.18/{0}'
+          targets:
+            - name: Sanity
+              test: sanity
+            - name: Units
+              test: units
   - stage: Ansible_2_17
     displayName: Ansible 2.17
     dependsOn: []
@@ -156,6 +169,7 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_18
       - Ansible_2_17
       - Ansible_2_16
       - Ansible_2_15


### PR DESCRIPTION
##### SUMMARY
Adds 2.18 back into the versions tests for the sanity checks now that devel has been bumped to 2.19.

##### ISSUE TYPE
- Bugfix Pull Request