### PR TITLE
Migrate win_dns_record module to ansible.windows repo from ansible.community repo

### DIFF
--- a/plugins/modules/win_dns_record.ps1
+++ b/plugins/modules/win_dns_record.ps1
@@ -1,0 +1,225 @@
+#!powershell
+# Copyright: (c) 2021 Sebastian Gruber ,dacoso GmbH All Rights Reserved.
+# Copyright: (c) 2019, Hitachi ID Systems, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    options = @{
+        name = @{ type = "str"; required = $true }
+        port = @{ type = "int" }
+        priority = @{ type = "int" }
+        state = @{ type = "str"; choices = "absent", "present"; default = "present" }
+        ttl = @{ type = "int"; default = "3600" }
+        aging = @{ type = "bool"; default = $false }
+        type = @{ type = "str"; choices = "A", "AAAA", "CNAME", "DHCID", "NS", "PTR", "SRV", "TXT"; required = $true }
+        value = @{ type = "list"; elements = "str"; default = @() ; aliases = @( 'values' ) }
+        weight = @{ type = "int" }
+        zone = @{ type = "str"; required = $true }
+        zone_scope = @{ type = "str" }
+        computer_name = @{ type = "str" }
+    }
+    required_if = @(, @("type", "SRV", @("port", "priority", "weight")))
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+$name = $module.Params.name
+$port = $module.Params.port
+$priority = $module.Params.priority
+$state = $module.Params.state
+$ttl = $module.Params.ttl
+$aging = $module.Params.aging
+$type = $module.Params.type
+$values = $module.Params.value
+$weight = $module.Params.weight
+$zone = $module.Params.zone
+$zone_scope = $module.Params.zone_scope
+$dns_computer_name = $module.Params.computer_name
+
+$extra_args = @{}
+$extra_args_new_records = @{}
+
+if ($null -ne $dns_computer_name) {
+    $extra_args.ComputerName = $dns_computer_name
+}
+if ($null -ne $zone_scope) {
+    $extra_args.ZoneScope = $zone_scope
+}
+if ($aging -eq $true) {
+    $extra_args_new_records.AgeRecord = $true
+}
+
+if ($state -eq 'present') {
+    if ($values.Count -eq 0) {
+        $module.FailJson("Parameter 'values' must be non-empty when state='present'")
+    }
+}
+else {
+    if ($values.Count -ne 0) {
+        $module.FailJson("Parameter 'values' must be undefined or empty when state='absent'")
+    }
+}
+
+# TODO: add warning for forest minTTL override -- see https://docs.microsoft.com/en-us/windows/desktop/ad/configuration-of-ttl-limits
+if ($ttl -lt 1 -or $ttl -gt 31557600) {
+    $module.FailJson("Parameter 'ttl' must be between 1 and 31557600")
+}
+
+$ttl = New-TimeSpan -Seconds $ttl
+
+if (($type -eq 'CNAME' -or $type -eq 'NS' -or $type -eq 'PTR' -or $type -eq 'SRV') -and $null -ne $values -and $values.Count -gt 0 -and $zone[-1] -ne '.') {
+    # CNAMEs and PTRs should be '.'-terminated, or record matching will fail
+    $values = $values | ForEach-Object {
+        if ($_ -Like "*.") { $_ } else { "$_." }
+    }
+}
+
+$record_argument_name = @{
+    A = "IPv4Address"
+    AAAA = "IPv6Address"
+    CNAME = "HostNameAlias"
+    DHCID = "DhcpIdentifier"
+    # MX = "MailExchange"
+    NS = "NameServer"
+    PTR = "PtrDomainName"
+    SRV = "DomainName"
+    TXT = "DescriptiveText"
+}[$type]
+
+function Get-DnsServerResourceRecordDataPropertyName {
+    Switch -Exact ($type) {
+        'DHCID' {
+            'DhcId'
+        }
+        default {
+            $record_argument_name
+        }
+    }
+}
+
+$changes = @{
+    before = ""
+    after = ""
+}
+
+$records = Get-DnsServerResourceRecord -ZoneName $zone -Name $name -RRType $type -Node -ErrorAction:Ignore @extra_args | Sort-Object
+
+if ($null -ne $records) {
+    # We use [Hashtable]$required_values below as a set rather than a map.
+    # It provides quick lookup to test existing DNS record against. By removing
+    # items as each is processed, whatever remains at the end is missing
+    # content (that needs to be added).
+    $required_values = @{}
+    foreach ($value in $values) {
+        $required_values[$value.ToString()] = $null
+    }
+
+    foreach ($record in $records) {
+        # check, if record is aging
+        $record_aging_old = ($null -ne $record.Timestamp)
+
+        $record_value = $record.RecordData.$(Get-DnsServerResourceRecordDataPropertyName).ToString()
+        if ((-Not $required_values.ContainsKey($record_value)) -Or (-Not $record_aging_old -eq $aging)) {
+            $record | Remove-DnsServerResourceRecord -ZoneName $zone -Force -WhatIf:$module.CheckMode @extra_args
+            $changes.before += "[$zone{0}] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN $type $record_value`n" `
+                -f ("", "/$zone_scope")[$null -ne $zone_scope]
+            $module.Result.changed = $true
+        }
+        else {
+            if ($type -eq 'SRV') {
+                $record_port_old = $record.RecordData.Port.ToString()
+                $record_priority_old = $record.RecordData.Priority.ToString()
+                $record_weight_old = $record.RecordData.Weight.ToString()
+
+                if ($record.TimeToLive -ne $ttl -or $port -ne $record_port_old -or $priority -ne $record_priority_old -or $weight -ne $record_weight_old) {
+                    $new_record = $record.Clone()
+                    $new_record.TimeToLive = $ttl
+                    $new_record.RecordData.Port = $port
+                    $new_record.RecordData.Priority = $priority
+                    $new_record.RecordData.Weight = $weight
+                    Set-DnsServerResourceRecord -ZoneName $zone -OldInputObject $record -NewInputObject $new_record -WhatIf:$module.CheckMode @extra_args
+
+                    $changes.before += -join @(
+                        "[$zone{0}] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN " `
+                            -f ("", "/$zone_scope")[$null -ne $zone_scope]
+                        "$type $record_value $record_port_old $record_weight_old $record_priority_old`n"
+                    )
+                    $changes.after += "[$zone{0}] $($record.HostName) $($ttl.TotalSeconds) IN $type $record_value $port $weight $priority`n" `
+                        -f ("", "/$zone_scope")[$null -ne $zone_scope]
+                    $module.Result.changed = $true
+                }
+            }
+            else {
+                # This record matches one of the values; but does it match the TTL?
+                if ($record.TimeToLive -ne $ttl) {
+                    $new_record = $record.Clone()
+                    $new_record.TimeToLive = $ttl
+                    Set-DnsServerResourceRecord -ZoneName $zone -OldInputObject $record -NewInputObject $new_record -WhatIf:$module.CheckMode @extra_args
+                    $changes.before += "[$zone{0}] $($record.HostName) $($record.TimeToLive.TotalSeconds) IN $type $record_value`n" `
+                        -f ("", "/$zone_scope")[$null -ne $zone_scope]
+                    $changes.after += "[$zone{0}] $($record.HostName) $($ttl.TotalSeconds) IN $type $record_value`n" `
+                        -f ("", "/$zone_scope")[$null -ne $zone_scope]
+                    $module.Result.changed = $true
+                }
+            }
+            # Cross this one off the list, so we don't try adding it late
+            $required_values.Remove($record_value)
+            # Whatever is left in $required_values needs to be added
+            $values = $required_values.Keys
+        }
+    }
+}
+
+if ($null -ne $values -and $values.Count -gt 0) {
+    foreach ($value in $values) {
+        $splat_args = @{ $type = $true; $record_argument_name = $value }
+        $module.Result.debug_splat_args = $splat_args
+        $srv_args = @{
+            DomainName = $value
+            Weight = $weight
+            Priority = $priority
+            Port = $port
+        }
+        try {
+            if ($type -eq 'SRV') {
+                Add-DnsServerResourceRecord -SRV -Name $name -ZoneName $zone @srv_args @extra_args @extra_args_new_records -WhatIf:$module.CheckMode
+            }
+            else {
+                Add-DnsServerResourceRecord -Name $name -AllowUpdateAny -ZoneName $zone -TimeToLive $ttl @splat_args -WhatIf:$module.CheckMode `
+                    @extra_args @extra_args_new_records
+            }
+        }
+        catch {
+            $module.FailJson("Error adding DNS $type resource $name in zone $zone with value $value", $_)
+        }
+        $changes.after += "[$zone{0}] $name $($ttl.TotalSeconds) IN $type $value`n" `
+            -f ("", "/$zone_scope")[$null -ne $zone_scope]
+    }
+    $module.Result.changed = $true
+}
+
+if ($module.CheckMode) {
+    # Simulated changes
+    $module.Diff.before = $changes.before
+    $module.Diff.after = $changes.after
+}
+else {
+    # Real changes
+    $records_end = Get-DnsServerResourceRecord -ZoneName $zone -Name $name -RRType $type -Node -ErrorAction:Ignore @extra_args | Sort-Object
+    $module.Diff.before = @(
+        $records | ForEach-Object {
+            "[$zone{0}] $($_.HostName) $($_.TimeToLive.TotalSeconds) IN $type $($_.RecordData.$(Get-DnsServerResourceRecordDataPropertyName).ToString())`n" `
+                -f ("", "/$zone_scope")[$null -ne $zone_scope]
+        }
+    ) -join ''
+    $module.Diff.after = @(
+        $records_end | ForEach-Object {
+            "[$zone{0}] $($_.HostName) $($_.TimeToLive.TotalSeconds) IN $type $($_.RecordData.$(Get-DnsServerResourceRecordDataPropertyName).ToString())`n" `
+                -f ("", "/$zone_scope")[$null -ne $zone_scope]
+        }
+    ) -join ''
+}
+
+$module.ExitJson()

--- a/plugins/modules/win_dns_record.py
+++ b/plugins/modules/win_dns_record.py
@@ -1,0 +1,212 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021 Sebastian Gruber ,dacoso GmbH All Rights Reserved.
+# Copyright: (c) 2019, Hitachi ID Systems, Inc.
+# SPDX-License-Identifier: GPL-3.0-only
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r'''
+---
+module: win_dns_record
+short_description: Manage Windows Server DNS records
+description:
+- Manage DNS records within an existing Windows Server DNS zone.
+version_added: 2.6.0
+author:
+ - Sebastian Gruber (@sgruber94)
+ - John Nelson (@johnboy2)
+requirements:
+  - This module requires Windows 8, Server 2012, or newer.
+options:
+  name:
+    description:
+    - The name of the record.
+    required: yes
+    type: str
+  port:
+    description:
+    - The port number of the record.
+    - Required when C(type=SRV).
+    - Supported only for C(type=SRV).
+    type: int
+  priority:
+    description:
+    - The priority number for each service in SRV record.
+    - Required when C(type=SRV).
+    - Supported only for C(type=SRV).
+    type: int
+  state:
+    description:
+    - Whether the record should exist or not.
+    choices: [ absent, present ]
+    default: present
+    type: str
+  ttl:
+    description:
+    - The "time to live" of the record, in seconds.
+    - Ignored when C(state=absent).
+    - Valid range is 1 - 31557600.
+    - Note that an Active Directory forest can specify a minimum TTL, and will
+      dynamically "round up" other values to that minimum.
+    default: 3600
+    type: int
+  aging:
+    description:
+    - Should aging be activated for the record.
+    - If set to C(false), the record will be static.
+    default: false
+    type: bool
+  type:
+    description:
+    - The type of DNS record to manage.
+    - C(SRV) was added in the 1.0.0 release of this collection.
+    - C(NS) was added in the 1.1.0 release of this collection.
+    - C(TXT) was added in the 1.6.0 release of this collection.
+    - C(DHCID) was added in the 1.12.0 release of this collection.
+    choices: [ A, AAAA, CNAME, DHCID, NS, PTR, SRV, TXT ]
+    required: yes
+    type: str
+  value:
+    description:
+    - The value(s) to specify. Required when C(state=present).
+    - When C(type=PTR) only the partial part of the IP should be given.
+    - Multiple values can be passed when C(type=NS)
+    aliases: [ values ]
+    default: []
+    type: list
+    elements: str
+  weight:
+    description:
+    - Weightage given to each service record in SRV record.
+    - Required when C(type=SRV).
+    - Supported only for C(type=SRV).
+    type: int
+  zone:
+    description:
+    - The name of the zone to manage (eg C(example.com)).
+    - The zone must already exist.
+    required: yes
+    type: str
+  zone_scope:
+    description:
+    - The name of the zone scope to manage (eg C(ScopeAZ)).
+    - The zone must already exist.
+    required: no
+    type: str
+  computer_name:
+    description:
+      - Specifies a DNS server.
+      - You can specify an IP address or any value that resolves to an IP
+        address, such as a fully qualified domain name (FQDN), host name, or
+        NETBIOS name.
+    type: str
+'''
+
+EXAMPLES = r'''
+# Demonstrate creating a matching A and PTR record.
+
+- name: Create database server record
+  ansible.windows.win_dns_record:
+    name: "cgyl1404p"
+    type: "A"
+    value: "10.1.1.1"
+    zone: "amer.example.com"
+
+- name: Create matching PTR record
+  ansible.windows.win_dns_record:
+    name: "1.1.1"
+    type: "PTR"
+    value: "db1"
+    zone: "10.in-addr.arpa"
+
+# Demonstrate replacing an A record with a CNAME
+
+- name: Remove static record
+  ansible.windows.win_dns_record:
+    name: "db1"
+    type: "A"
+    state: absent
+    zone: "amer.example.com"
+
+- name: Create database server alias
+  ansible.windows.win_dns_record:
+    name: "db1"
+    type: "CNAME"
+    value: "cgyl1404p.amer.example.com"
+    zone: "amer.example.com"
+
+# Demonstrate creating multiple A records for the same name
+
+- name: Create multiple A record values for www
+  ansible.windows.win_dns_record:
+    name: "www"
+    type: "A"
+    values:
+      - 10.0.42.5
+      - 10.0.42.6
+      - 10.0.42.7
+    zone: "example.com"
+
+# Demonstrates a partial update (replace some existing values with new ones)
+# for a pre-existing name
+
+- name: Update www host with new addresses
+  ansible.windows.win_dns_record:
+    name: "www"
+    type: "A"
+    values:
+      - 10.0.42.5  # this old value was kept (others removed)
+      - 10.0.42.12  # this new value was added
+    zone: "example.com"
+
+# Demonstrate creating a SRV record
+
+- name: Creating a SRV record with port number and priority
+  ansible.windows.win_dns_record:
+    name: "test"
+    priority: 5
+    port: 995
+    state: present
+    type: "SRV"
+    weight: 2
+    value: "amer.example.com"
+    zone: "example.com"
+
+# Demonstrate creating a NS record with multiple values
+
+- name: Creating NS record
+  ansible.windows.win_dns_record:
+    name: "ansible.prog"
+    state: present
+    type: "NS"
+    values:
+      - 10.0.0.1
+      - 10.0.0.2
+      - 10.0.0.3
+      - 10.0.0.4
+    zone: "example.com"
+
+# Demonstrate creating a TXT record
+
+- name: Creating a TXT record with descriptive Text
+  ansible.windows.win_dns_record:
+    name: "test"
+    state: present
+    type: "TXT"
+    value: "justavalue"
+    zone: "example.com"
+
+# Demostrate creating a A record to Zone Scope
+
+- name: Create database server record
+  ansible.windows.win_dns_record:
+    name: "cgyl1404p.amer.example.com"
+    type: "A"
+    value: "10.1.1.1"
+    zone: "amer.example.com"
+    zone_scope: "external"
+'''
+
+RETURN = r'''
+'''

--- a/tests/integration/targets/win_dns_record/aliases
+++ b/tests/integration/targets/win_dns_record/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group3

--- a/tests/integration/targets/win_dns_record/defaults/main.yml
+++ b/tests/integration/targets/win_dns_record/defaults/main.yml
@@ -1,0 +1,4 @@
+win_dns_record_zone: test.ansible.local
+win_dns_record_revzone: 0.0.255.in-addr.arpa
+win_dns_record_revzone_network: 255.0.0.0/24
+win_dns_zone_scope: external

--- a/tests/integration/targets/win_dns_record/tasks/clean.yml
+++ b/tests/integration/targets/win_dns_record/tasks/clean.yml
@@ -1,0 +1,17 @@
+- name: Remove test zone, if present
+  ansible.windows.win_shell: |
+    $zone = '{{ item }}'
+    $fail_on_missing = '{{ fail_on_missing | default(true) }}'
+
+    Trap { If (-not $fail_on_missing) { continue } }
+    Remove-DnsServerZone -Name $zone -Force
+    
+    # win_file could also do this, but it would need to know where the
+    # SystemRoot is located via fact gathering, which we cannot assume.
+    Trap { If (-not $fail_on_missing) { continue } }
+    Remove-Item -Path $env:SystemRoot\system32\dns\$zone.dns
+
+    $true  # so pipeline exits cleanly if an error was ignored above
+  loop:
+    - '{{ win_dns_record_zone }}'
+    - '{{ win_dns_record_revzone }}'

--- a/tests/integration/targets/win_dns_record/tasks/main.yml
+++ b/tests/integration/targets/win_dns_record/tasks/main.yml
@@ -1,0 +1,12 @@
+# We do an explicit OS version check here *INSTEAD OF* the usual test for
+# cmdlet existence. That's because a cmdlet test here won't work without first
+# installing the DNS feature, but we don't want to install the feature on OS'
+# that can't be supported anyway. Hence this fallback to an explicit OS version
+# test.
+- name: check OS version is supported
+  ansible.windows.win_shell: 'if ([Environment]::OSVersion.Version -ge [Version]"6.2") { $true } else { $false }'
+  register: os_supported
+
+- name: run tests on supported hosts
+  import_tasks: tests.yml
+  when: os_supported.stdout | trim | bool

--- a/tests/integration/targets/win_dns_record/tasks/tests-A.yml
+++ b/tests/integration/targets/win_dns_record/tasks/tests-A.yml
@@ -1,0 +1,329 @@
+- name: 'TYPE=A - creation (check mode)'
+  win_dns_record:
+    { zone: '{{ win_dns_record_zone }}', name: test1, value: 1.2.3.4, type: A }
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=A - creation get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType A -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=A - creation check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=A - creation'
+  win_dns_record:
+    { zone: '{{ win_dns_record_zone }}', name: test1, value: 1.2.3.4, type: A }
+  register: cmd_result
+
+- name: 'TYPE=A - creation get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType A -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty IPv4Address | Select -ExpandProperty IPAddressToString"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=A - creation check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '1.2.3.4\r\n'
+
+- name: 'TYPE=A - creation (idempotent)'
+  win_dns_record:
+    { zone: '{{ win_dns_record_zone }}', name: test1, value: 1.2.3.4, type: A }
+  register: cmd_result
+
+- name: 'TYPE=A - creation get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType A -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty IPv4Address | Select -ExpandProperty IPAddressToString"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=A - creation check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == '1.2.3.4\r\n'
+
+- name: 'TYPE=A - Add Zone Scope'
+  ansible.windows.win_shell: Add-DnsServerZoneScope -ZoneName '{{ win_dns_record_zone }}' -Name '{{ win_dns_zone_scope }}'
+
+- name: 'TYPE=A - creation zone scope '
+  win_dns_record:
+    { zone: '{{ win_dns_record_zone }}', name: test1, value: 5.6.7.8, type: A, zone_scope: '{{ win_dns_zone_scope }}'}
+  register: cmd_result
+
+- name: 'TYPE=A - creation get results zone scope'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -ZoneScope '{{ win_dns_zone_scope }}' -Name 'test1' -RRType A -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty IPv4Address | Select -ExpandProperty IPAddressToString"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=A - creation check results zone scope'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '5.6.7.8\r\n'
+
+- name: 'TYPE=A - creation zone scope (idempotent)'
+  win_dns_record:
+    { zone: '{{ win_dns_record_zone }}', name: test1, value: 5.6.7.8, type: A, zone_scope: '{{ win_dns_zone_scope }}' }
+  register: cmd_result
+
+- name: 'TYPE=A - creation get results zone scope (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -ZoneScope '{{ win_dns_zone_scope }}' -Name 'test1' -RRType A -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty IPv4Address | Select -ExpandProperty IPAddressToString"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=A - creation check results zone scope (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == '5.6.7.8\r\n'
+
+- name: 'TYPE=A - update address (check mode)'
+  win_dns_record:
+    { zone: '{{ win_dns_record_zone }}', name: test1, value: 5.6.7.8, type: A }
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=A - update address get results (check mode)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType A -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty IPv4Address | Select -ExpandProperty IPAddressToString"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=A - update address check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '1.2.3.4\r\n'
+
+- name: 'TYPE=A - update address'
+  win_dns_record:
+    { zone: '{{ win_dns_record_zone }}', name: test1, value: 5.6.7.8, type: A }
+  register: cmd_result
+
+- name: 'TYPE=A - update address get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType A -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty IPv4Address | Select -ExpandProperty IPAddressToString"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=A - update address check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '5.6.7.8\r\n'
+
+- name: 'TYPE=A - update address (idempotent)'
+  win_dns_record:
+    { zone: '{{ win_dns_record_zone }}', name: test1, value: 5.6.7.8, type: A }
+  register: cmd_result
+
+- name: 'TYPE=A - update address get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType A -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty IPv4Address | Select -ExpandProperty IPAddressToString"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=A - update address check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == '5.6.7.8\r\n'
+
+- name: 'TYPE=A - update TTL (check mode)'
+  win_dns_record:
+    {
+      zone: '{{ win_dns_record_zone }}',
+      name: test1,
+      value: 5.6.7.8,
+      ttl: 7200,
+      type: A,
+    }
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=A - update TTL get results (check mode)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType A -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=A - update TTL check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '3600\r\n'
+
+- name: 'TYPE=A - update TTL'
+  win_dns_record:
+    {
+      zone: '{{ win_dns_record_zone }}',
+      name: test1,
+      value: 5.6.7.8,
+      ttl: 7200,
+      type: A,
+    }
+  register: cmd_result
+
+- name: 'TYPE=A - update TTL get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType A -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=A - update TTL check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+- name: 'TYPE=A - update TTL (idempotent)'
+  win_dns_record:
+    {
+      zone: '{{ win_dns_record_zone }}',
+      name: test1,
+      value: 5.6.7.8,
+      ttl: 7200,
+      type: A,
+    }
+  register: cmd_result
+
+- name: 'TYPE=A - update TTL get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType A -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=A - update TTL check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+- name: 'TYPE=A - remove record (check mode)'
+  win_dns_record:
+    { zone: '{{ win_dns_record_zone }}', name: test1, type: A, state: absent }
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=A - remove record get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType A -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=A - remove record check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'exists\r\n'
+
+- name: 'TYPE=A - remove record'
+  win_dns_record:
+    { zone: '{{ win_dns_record_zone }}', name: test1, type: A, state: absent }
+  register: cmd_result
+
+- name: 'TYPE=A - remove record get results'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType A -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=A - remove record check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=A - remove record (idempotent)'
+  win_dns_record:
+    { zone: '{{ win_dns_record_zone }}', name: test1, type: A, state: absent }
+  register: cmd_result
+
+- name: 'TYPE=A - remove record get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType A -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=A - remove record check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+# tests for aging
+# -----------------------------------------------------------------------------
+# create aging record
+- name: 'TYPE=A - add aging record'
+  win_dns_record:
+    zone: '{{ win_dns_record_zone }}'
+    name: testaging
+    value: 1.2.3.4
+    aging: true
+    type: A
+    state: present
+  register: cmd_result
+
+- name: 'Type=A - check if record is actually aging'
+  ansible.windows.win_command: powershell.exe "If ($null -ne (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testaging' -RRType A).Timestamp) {'aging'} else {'not aging'}"
+  register: cmd_result_actual
+
+- name: 'TYPE=A - check aging record results'
+  ansible.builtin.assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'aging\r\n'
+
+# check idempotency
+- name: 'TYPE=A - check aging record (idempotency)'
+  win_dns_record:
+    zone: '{{ win_dns_record_zone }}'
+    name: testaging
+    value: 1.2.3.4
+    aging: true
+    type: A
+    state: present
+  register: cmd_result
+
+- name: 'TYPE=A - check aging record'
+  ansible.builtin.assert:
+    that:
+      - cmd_result is not changed
+
+# change aging attribute
+- name: 'TYPE=A - aging record (change aging)'
+  win_dns_record:
+    zone: '{{ win_dns_record_zone }}'
+    name: testaging
+    aging: false
+    value: 1.2.3.4
+    type: A
+    state: present
+  register: cmd_result
+
+- name: Type=A - check if record is not aging
+  ansible.windows.win_command: powershell.exe "If ($null -ne (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testaging' -RRType A).Timestamp) {'aging'} else {'not aging'}"
+  register: cmd_result_actual
+
+- name: 'TYPE=A - check not aging record results'
+  ansible.builtin.assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'not aging\r\n'
+
+# remove record again
+- name: 'TYPE=A - remove record'
+  win_dns_record:
+    zone: '{{ win_dns_record_zone }}'
+    name: testaging
+    type: A
+    state: absent
+  register: cmd_result
+
+- name: 'TYPE=A - remove record get results'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testaging' -RRType A -Node -ErrorAction:Ignore) {'exists'} else {'absent'}"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=A - remove record check results'
+  ansible.builtin.assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+# -----------------------------------------------------------------------------

--- a/tests/integration/targets/win_dns_record/tasks/tests-AAAA.yml
+++ b/tests/integration/targets/win_dns_record/tasks/tests-AAAA.yml
@@ -1,0 +1,186 @@
+- name: 'TYPE=AAAA - creation (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: '2001:db8::1', type: AAAA}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=AAAA - creation get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType AAAA -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=AAAA - creation check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=AAAA - creation'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: '2001:db8::1', type: AAAA}
+  register: cmd_result
+
+- name: 'TYPE=AAAA - creation get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType AAAA -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty IPv6Address | Select -ExpandProperty IPAddressToString"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=AAAA - creation check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '2001:db8::1\r\n'
+
+- name: 'TYPE=AAAA - creation (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: '2001:db8::1', type: AAAA}
+  register: cmd_result
+
+- name: 'TYPE=AAAA - creation get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType AAAA -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty IPv6Address | Select -ExpandProperty IPAddressToString"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=AAAA - creation check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == '2001:db8::1\r\n'
+
+
+- name: 'TYPE=AAAA - update address (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: '2001:db8::2', type: AAAA}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=AAAA - update address get results (check mode)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType AAAA -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty IPv6Address | Select -ExpandProperty IPAddressToString"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=AAAA - update address check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '2001:db8::1\r\n'
+
+- name: 'TYPE=AAAA - update address'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: '2001:db8::2', type: AAAA}
+  register: cmd_result
+
+- name: 'TYPE=AAAA - update address get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType AAAA -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty IPv6Address | Select -ExpandProperty IPAddressToString"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=AAAA - update address check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '2001:db8::2\r\n'
+
+- name: 'TYPE=AAAA - update address (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: '2001:db8::2', type: AAAA}
+  register: cmd_result
+
+- name: 'TYPE=AAAA - update address get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType AAAA -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty IPv6Address | Select -ExpandProperty IPAddressToString"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=AAAA - update address check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == '2001:db8::2\r\n'
+
+
+- name: 'TYPE=AAAA - update TTL (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: '2001:db8::2', ttl: 7200, type: AAAA}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=AAAA - update TTL get results (check mode)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType AAAA -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=AAAA - update TTL check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '3600\r\n'
+
+- name: 'TYPE=AAAA - update TTL'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: '2001:db8::2', ttl: 7200, type: AAAA}
+  register: cmd_result
+
+- name: 'TYPE=AAAA - update TTL get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType AAAA -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=AAAA - update TTL check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+- name: 'TYPE=AAAA - update address (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: '2001:db8::2', ttl: 7200, type: AAAA}
+  register: cmd_result
+
+- name: 'TYPE=AAAA - update address get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType AAAA -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=AAAA - update address check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+
+- name: 'TYPE=AAAA - remove record (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, type: AAAA, state: absent}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=AAAA - remove record get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType AAAA -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=AAAA - remove record check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'exists\r\n'
+
+- name: 'TYPE=AAAA - remove record'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, type: AAAA, state: absent}
+  register: cmd_result
+
+- name: 'TYPE=AAAA - remove record get results'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType AAAA -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=AAAA - remove record check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=AAAA - remove record (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, type: AAAA, state: absent}
+  register: cmd_result
+
+- name: 'TYPE=AAAA - remove record get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType AAAA -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=AAAA - remove record check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'absent\r\n'

--- a/tests/integration/targets/win_dns_record/tasks/tests-CNAME.yml
+++ b/tests/integration/targets/win_dns_record/tasks/tests-CNAME.yml
@@ -1,0 +1,205 @@
+- name: 'TYPE=CNAME - creation (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: www.ansible.com, type: CNAME}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=CNAME - creation get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType CNAME -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=CNAME - creation check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=CNAME - creation'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: www.ansible.com, type: CNAME}
+  register: cmd_result
+
+- name: 'TYPE=CNAME - creation get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType CNAME -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty HostNameAlias"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=CNAME - creation check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'www.ansible.com.\r\n'
+
+- name: 'TYPE=CNAME - creation (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: www.ansible.com, type: CNAME}
+  register: cmd_result
+
+- name: 'TYPE=CNAME - creation get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType CNAME -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty HostNameAlias"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=CNAME - creation check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'www.ansible.com.\r\n'
+
+
+- name: 'TYPE=CNAME - update address (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: docs.ansible.com, type: CNAME}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=CNAME - update address get results (check mode)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType CNAME -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty HostNameAlias"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=CNAME - update address check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'www.ansible.com.\r\n'
+
+- name: 'TYPE=CNAME - update address'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: docs.ansible.com, type: CNAME}
+  register: cmd_result
+
+- name: 'TYPE=CNAME - update address get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType CNAME -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty HostNameAlias"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=CNAME - update address check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'docs.ansible.com.\r\n'
+
+- name: 'TYPE=CNAME - update address (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: docs.ansible.com, type: CNAME}
+  register: cmd_result
+
+- name: 'TYPE=CNAME - update address get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType CNAME -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty HostNameAlias"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=CNAME - update address check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'docs.ansible.com.\r\n'
+
+
+- name: 'TYPE=CNAME - update TTL (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: docs.ansible.com, ttl: 7200, type: CNAME}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=CNAME - update TTL get results (check mode)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType CNAME -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=CNAME - update TTL check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '3600\r\n'
+
+- name: 'TYPE=CNAME - update TTL'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: docs.ansible.com, ttl: 7200, type: CNAME}
+  register: cmd_result
+
+- name: 'TYPE=CNAME - update TTL get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType CNAME -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=CNAME - update TTL check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+- name: 'TYPE=CNAME - update TTL (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: docs.ansible.com, ttl: 7200, type: CNAME}
+  register: cmd_result
+
+- name: 'TYPE=CNAME - update TTL get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType CNAME -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=CNAME - update TTL check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+
+- name: 'TYPE=CNAME - remove record (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, type: CNAME, state: absent}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=CNAME - remove record get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType CNAME -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=CNAME - remove record check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'exists\r\n'
+
+- name: 'TYPE=CNAME - remove record'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, type: CNAME, state: absent}
+  register: cmd_result
+
+- name: 'TYPE=CNAME - remove record get results'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType CNAME -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=CNAME - remove record check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=CNAME - remove record (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, type: CNAME, state: absent}
+  register: cmd_result
+
+- name: 'TYPE=CNAME - remove record get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType CNAME -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=CNAME - remove record check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: Issue 429 - creation
+  win_dns_record:
+    name: helloworld.test
+    type: CNAME
+    value: myserver.example.com
+    zone: "{{ win_dns_record_zone }}"
+  register: cmd_result
+
+- name: Issue 429 - get results
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'helloworld.test' -RRType CNAME -Node -ErrorAction:Ignore | Select-Object -ExpandProperty RecordData | Select-Object -ExpandProperty HostNameAlias"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: Issue 429 - creation check results"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'myserver.example.com.\r\n'

--- a/tests/integration/targets/win_dns_record/tasks/tests-DHCID.yml
+++ b/tests/integration/targets/win_dns_record/tasks/tests-DHCID.yml
@@ -1,0 +1,234 @@
+- name: "TYPE=DHCID - creation (check mode)"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testdhcid
+    value: "AAIBY2/AuCccgoJbsaxcQc9TUapptP69lOjxfNuVAA2kjEA="
+    type: DHCID
+  register: cmd_result
+  check_mode: yes
+
+- name: "TYPE=DHCID - creation get results (check mode)"
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testdhcid' -RRType DHCID -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=DHCID - creation check results (check mode)"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: "TYPE=DHCID - creation"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testdhcid
+    value: "AAIBY2/AuCccgoJbsaxcQc9TUapptP69lOjxfNuVAA2kjEA="
+    type: DHCID
+  register: cmd_result
+
+- name: "TYPE=DHCID - creation get results"
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testdhcid' -RRType DHCID -Node -ErrorAction:Ignore | Select-Object -ExpandProperty RecordData | Select-Object -ExpandProperty DhcId"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=DHCID - creation check results"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'AAIBY2/AuCccgoJbsaxcQc9TUapptP69lOjxfNuVAA2kjEA=\r\n'
+
+- name: "TYPE=DHCID - creation (idempotent)"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testdhcid
+    value: "AAIBY2/AuCccgoJbsaxcQc9TUapptP69lOjxfNuVAA2kjEA="
+    type: DHCID
+  register: cmd_result
+
+- name: "TYPE=DHCID - creation get results (idempotent)"
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testdhcid' -RRType DHCID -Node -ErrorAction:Ignore | Select-Object -ExpandProperty RecordData | Select-Object -ExpandProperty DhcId"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=DHCID - creation check results (idempotent)"
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'AAIBY2/AuCccgoJbsaxcQc9TUapptP69lOjxfNuVAA2kjEA=\r\n'
+
+- name: "TYPE=DHCID - update value (check mode)"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testdhcid
+    value: "AAEBOSD+XR3Os/0LozeXVqcNc7FwCfQdWL3b/NaiUDlW2No="
+    type: DHCID
+  register: cmd_result
+  check_mode: yes
+
+- name: "TYPE=DHCID - update value get results (check mode)"
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testdhcid' -RRType DHCID -Node -ErrorAction:Ignore | Select-Object -ExpandProperty RecordData | Select-Object -ExpandProperty DhcId"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=DHCID - update value check results (check mode)"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'AAIBY2/AuCccgoJbsaxcQc9TUapptP69lOjxfNuVAA2kjEA=\r\n'
+
+- name: "TYPE=DHCID - update value"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testdhcid
+    value: "AAEBOSD+XR3Os/0LozeXVqcNc7FwCfQdWL3b/NaiUDlW2No="
+    type: DHCID
+  register: cmd_result
+
+- name: "TYPE=DHCID - update value get results"
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testdhcid' -RRType DHCID -Node -ErrorAction:Ignore | Select-Object -ExpandProperty RecordData | Select-Object -ExpandProperty DhcId"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=DHCID - update value check results"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'AAEBOSD+XR3Os/0LozeXVqcNc7FwCfQdWL3b/NaiUDlW2No=\r\n'
+
+- name: "TYPE=DHCID - update value (idempotent)"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testdhcid
+    value: "AAEBOSD+XR3Os/0LozeXVqcNc7FwCfQdWL3b/NaiUDlW2No="
+    type: DHCID
+  register: cmd_result
+
+- name: "TYPE=DHCID - update value get results (idempotent)"
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testdhcid' -RRType DHCID -Node -ErrorAction:Ignore | Select-Object -ExpandProperty RecordData | Select-Object -ExpandProperty DhcId"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=DHCID - update value check results (idempotent)"
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'AAEBOSD+XR3Os/0LozeXVqcNc7FwCfQdWL3b/NaiUDlW2No=\r\n'
+
+- name: "TYPE=DHCID - update TTL (check mode)"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testdhcid
+    value: "AAEBOSD+XR3Os/0LozeXVqcNc7FwCfQdWL3b/NaiUDlW2No="
+    ttl: 7200
+    type: DHCID
+  register: cmd_result
+  check_mode: yes
+
+- name: "TYPE=DHCID - update TTL get results (check mode)"
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testdhcid' -RRType DHCID -Node -ErrorAction:Ignore | Select-Object -ExpandProperty TimeToLive | Select-Object -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=DHCID - update TTL check results (check mode)"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '3600\r\n'
+
+- name: "TYPE=DHCID - update TTL"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testdhcid
+    value: "AAEBOSD+XR3Os/0LozeXVqcNc7FwCfQdWL3b/NaiUDlW2No="
+    ttl: 7200
+    type: DHCID
+  register: cmd_result
+
+- name: "TYPE=DHCID - update TTL get results"
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testdhcid' -RRType DHCID -Node -ErrorAction:Ignore | Select-Object -ExpandProperty TimeToLive | Select-Object -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=DHCID - update TTL check results"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+- name: "TYPE=DHCID - update TTL (idempotent)"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testdhcid
+    value: "AAEBOSD+XR3Os/0LozeXVqcNc7FwCfQdWL3b/NaiUDlW2No="
+    ttl: 7200
+    type: DHCID
+  register: cmd_result
+
+- name: "TYPE=DHCID - update TTL get results (idempotent)"
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testdhcid' -RRType DHCID -Node -ErrorAction:Ignore | Select-Object -ExpandProperty TimeToLive | Select-Object -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=DHCID - update TTL check results (idempotent)"
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+- name: "TYPE=DHCID - remove record (check mode)"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testdhcid
+    type: DHCID
+    state: absent
+  register: cmd_result
+  check_mode: yes
+
+- name: "TYPE=DHCID - remove record get results (check mode)"
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testdhcid' -RRType DHCID -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=DHCID - remove record check results (check mode)"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'exists\r\n'
+
+- name: "TYPE=DHCID - remove record"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testdhcid
+    type: DHCID
+    state: absent
+  register: cmd_result
+
+- name: "TYPE=DHCID - remove record get results"
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testdhcid' -RRType DHCID -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=DHCID - remove record check results"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: "TYPE=DHCID - remove record (idempotent)"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testdhcid
+    type: DHCID
+    state: absent
+  register: cmd_result
+
+- name: "TYPE=DHCID - remove record get results (idempotent)"
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testdhcid' -RRType DHCID -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=DHCID - remove record check results (idempotent)"
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'absent\r\n'

--- a/tests/integration/targets/win_dns_record/tasks/tests-NS.yml
+++ b/tests/integration/targets/win_dns_record/tasks/tests-NS.yml
@@ -1,0 +1,277 @@
+- name: 'TYPE=NS - creation (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-mirror.example.com, type: NS}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=NS - creation get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - creation check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=NS- creation'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-mirror.example.com, type: NS}
+  register: cmd_result
+
+- name: 'TYPE=NS - creation get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty NameServer"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - creation check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'ansible-mirror.example.com.\r\n'
+
+- name: 'TYPE=NS - creation (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-mirror.example.com, type: NS}
+  register: cmd_result
+
+- name: 'TYPE=NS - creation get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty NameServer"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - creation check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'ansible-mirror.example.com.\r\n'
+
+
+- name: 'TYPE=NS - update address (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-altmirror.example.com, type: NS}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=NS - update address get results (check mode)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty NameServer"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - update address check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'ansible-mirror.example.com.\r\n'
+
+- name: 'TYPE=NS - update address'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-altmirror.example.com, type: NS}
+  register: cmd_result
+
+- name: 'TYPE=NS - update address get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty NameServer"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - update address check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'ansible-altmirror.example.com.\r\n'
+
+- name: 'TYPE=NS - update address (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-altmirror.example.com, type: NS}
+  register: cmd_result
+
+- name: 'TYPE=NS - update address get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty NameServer"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - update address check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'ansible-altmirror.example.com.\r\n'
+
+
+- name: 'TYPE=NS - update TTL (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-altmirror.example.com, ttl: 7200, type: NS}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=NS - update TTL get results (check mode)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - update TTL check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '3600\r\n'
+
+- name: 'TYPE=NS - update TTL'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-altmirror.example.com, ttl: 7200, type: NS}
+  register: cmd_result
+
+- name: 'TYPE=NS - update TTL get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - update TTL check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+- name: 'TYPE=NS - update TTL (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: ansible-altmirror.example.com, ttl: 7200, type: NS}
+  register: cmd_result
+
+- name: 'TYPE=NS - update TTL get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - update TTL check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+- name: 'TYPE=NS - remove record (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, type: NS, state: absent}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=NS - remove record get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - remove record check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'exists\r\n'
+
+- name: 'TYPE=NS - remove record'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, type: NS, state: absent}
+  register: cmd_result
+
+- name: 'TYPE=NS - remove record get results'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - remove record check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=NS - remove record (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, type: NS, state: absent}
+  register: cmd_result
+
+- name: 'TYPE=NS - remove record get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - remove record check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=NS - creation with multiple values (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com, ansible-altmirror.example.com, ansiblull-mirror.example.com], type: NS}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=NS - creation get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - creation check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=NS - creation with multiple values'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com, ansible-altmirror.example.com, ansiblull-mirror.example.com], type: NS}
+  register: cmd_result
+
+- name: 'TYPE=NS - creation get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty NameServer"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - creation check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'ansible-mirror.example.com.\r\nansible-altmirror.example.com.\r\nansiblull-mirror.example.com.\r\n'
+
+- name: 'TYPE=NS - creation with multiple values (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, value: [ansible-mirror.example.com, ansible-altmirror.example.com, ansiblull-mirror.example.com], type: NS}
+  register: cmd_result
+
+- name: 'TYPE=NS - creation get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty NameServer"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - creation check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'ansible-mirror.example.com.\r\nansible-altmirror.example.com.\r\nansiblull-mirror.example.com.\r\n'
+
+- name: 'TYPE=NS - remove record (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, type: NS, state: absent}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=NS - remove record get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - remove record check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'exists\r\n'
+
+- name: 'TYPE=NS - remove record'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, type: NS, state: absent}
+  register: cmd_result
+
+- name: 'TYPE=NS - remove record get results'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - remove record check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=NS - remove record (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: z, type: NS, state: absent}
+  register: cmd_result
+
+- name: 'TYPE=NS - remove record get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'z' -RRType NS -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=NS - remove record check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'absent\r\n'

--- a/tests/integration/targets/win_dns_record/tasks/tests-PTR.yml
+++ b/tests/integration/targets/win_dns_record/tasks/tests-PTR.yml
@@ -1,0 +1,186 @@
+- name: 'TYPE=PTR - creation (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_revzone }}', name: 7, value: ansible-mirror.example.com, type: PTR}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=PTR - creation get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_revzone }}' -Name '7' -RRType PTR -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=PTR - creation check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=PTR - creation'
+  win_dns_record: {zone: '{{ win_dns_record_revzone }}', name: 7, value: ansible-mirror.example.com, type: PTR}
+  register: cmd_result
+
+- name: 'TYPE=PTR - creation get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_revzone }}' -Name '7' -RRType PTR -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty PtrDomainName"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=PTR - creation check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'ansible-mirror.example.com.\r\n'
+
+- name: 'TYPE=PTR - creation (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_revzone }}', name: 7, value: ansible-mirror.example.com, type: PTR}
+  register: cmd_result
+
+- name: 'TYPE=PTR - creation get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_revzone }}' -Name '7' -RRType PTR -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty PtrDomainName"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=PTR - creation check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'ansible-mirror.example.com.\r\n'
+
+
+- name: 'TYPE=PTR - update address (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_revzone }}', name: 7, value: ansible-altmirror.example.com, type: PTR}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=PTR - update address get results (check mode)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_revzone }}' -Name '7' -RRType PTR -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty PtrDomainName"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=PTR - update address check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'ansible-mirror.example.com.\r\n'
+
+- name: 'TYPE=PTR - update address'
+  win_dns_record: {zone: '{{ win_dns_record_revzone }}', name: 7, value: ansible-altmirror.example.com, type: PTR}
+  register: cmd_result
+
+- name: 'TYPE=PTR - update address get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_revzone }}' -Name '7' -RRType PTR -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty PtrDomainName"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=PTR - update address check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'ansible-altmirror.example.com.\r\n'
+
+- name: 'TYPE=PTR - update address (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_revzone }}', name: 7, value: ansible-altmirror.example.com, type: PTR}
+  register: cmd_result
+
+- name: 'TYPE=PTR - update address get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_revzone }}' -Name '7' -RRType PTR -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty PtrDomainName"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=PTR - update address check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'ansible-altmirror.example.com.\r\n'
+
+
+- name: 'TYPE=PTR - update TTL (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_revzone }}', name: 7, value: ansible-altmirror.example.com, ttl: 7200, type: PTR}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=PTR - update TTL get results (check mode)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_revzone }}' -Name '7' -RRType PTR -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=PTR - update TTL check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '3600\r\n'
+
+- name: 'TYPE=PTR - update TTL'
+  win_dns_record: {zone: '{{ win_dns_record_revzone }}', name: 7, value: ansible-altmirror.example.com, ttl: 7200, type: PTR}
+  register: cmd_result
+
+- name: 'TYPE=PTR - update TTL get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_revzone }}' -Name '7' -RRType PTR -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=PTR - update TTL check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+- name: 'TYPE=PTR - update TTL (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_revzone }}', name: 7, value: ansible-altmirror.example.com, ttl: 7200, type: PTR}
+  register: cmd_result
+
+- name: 'TYPE=PTR - update TTL get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_revzone }}' -Name '7' -RRType PTR -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=PTR - update TTL check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+
+- name: 'TYPE=PTR - remove record (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_revzone }}', name: 7, type: PTR, state: absent}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=PTR - remove record get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_revzone }}' -Name '7' -RRType PTR -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=PTR - remove record check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'exists\r\n'
+
+- name: 'TYPE=PTR - remove record'
+  win_dns_record: {zone: '{{ win_dns_record_revzone }}', name: 7, type: PTR, state: absent}
+  register: cmd_result
+
+- name: 'TYPE=PTR - remove record get results'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_revzone }}' -Name '7' -RRType PTR -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=PTR - remove record check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=PTR - remove record (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_revzone }}', name: 7, type: PTR, state: absent}
+  register: cmd_result
+
+- name: 'TYPE=PTR - remove record get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_revzone }}' -Name '7' -RRType PTR -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=PTR - remove record check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'absent\r\n'

--- a/tests/integration/targets/win_dns_record/tasks/tests-SRV.yml
+++ b/tests/integration/targets/win_dns_record/tasks/tests-SRV.yml
@@ -1,0 +1,321 @@
+- name: 'TYPE=SRV - creation (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: ansible.example.com, weight: 5, priority: 2, port: 755, type: SRV}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=SRV - creation get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - creation check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=SRV - creation'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: ansible.example.com, weight: 5, priority: 2, port: 755, type: SRV}
+  register: cmd_result
+
+- name: 'TYPE=SRV - creation get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty DomainName"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - creation check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'ansible.example.com.\r\n'
+
+- name: 'TYPE=SRV - creation (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: ansible.example.com, weight: 5, priority: 2, port: 755, type: SRV}
+  register: cmd_result
+
+- name: 'TYPE=SRV - creation get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty DomainName"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - creation check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'ansible.example.com.\r\n'
+
+- name: 'TYPE=SRV - update address (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: altansible.example.com, weight: 5, priority: 2, port: 755, type: SRV}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=SRV - update address get results (check mode)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty DomainName"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - update address check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'ansible.example.com.\r\n'
+
+- name: 'TYPE=SRV - update address'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: altansible.example.com, weight: 5, priority: 2, port: 755, type: SRV}
+  register: cmd_result
+
+- name: 'TYPE=SRV - update address get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty DomainName"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - update address check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'altansible.example.com.\r\n'
+
+- name: 'TYPE=SRV - update address (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: altansible.example.com, weight: 5, priority: 2, port: 755, type: SRV}
+  register: cmd_result
+
+- name: 'TYPE=SRV - update address get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty DomainName"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - update address check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'altansible.example.com.\r\n'
+
+- name: 'TYPE=SRV - update TTL (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: altansible.example.com, weight: 5, priority: 2, port: 755, ttl: 7200, type: SRV}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=SRV - update TTL get results (check mode)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - update TTL check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '3600\r\n'
+
+- name: 'TYPE=SRV - update TTL'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: altansible.example.com, weight: 5, priority: 2, port: 755, ttl: 7200, type: SRV}
+  register: cmd_result
+
+- name: 'TYPE=SRV - update TTL get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - update TTL check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+- name: 'TYPE=SRV - update TTL (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: altansible.example.com, weight: 5, priority: 2, port: 755, ttl: 7200, type: SRV}
+  register: cmd_result
+
+- name: 'TYPE=SRV - update TTL get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore | Select -ExpandProperty TimeToLive | Select -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - update TTL check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+- name: 'TYPE=SRV - update weight (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: altansible.example.com, weight: 1, priority: 2, port: 755, type: SRV}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=SRV - update weight get results (check mode)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty Weight"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - update weight check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '5\r\n'
+
+- name: 'TYPE=SRV - update weight'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, weight: 1, priority: 2, port: 755, value: altansible.example.com, type: SRV}
+  register: cmd_result
+
+- name: 'TYPE=SRV - update weight get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty Weight"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - update weight check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '1\r\n'
+
+- name: 'TYPE=SRV - update weight (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: altansible.example.com, weight: 1, priority: 2, port: 755, type: SRV}
+  register: cmd_result
+
+- name: 'TYPE=SRV - update weight get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty Weight"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - update weight check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == '1\r\n'
+
+- name: 'TYPE=SRV - update port (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: altansible.example.com, weight: 1, priority: 2, port: 355, type: SRV}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=SRV - update port get results (check mode)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty Port"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - update port check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '755\r\n'
+
+- name: 'TYPE=SRV - update port'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, weight: 1, priority: 2, port: 355, value: altansible.example.com, type: SRV}
+  register: cmd_result
+
+- name: 'TYPE=SRV - update port get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty Port"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - update port check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '355\r\n'
+
+- name: 'TYPE=SRV - update port (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: altansible.example.com, weight: 1, priority: 2, port: 355, type: SRV}
+  register: cmd_result
+
+- name: 'TYPE=SRV - update port get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty Port"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - update port check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == '355\r\n'
+
+- name: 'TYPE=SRV - update priority (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: altansible.example.com, weight: 1, priority: 7, port: 355, type: SRV}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=SRV - update priority get results (check mode)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty Priority"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - update priority check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '2\r\n'
+
+- name: 'TYPE=SRV - update priority'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, weight: 1, priority: 7, port: 355, value: altansible.example.com, type: SRV}
+  register: cmd_result
+
+- name: 'TYPE=SRV - update priority get results'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty Priority"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - update priority check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '7\r\n'
+
+- name: 'TYPE=SRV - update priority (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, value: altansible.example.com, weight: 1, priority: 7, port: 355, type: SRV}
+  register: cmd_result
+
+- name: 'TYPE=SRV - update priority get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty Priority"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - update priority check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == '7\r\n'
+
+- name: 'TYPE=SRV - remove record (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, weight: 1, priority: 7, port: 355, type: SRV, state: absent}
+  register: cmd_result
+  check_mode: yes
+
+- name: 'TYPE=SRV - remove record get results (check mode)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - remove record check results (check mode)'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'exists\r\n'
+
+- name: 'TYPE=SRV - remove record'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, weight: 1, priority: 7, port: 355, type: SRV, state: absent}
+  register: cmd_result
+
+- name: 'TYPE=SRV - remove record get results'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - remove record check results'
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: 'TYPE=SRV - remove record (idempotent)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: test1, weight: 1, priority: 7, port: 355, type: SRV, state: absent}
+  register: cmd_result
+
+- name: 'TYPE=SRV - remove record get results (idempotent)'
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'test1' -RRType SRV -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: 'TYPE=SRV - remove record check results (idempotent)'
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'absent\r\n'

--- a/tests/integration/targets/win_dns_record/tasks/tests-TXT.yml
+++ b/tests/integration/targets/win_dns_record/tasks/tests-TXT.yml
@@ -1,0 +1,234 @@
+- name: "TYPE=TXT - creation (check mode)"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testtxt
+    value: txtrecordvalue
+    type: TXT
+  register: cmd_result
+  check_mode: yes
+
+- name: "TYPE=TXT - creation get results (check mode)"
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testtxt' -RRType TXT -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=TXT - creation check results (check mode)"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: "TYPE=TXT - creation"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testtxt
+    value: txtrecordvalue
+    type: TXT
+  register: cmd_result
+
+- name: "TYPE=TXT - creation get results"
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testtxt' -RRType TXT -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty DescriptiveText"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=TXT - creation check results"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'txtrecordvalue\r\n'
+
+- name: "TYPE=TXT - creation (idempotent)"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testtxt
+    value: txtrecordvalue
+    type: TXT
+  register: cmd_result
+
+- name: "TYPE=TXT - creation get results (idempotent)"
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testtxt' -RRType TXT -Node -ErrorAction:Ignore | Select -ExpandProperty RecordData | Select -ExpandProperty DescriptiveText"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=TXT - creation check results (idempotent)"
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'txtrecordvalue\r\n'
+
+- name: "TYPE=TXT - update value (check mode)"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testtxt
+    value: updated txt record value
+    type: TXT
+  register: cmd_result
+  check_mode: yes
+
+- name: "TYPE=TXT - update value get results (check mode)"
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testtxt' -RRType TXT -Node -ErrorAction:Ignore | Select-Object -ExpandProperty RecordData | Select-Object -ExpandProperty DescriptiveText"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=TXT - update value check results (check mode)"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'txtrecordvalue\r\n'
+
+- name: "TYPE=TXT - update value"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testtxt
+    value: updated txt record value
+    type: TXT
+  register: cmd_result
+
+- name: "TYPE=TXT - update value get results"
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testtxt' -RRType TXT -Node -ErrorAction:Ignore | Select-Object -ExpandProperty RecordData | Select-Object -ExpandProperty DescriptiveText"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=TXT - update value check results"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'updated txt record value\r\n'
+
+- name: "TYPE=TXT - update value (idempotent)"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testtxt
+    value: updated txt record value
+    type: TXT
+  register: cmd_result
+
+- name: "TYPE=TXT - update value get results (idempotent)"
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testtxt' -RRType TXT -Node -ErrorAction:Ignore | Select-Object -ExpandProperty RecordData | Select-Object -ExpandProperty DescriptiveText"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=TXT - update value check results (idempotent)"
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'updated txt record value\r\n'
+
+- name: "TYPE=TXT - update TTL (check mode)"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testtxt
+    value: updated txt record value
+    ttl: 7200
+    type: TXT
+  register: cmd_result
+  check_mode: true
+
+- name: "TYPE=TXT - update TTL get results (check mode)"
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testtxt' -RRType TXT -Node -ErrorAction:Ignore | Select-Object -ExpandProperty TimeToLive | Select-Object -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=TXT - update TTL check results (check mode)"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '3600\r\n'
+
+- name: "TYPE=TXT - update TTL"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testtxt
+    value: updated txt record value
+    ttl: 7200
+    type: TXT
+  register: cmd_result
+
+- name: "TYPE=TXT - update TTL get results"
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testtxt' -RRType TXT -Node -ErrorAction:Ignore | Select-Object -ExpandProperty TimeToLive | Select-Object -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=TXT - update TTL check results"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+- name: "TYPE=TXT - update TTL (idempotent)"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testtxt
+    value: updated txt record value
+    ttl: 7200
+    type: TXT
+  register: cmd_result
+
+- name: "TYPE=TXT - update TTL get results (idempotent)"
+  ansible.windows.win_command: powershell.exe "Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testtxt' -RRType TXT -Node -ErrorAction:Ignore | Select-Object -ExpandProperty TimeToLive | Select-Object -ExpandProperty TotalSeconds"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=TXT - update TTL check results (idempotent)"
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == '7200\r\n'
+
+- name: "TYPE=TXT - remove record (check mode)"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testtxt
+    type: TXT
+    state: absent
+  register: cmd_result
+  check_mode: yes
+
+- name: "TYPE=TXT - remove record get results (check mode)"
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testtxt' -RRType TXT -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=TXT - remove record check results (check mode)"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'exists\r\n'
+
+- name: "TYPE=TXT - remove record"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testtxt
+    type: TXT
+    state: absent
+  register: cmd_result
+
+- name: "TYPE=TXT - remove record get results"
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testtxt' -RRType TXT -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=TXT - remove record check results"
+  assert:
+    that:
+      - cmd_result is changed
+      - cmd_result_actual.stdout == 'absent\r\n'
+
+- name: "TYPE=TXT - remove record (idempotent)"
+  win_dns_record:
+    zone: "{{ win_dns_record_zone }}"
+    name: testtxt
+    type: TXT
+    state: absent
+  register: cmd_result
+
+- name: "TYPE=TXT - remove record get results (idempotent)"
+  ansible.windows.win_command: powershell.exe "If (Get-DnsServerResourceRecord -ZoneName '{{ win_dns_record_zone }}' -Name 'testtxt' -RRType TXT -Node -ErrorAction:Ignore) { 'exists' } else { 'absent' }"
+  register: cmd_result_actual
+  changed_when: false
+
+- name: "TYPE=TXT - remove record check results (idempotent)"
+  assert:
+    that:
+      - cmd_result is not changed
+      - cmd_result_actual.stdout == 'absent\r\n'

--- a/tests/integration/targets/win_dns_record/tasks/tests-diff.yml
+++ b/tests/integration/targets/win_dns_record/tasks/tests-diff.yml
@@ -1,0 +1,63 @@
+# Diff tests are present because those records have to be created MANUALLY by
+# the win_dns_record module when in check mode, as there is otherwise no way in
+# Windows DNS to *simulate* a record or change.
+
+
+- name: 'Diff test - creation (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: diff_host, value: 1.2.3.4, type: A}
+  register: create_check
+  check_mode: yes
+  diff: yes
+
+- name: 'Diff test - creation'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: diff_host, value: 1.2.3.4, type: A}
+  register: create_do
+  diff: yes
+
+- name: 'Diff test - creation check results'
+  assert:
+    that:
+      - create_check.diff.before == create_do.diff.before
+      - create_check.diff.before == ''
+      - create_check.diff.after == create_do.diff.after
+      - create_check.diff.after == "[{{ win_dns_record_zone }}] diff_host 3600 IN A 1.2.3.4\n"
+
+
+- name: 'Diff test - update TTL (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: diff_host, value: 1.2.3.4, type: A, ttl: 7200}
+  register: update_check
+  check_mode: yes
+  diff: yes
+
+- name: 'Diff test - update TTL'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: diff_host, value: 1.2.3.4, type: A, ttl: 7200}
+  register: update_do
+  diff: yes
+
+- name: 'Diff test - update TTL check results'
+  assert:
+    that:
+      - update_check.diff.before == update_do.diff.before
+      - update_check.diff.before == "[{{ win_dns_record_zone }}] diff_host 3600 IN A 1.2.3.4\n"
+      - update_check.diff.after == update_do.diff.after
+      - update_check.diff.after == "[{{ win_dns_record_zone }}] diff_host 7200 IN A 1.2.3.4\n"
+
+
+- name: 'Diff test - deletion (check mode)'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: diff_host, type: A, state: absent}
+  register: delete_check
+  check_mode: yes
+  diff: yes
+
+- name: 'Diff test - deletion'
+  win_dns_record: {zone: '{{ win_dns_record_zone }}', name: diff_host, type: A, state: absent}
+  register: delete_do
+  diff: yes
+
+- name: 'Diff test - deletion check results'
+  assert:
+    that:
+      - delete_check.diff.before == delete_do.diff.before
+      - delete_check.diff.before == "[{{ win_dns_record_zone }}] diff_host 7200 IN A 1.2.3.4\n"
+      - delete_check.diff.after == delete_do.diff.after
+      - delete_check.diff.after == ''

--- a/tests/integration/targets/win_dns_record/tasks/tests.yml
+++ b/tests/integration/targets/win_dns_record/tasks/tests.yml
@@ -1,0 +1,36 @@
+- name: ensure DNS services are installed
+  ansible.windows.win_feature:
+    name: DNS
+    state: present
+  register: dns_install
+
+- name: reboot server if needed
+  ansible.windows.win_reboot:
+  when: dns_install.reboot_required
+
+- name: Clean slate
+  import_tasks: clean.yml
+  vars:
+    fail_on_missing: false
+
+- block:
+   - name: Create the forward zone
+     ansible.windows.win_shell: Add-DnsServerPrimaryZone -Name '{{ win_dns_record_zone }}' -ZoneFile '{{ win_dns_record_zone}}.dns'
+   - name: Create the reverse zone
+     ansible.windows.win_shell: Add-DnsServerPrimaryZone -NetworkID '{{ win_dns_record_revzone_network }}' -ZoneFile '{{ win_dns_record_revzone}}.dns'
+
+   - import_tasks: tests-A.yml
+   - import_tasks: tests-AAAA.yml
+   - import_tasks: tests-NS.yml
+   - import_tasks: tests-SRV.yml
+   - import_tasks: tests-CNAME.yml
+   - import_tasks: tests-DHCID.yml
+   - import_tasks: tests-PTR.yml
+   - import_tasks: tests-TXT.yml
+   - import_tasks: tests-diff.yml
+
+  always:
+   - name: Clean slate
+     import_tasks: clean.yml
+     vars:
+       fail_on_missing: true


### PR DESCRIPTION
##### SUMMARY
- Migration of win_dns_record module from community repo to ansible.windows repo.
- Added extra integration test for zone_scope.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
- win_dns_record

##### ADDITIONAL INFORMATION
Ansible windows module win_dns_record migration
As part of community.windows to ansible.windows migration.
