### PR TITLE
setup - Add ansible_os_install_date fact

### DIFF
--- a/changelogs/fragments/setup-install-date.yml
+++ b/changelogs/fragments/setup-install-date.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - >-
+    setup - Added ``ansible_os_install_date`` as the OS installation date in the ISO 8601 format
+    ``yyyy-MM-ddTHH:mm:ssZ``. This date is represented in the UTC timezone -
+    https://github.com/ansible-collections/ansible.windows/issues/663

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -652,7 +652,7 @@ $factMeta = @(
 
             $osInfoParams = @{
                 LiteralPath = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion'
-                Name = 'InstallationType'
+                Name = 'InstallationType', 'InstallTime'
                 ErrorAction = 'SilentlyContinue'
             }
             $osInfo = Get-ItemProperty @osInfoParams
@@ -664,6 +664,11 @@ $factMeta = @(
             $ansibleFacts.ansible_os_name = $null
             $ansibleFacts.ansible_os_product_type = $productType
             $ansibleFacts.ansible_os_installation_type = $osInfo.InstallationType
+            $ansibleFacts.ansible_os_install_date = $null
+            if ($osInfo.InstallTime) {
+                $installDate = [DateTime]::FromFileTimeUtc($osInfo.InstallTime)
+                $ansibleFacts.ansible_os_install_date = $installDate.ToString("yyyy-MM-ddTHH:mm:ssZ")
+            }
 
             # We cannot call WMI if we aren't an admin (on a network logon), conditionally set these facts.
             $currentUser = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()


### PR DESCRIPTION
##### SUMMARY
Adds the ansible_os_install_date fact that contains the OS installation date as an ISO 8601 string value.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/663

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
setup