### PR TITLE
Remove ansbile-lint warnings/errors from win_domain_membership

### DIFF
--- a/tests/integration/targets/win_domain_membership/tasks/main.yml
+++ b/tests/integration/targets/win_domain_membership/tasks/main.yml
@@ -1,20 +1,22 @@
 ---
-- name: get current workgroup
-  win_shell: (Get-WmiObject Win32_ComputerSystem).Workgroup
+- name: Get current workgroup
+  ansible.windows.win_shell: (Get-WmiObject Win32_ComputerSystem).Workgroup
   register: workgroup
 
-- name: fail if workgroup result is empty (means test host is in a domain)
-  fail:
+- name: Fail if workgroup result is empty (means test host is in a domain)
+  ansible.builtin.fail:
     msg: Cannot run tests for win_domain_membership when host is a member of a domain
   when: workgroup.stdout == ""
 
-- block:
-  - include_tasks: tests.yml
+- name: Run win_domain_membership tests
+  block:
+    - name: Include test.yml
+      ansible.builtin.include_tasks: tests.yml
 
   always:
-  - name: revert workgroup back to original before tests
-    win_domain_membership:
-      workgroup_name: '{{workgroup.stdout_lines[0]}}'
-      state: workgroup
-      domain_admin_user: fake user
-      domain_admin_password: fake password
+    - name: Revert workgroup back to original before tests
+      ansible.windows.win_domain_membership:
+        workgroup_name: '{{ workgroup.stdout_lines[0] }}'
+        state: workgroup
+        domain_admin_user: fake user
+        domain_admin_password: fake password

--- a/tests/integration/targets/win_domain_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_domain_membership/tasks/tests.yml
@@ -1,56 +1,56 @@
 ---
-- name: change workgroup (check mode)
-  win_domain_membership:
+- name: Change workgroup (check mode)
+  ansible.windows.win_domain_membership:
     workgroup_name: ANSIBLETEST
     state: workgroup
     domain_admin_user: fake user
     domain_admin_password: fake password
   register: change_workgroup_check
-  check_mode: yes
+  check_mode: true
 
-- name: get result of change workgroup (check mode)
-  win_shell: (Get-WmiObject Win32_ComputerSystem).Workgroup
+- name: Get result of change workgroup (check mode)
+  ansible.windows.win_shell: (Get-WmiObject Win32_ComputerSystem).Workgroup
   register: change_workgroup_result_check
 
-- name: assert result of change workgroup (check mode)
-  assert:
+- name: Assert result of change workgroup (check mode)
+  ansible.builtin.assert:
     that:
-    - change_workgroup_check is changed
-    - change_workgroup_result_check.stdout == workgroup.stdout
+      - change_workgroup_check is changed
+      - change_workgroup_result_check.stdout == workgroup.stdout
 
-- name: change workgroup
-  win_domain_membership:
+- name: Change workgroup
+  ansible.windows.win_domain_membership:
     workgroup_name: ANSIBLETEST
     state: workgroup
     domain_admin_user: fake user
     domain_admin_password: fake password
   register: change_workgroup
 
-- name: get result of change workgroup
-  win_shell: (Get-WmiObject Win32_ComputerSystem).Workgroup
+- name: Get result of change workgroup
+  ansible.windows.win_shell: (Get-WmiObject Win32_ComputerSystem).Workgroup
   register: change_workgroup_result
 
-- name: assert result of change workgroup
-  assert:
+- name: Assert result of change workgroup
+  ansible.builtin.assert:
     that:
-    - change_workgroup is changed
-    - change_workgroup_result.stdout_lines[0] == "ANSIBLETEST"
+      - change_workgroup is changed
+      - change_workgroup_result.stdout_lines[0] == "ANSIBLETEST"
 
-- name: change workgroup (idempotent)
-  win_domain_membership:
+- name: Change workgroup (idempotent)
+  ansible.windows.win_domain_membership:
     workgroup_name: ANSIBLETEST
     state: workgroup
     domain_admin_user: fake user
     domain_admin_password: fake password
   register: change_workgroup_again
 
-- name: assert result of change workgroup (idempotent)
-  assert:
+- name: Assert result of change workgroup (idempotent)
+  ansible.builtin.assert:
     that:
-    - change_workgroup_again is not changed
+      - change_workgroup_again is not changed
 
-- name: change workgroup fail invalid name
-  win_domain_membership:
+- name: Change workgroup fail invalid name
+  ansible.windows.win_domain_membership:
     workgroup_name: ANSIBLELONGNAMEFAILURE
     state: workgroup
     domain_admin_user: fake user


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixed the errors and warning that came from ansible-lint for win_domain_membership integration test
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_domain_membership
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
Ref:
Partially fixes #671 

Note:
This one is not a new PR but rather a fix of one I created 2 days ago.