### PR TITLE
Migrate win_dhcp_lease module to ansible.windows repo from ansible.community repo

### DIFF
--- a/plugins/modules/win_dhcp_lease.ps1
+++ b/plugins/modules/win_dhcp_lease.ps1
@@ -1,0 +1,445 @@
+#!powershell
+
+# Copyright: (c) 2020 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: GPL-3.0-only
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+$spec = @{
+    options = @{
+        type = @{ type = "str"; choices = "reservation", "lease"; default = "reservation" }
+        ip = @{ type = "str" }
+        scope_id = @{ type = "str" }
+        mac = @{ type = "str" }
+        duration = @{ type = "int" }
+        dns_hostname = @{ type = "str"; }
+        dns_regtype = @{ type = "str"; choices = "aptr", "a", "noreg"; default = "aptr" }
+        reservation_name = @{ type = "str"; }
+        description = @{ type = "str"; }
+        state = @{ type = "str"; choices = "absent", "present"; default = "present" }
+    }
+    required_if = @(
+        @("state", "present", @("mac", "ip"), $true),
+        @("state", "absent", @("mac", "ip"), $true)
+    )
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+$check_mode = $module.CheckMode
+
+$type = $module.Params.type
+$ip = $module.Params.ip
+$scope_id = $module.Params.scope_id
+$mac = $module.Params.mac
+$duration = $module.Params.duration
+$dns_hostname = $module.Params.dns_hostname
+$dns_regtype = $module.Params.dns_regtype
+$reservation_name = $module.Params.reservation_name
+$description = $module.Params.description
+$state = $module.Params.state
+
+Function Convert-MacAddress {
+    Param(
+        [string]$mac
+    )
+
+    # Evaluate Length
+    if ($mac.Length -eq 12) {
+        # Insert Dashes
+        $mac = $mac.Insert(2, "-").Insert(5, "-").Insert(8, "-").Insert(11, "-").Insert(14, "-")
+        return $mac
+    }
+    elseif ($mac.Length -eq 17) {
+        # Replace Colons by Dashes
+        return ($mac -replace ':', '-')
+    }
+    else {
+        return $false
+    }
+}
+
+Function Compare-DhcpLease {
+    Param(
+        [PSObject]$Original,
+        [PSObject]$Updated
+    )
+
+    # Compare values that we care about
+    -not (
+        ($Original.AddressState -eq $Updated.AddressState) -and
+        ($Original.IPAddress -eq $Updated.IPAddress) -and
+        ($Original.ScopeId -eq $Updated.ScopeId) -and
+        ($Original.Name -eq $Updated.Name) -and
+        ($Original.Description -eq $Updated.Description)
+    )
+}
+
+Function Convert-ReturnValue {
+    Param(
+        $Object
+    )
+
+    return @{
+        address_state = $Object.AddressState
+        client_id = $Object.ClientId
+        ip_address = $Object.IPAddress.IPAddressToString
+        scope_id = $Object.ScopeId.IPAddressToString
+        name = $Object.Name
+        description = $Object.Description
+    }
+}
+
+# Parse Regtype
+if ($dns_regtype) {
+    Switch ($dns_regtype) {
+        "aptr" { $dns_regtype = "AandPTR"; break }
+        "a" { $dns_regtype = "A"; break }
+        "noreg" { $dns_regtype = "NoRegistration"; break }
+        default { $dns_regtype = "NoRegistration"; break }
+    }
+}
+
+Try {
+    # Import DHCP Server PS Module
+    Import-Module DhcpServer
+}
+Catch {
+    # Couldn't load the DhcpServer Module
+    $module.FailJson("The DhcpServer module failed to load properly: $($_.Exception.Message)", $_)
+}
+
+# Find existing lease by MAC address
+if ($mac) {
+    $mac = Convert-MacAddress -mac $mac
+
+    if ($mac -eq $false) {
+        $module.FailJson("The MAC Address is not properly formatted")
+    }
+    else {
+        $current_lease = Get-DhcpServerv4Scope | Get-DhcpServerv4Lease | Where-Object ClientId -eq $mac
+    }
+}
+
+# Find existing lease by IP address
+if ($ip -and (-not $current_lease)) {
+    $current_lease = Get-DhcpServerv4Scope | Get-DhcpServerv4Lease | Where-Object IPAddress -eq $ip
+}
+
+# Did we find a lease/reservation
+if ($current_lease) {
+    $current_lease_exists = $true
+    $original_lease = $current_lease
+    $module.Diff.before = Convert-ReturnValue -Object $original_lease
+}
+else {
+    $current_lease_exists = $false
+}
+
+# If we found a lease, is it a reservation?
+if ($current_lease_exists -eq $true -and ($current_lease.AddressState -like "*Reservation*")) {
+    $current_lease_reservation = $true
+}
+else {
+    $current_lease_reservation = $false
+}
+
+# State: Absent
+# Ensure the DHCP Lease/Reservation is not present
+if ($state -eq "absent") {
+    # If the lease doesn't exist, our work here is done
+    if ($current_lease_exists -eq $false) {
+        $module.Result.msg = "The lease doesn't exist."
+    }
+    else {
+        # If the lease exists, we need to destroy it
+        if ($current_lease_reservation -eq $true) {
+            # Try to remove reservation
+            Try {
+                $current_lease | Remove-DhcpServerv4Reservation -WhatIf:$check_mode
+                $state_absent_removed = $true
+            }
+            Catch {
+                $state_absent_removed = $false
+                $remove_err = $_
+            }
+        }
+        else {
+            # Try to remove lease
+            Try {
+                $current_lease | Remove-DhcpServerv4Lease -WhatIf:$check_mode
+                $state_absent_removed = $true
+            }
+            Catch {
+                $state_absent_removed = $false
+                $remove_err = $_
+            }
+        }
+
+        # See if we removed the lease/reservation
+        if ($state_absent_removed) {
+            $module.Result.changed = $true
+        }
+        else {
+            $module.Result.lease = Convert-ReturnValue -Object $current_lease
+            $module.FailJson("Unable to remove lease/reservation: $($remove_err.Exception.Message)", $remove_err)
+        }
+    }
+}
+
+# State: Present
+# Ensure the DHCP Lease/Reservation is present, and consistent
+if ($state -eq "present") {
+    # Current lease exists, and is not a reservation
+    if (($current_lease_reservation -eq $false) -and ($current_lease_exists -eq $true)) {
+        if ($type -eq "reservation") {
+            Try {
+                # Update parameters
+                $params = @{ }
+
+                if ($mac) {
+                    $params.ClientId = $mac
+                }
+                else {
+                    $params.ClientId = $current_lease.ClientId
+                }
+
+                if ($description) {
+                    $params.Description = $description
+                }
+                else {
+                    $params.Description = $current_lease.Description
+                }
+
+                if ($reservation_name) {
+                    $params.Name = $reservation_name
+                }
+                else {
+                    $params.Name = "reservation-" + $params.ClientId
+                }
+
+                # Desired type is reservation
+                $current_lease | Add-DhcpServerv4Reservation -WhatIf:$check_mode
+
+                if (-not $check_mode) {
+                    $current_reservation = Get-DhcpServerv4Lease -ClientId $params.ClientId -ScopeId $current_lease.ScopeId
+                }
+
+                # Update the reservation with new values
+                $current_reservation | Set-DhcpServerv4Reservation @params -WhatIf:$check_mode
+
+                if (-not $check_mode) {
+                    $updated_reservation = Get-DhcpServerv4Lease -ClientId $params.ClientId -ScopeId $current_reservation.ScopeId
+                }
+
+                if (-not $check_mode) {
+                    # Compare Values
+                    $module.Result.changed = Compare-DhcpLease -Original $original_lease -Updated $updated_reservation
+                    $module.Result.lease = Convert-ReturnValue -Object $updated_reservation
+                }
+                else {
+                    $module.Result.changed = $true
+                }
+
+                $module.ExitJson()
+            }
+            Catch {
+                $module.FailJson("Could not convert lease to a reservation", $_)
+            }
+        }
+    }
+
+    # Current lease exists, and is a reservation
+    if (($current_lease_reservation -eq $true) -and ($current_lease_exists -eq $true)) {
+        if ($type -eq "lease") {
+            Try {
+                # Desired type is a lease, remove the reservation
+                $current_lease | Remove-DhcpServerv4Reservation -WhatIf:$check_mode
+                # Build a new lease object with remnants of the reservation
+                $lease_params = @{
+                    ClientId = $original_lease.ClientId
+                    IPAddress = $original_lease.IPAddress.IPAddressToString
+                    ScopeId = $original_lease.ScopeId.IPAddressToString
+                    HostName = $original_lease.HostName
+                    AddressState = 'Active'
+                }
+
+                # Create new lease
+                Try {
+                    Add-DhcpServerv4Lease @lease_params -WhatIf:$check_mode
+                }
+                Catch {
+                    $module.FailJson("Unable to convert the reservation to a lease", $_)
+                }
+
+                # Get the lease we just created
+                if (-not $check_mode) {
+                    Try {
+                        $new_lease = Get-DhcpServerv4Lease -ClientId $lease_params.ClientId -ScopeId $lease_params.ScopeId
+                    }
+                    Catch {
+                        $module.FailJson("Unable to retreive the newly created lease", $_)
+                    }
+                }
+
+                if (-not $check_mode) {
+                    $module.Result.lease = Convert-ReturnValue -Object $new_lease
+                }
+
+                $module.Result.changed = $true
+                $module.ExitJson()
+            }
+            Catch {
+                $module.FailJson("Could not convert reservation to lease", $_)
+            }
+        }
+
+        # Already in the desired state
+        if ($type -eq "reservation") {
+
+            # Update parameters
+            $params = @{ }
+
+            if ($mac) {
+                $params.ClientId = $mac
+            }
+            else {
+                $params.ClientId = $current_lease.ClientId
+            }
+
+            if ($description) {
+                $params.Description = $description
+            }
+            else {
+                $params.Description = $current_lease.Description
+            }
+
+            if ($reservation_name) {
+                $params.Name = $reservation_name
+            }
+            else {
+                # Original lease had a null name so let's generate one
+                if ($null -eq $original_lease.Name) {
+                    $params.Name = "reservation-" + $original_lease.ClientId
+                }
+                else {
+                    $params.Name = $original_lease.Name
+                }
+            }
+
+            # Update the reservation with new values
+            $current_lease | Set-DhcpServerv4Reservation @params -WhatIf:$check_mode
+
+            if (-not $check_mode) {
+                $reservation = Get-DhcpServerv4Lease -ClientId $current_lease.ClientId -ScopeId $current_lease.ScopeId
+                $module.Result.changed = Compare-DhcpLease -Original $original_lease -Updated $reservation
+                $module.Result.lease = Convert-ReturnValue -Object $reservation
+            }
+            else {
+                $module.Result.changed = $true
+            }
+
+            # Return values
+            $module.ExitJson()
+        }
+    }
+
+    # Lease Doesn't Exist - Create
+    if ($current_lease_exists -eq $false) {
+        # Required: Scope ID
+        if (-not $scope_id) {
+            $module.Result.changed = $false
+            $module.FailJson("The scope_id parameter is required for state=present when a lease or reservation doesn't already exist")
+        }
+
+        # Required Parameters for both lease and reservataion
+        $params = @{
+            ClientId = $mac
+            IPAddress = $ip
+            ScopeId = $scope_id
+            Confirm = $false
+        }
+
+        if ($dns_hostname) {
+            $params.HostName = $dns_hostname
+        }
+
+        if ($description) {
+            $params.Description = $description
+        }
+
+        # Create Lease
+        Try {
+            if ($type -eq "lease") {
+                if ($duration) {
+                    $params.LeaseExpiryTime = (Get-Date).AddDays($duration)
+                }
+                if ($dns_regtype) {
+                    $params.DnsRR = $dns_regtype
+                }
+                $params.AddressState = 'Active'
+                # Create lease based on parameters
+                Add-DhcpServerv4Lease @params -WhatIf:$check_mode
+
+                # Retreive the lease
+                if (-not $check_mode) {
+                    $new_lease = Get-DhcpServerv4Lease -ClientId $mac -ScopeId $scope_id
+                    $module.Result.lease = Convert-ReturnValue -Object $new_lease
+                }
+
+                # If lease is the desired type
+                if ($type -eq "lease") {
+                    $module.Result.changed = $true
+                    $module.ExitJson()
+                }
+            }
+        }
+        Catch {
+            # Failed to create lease
+            $module.FailJson("Could not create DHCP lease: $($_.Exception.Message)", $_)
+        }
+
+        # Create Reservation
+        Try {
+            # If reservation is the desired type
+            if ($type -eq "reservation") {
+                if ($reservation_name) {
+                    $params.Name = $reservation_name
+                }
+                else {
+                    $params.Name = "reservation-" + $mac
+                }
+
+                Try {
+                    if ($check_mode) {
+                        # In check mode, a lease won't exist for conversion, make one manually
+                        Add-DhcpServerv4Reservation -ScopeId $scope_id -ClientId $mac -IPAddress $ip -WhatIf:$check_mode
+                    }
+                    else {
+                        # Convert to Reservation
+                        Add-DhcpServerv4Reservation @params -WhatIf:$check_mode
+                    }
+                }
+                Catch {
+                    # Failed to create reservation
+                    $module.FailJson("Could not create DHCP reservation: $($_.Exception.Message)", $_)
+                }
+
+                if (-not $check_mode) {
+                    # Get DHCP reservation object
+                    $new_lease = Get-DhcpServerv4Reservation -ClientId $mac -ScopeId $scope_id
+                    $module.Result.lease = Convert-ReturnValue -Object $new_lease
+                }
+
+                $module.Result.changed = $true
+            }
+        }
+        Catch {
+            # Failed to create reservation
+            $module.FailJson("Could not create DHCP reservation: $($_.Exception.Message)", $_)
+        }
+    }
+}
+
+$module.ExitJson()

--- a/plugins/modules/win_dhcp_lease.py
+++ b/plugins/modules/win_dhcp_lease.py
@@ -1,0 +1,149 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020 VMware, Inc. All Rights Reserved.
+# SPDX-License-Identifier: GPL-3.0-only
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r'''
+---
+module: win_dhcp_lease
+short_description: Manage Windows Server DHCP Leases
+author: Joe Zollo (@joezollo)
+requirements:
+  - This module requires Windows Server 2012 or Newer
+description:
+  - Manage Windows Server DHCP Leases (IPv4 Only)
+  - Adds, Removes and Modifies DHCP Leases and Reservations
+  - Task should be delegated to a Windows DHCP Server
+version_added: 2.6.0
+options:
+  type:
+    description:
+      - The type of DHCP address.
+      - Leases expire as defined by l(duration).
+      - When l(duration) is not specified, the server default is used.
+      - Reservations are permanent.
+    type: str
+    default: reservation
+    choices: [ reservation, lease ]
+  state:
+    description:
+      - Specifies the desired state of the DHCP lease or reservation.
+    type: str
+    default: present
+    choices: [ present, absent ]
+  ip:
+    description:
+      - The IPv4 address of the client server/computer.
+      - This is a required parameter, if l(mac) is not set.
+      - Can be used to identify an existing lease/reservation, instead of l(mac).
+    type: str
+    required: no
+  scope_id:
+    description:
+      - Specifies the scope identifier as defined by the DHCP server.
+      - This is a required parameter, if l(state=present) and the reservation or lease
+        doesn't already exist. Not required if updating an existing lease or reservation.
+    type: str
+  mac:
+    description:
+      - Specifies the client identifier to be set on the IPv4 address.
+      - This is a required parameter, if l(ip) is not set.
+      - Windows clients use the MAC address as the client ID.
+      - Linux and other operating systems can use other types of identifiers.
+      - Can be used to identify an existing lease/reservation, instead of l(ip).
+    type: str
+  duration:
+    description:
+      - Specifies the duration of the DHCP lease in days.
+      - The duration value only applies to l(type=lease).
+      - Defaults to the duration specified by the DHCP server
+        configuration.
+      - Only applicable to l(type=lease).
+    type: int
+  dns_hostname:
+    description:
+      - Specifies the DNS hostname of the client for which the IP address
+        lease is to be added.
+    type: str
+  dns_regtype:
+    description:
+      - Indicates the type of DNS record to be registered by the DHCP.
+        server service for this lease.
+      - l(a) results in an A record being registered.
+      - l(aptr) results in both A and PTR records to be registered.
+      - l(noreg) results in no DNS records being registered.
+    type: str
+    default: aptr
+    choices: [ aptr, a, noreg ]
+  reservation_name:
+    description:
+      - Specifies the name of the reservation being created.
+      - Only applicable to l(type=reservation).
+    type: str
+  description:
+    description:
+      - Specifies the description for reservation being created.
+      - Only applicable to l(type=reservation).
+    type: str
+'''
+
+EXAMPLES = r'''
+- name: Ensure DHCP reservation exists
+  ansible.windows.win_dhcp_lease:
+    type: reservation
+    ip: 192.168.100.205
+    scope_id: 192.168.100.0
+    mac: 00:B1:8A:D1:5A:1F
+    dns_hostname: "{{ ansible_inventory }}"
+    description: Testing Server
+
+- name: Ensure DHCP lease or reservation does not exist
+  ansible.windows.win_dhcp_lease:
+    mac: 00:B1:8A:D1:5A:1F
+    state: absent
+
+- name: Ensure DHCP lease or reservation does not exist
+  ansible.windows.win_dhcp_lease:
+    ip: 192.168.100.205
+    state: absent
+
+- name: Convert DHCP lease to reservation & update description
+  ansible.windows.win_dhcp_lease:
+    type: reservation
+    ip: 192.168.100.205
+    description: Testing Server
+
+- name: Convert DHCP reservation to lease
+  ansible.windows.win_dhcp_lease:
+    type: lease
+    ip: 192.168.100.205
+
+# Modify an existing lease by running the following tasks
+- name: Remove old lease
+  win_dhcp_lease:
+    mac: "00:11:22:33:44:55"
+    state: absent
+
+- name: Create new lease with updated properties
+  win_dhcp_lease:
+    mac: "00:11:22:33:44:55"
+    ip: "192.168.100.100"
+    duration: 14
+    state: present
+'''
+
+RETURN = r'''
+lease:
+  description: New/Updated DHCP object parameters
+  returned: When l(state=present)
+  type: dict
+  sample:
+    address_state: InactiveReservation
+    client_id: 0a-0b-0c-04-05-aa
+    description: Really Fancy
+    ip_address: 172.16.98.230
+    name: null
+    scope_id: 172.16.98.0
+'''

--- a/tests/integration/targets/win_dhcp_lease/aliases
+++ b/tests/integration/targets/win_dhcp_lease/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group3

--- a/tests/integration/targets/win_dhcp_lease/defaults/main.yml
+++ b/tests/integration/targets/win_dhcp_lease/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+dhcp_lease_ip: 172.16.98.230
+dhcp_scope_id: 172.16.98.0
+dhcp_scope_start: 172.16.98.2
+dhcp_scope_end: 172.16.98.254
+dhcp_scope_subnet_mask: 255.255.255.0
+dhcp_lease_mac: 0A-0B-0C-04-05-AA
+dhcp_lease_hostname: fancy-reservation

--- a/tests/integration/targets/win_dhcp_lease/tasks/main.yml
+++ b/tests/integration/targets/win_dhcp_lease/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+- block:
+  - name: Check DHCP Service/Role Install State
+    ansible.windows.win_feature:
+      name: DHCP
+      state: present
+      include_management_tools: yes
+    register: dhcp_role
+
+  - name: Reboot if Necessary
+    ansible.windows.win_reboot:
+    when: dhcp_role.reboot_required
+
+  - name: Add the DHCP scope
+    ansible.windows.win_shell: |
+      Add-DhcpServerv4Scope -Name "TestNetwork" -StartRange {{ dhcp_scope_start }} -EndRange {{dhcp_scope_end }} -SubnetMask {{ dhcp_scope_subnet_mask }}
+
+  - name: Run tests without check mode
+    include_tasks: tests.yml
+
+  - name: Run tests in check mode
+    include_tasks: tests_checkmode.yml
+
+  always:
+  - name: Remove the DHCP scope
+    ansible.windows.win_shell: |
+      Remove-DhcpServerv4Scope -ScopeId {{ dhcp_scope_id }} -Force

--- a/tests/integration/targets/win_dhcp_lease/tasks/tests.yml
+++ b/tests/integration/targets/win_dhcp_lease/tasks/tests.yml
@@ -1,0 +1,156 @@
+---
+- name: Remove DHCP Address by IP
+  ansible.windows.win_dhcp_lease:
+    state: absent
+    ip: "{{ dhcp_lease_ip }}"
+
+- name: Remove DHCP Address by IP (Idempotentcy Check) - Changed should equal false
+  ansible.windows.win_dhcp_lease:
+    state: absent
+    ip: "{{ dhcp_lease_ip }}"
+  register: remove_reservation_ip
+  failed_when: remove_reservation_ip.changed != false
+
+- name: Create New DHCP Lease
+  ansible.windows.win_dhcp_lease:
+    type: lease
+    ip: "{{ dhcp_lease_ip }}"
+    scope_id: "{{ dhcp_scope_id }}"
+    mac: "{{ dhcp_lease_mac }}"
+    dns_hostname: "{{ dhcp_lease_hostname }}"
+    dns_regtype: noreg
+    description: This is a description!
+
+- name: Create New DHCP Lease (Idempotentcy Check) - Changed should equal false
+  ansible.windows.win_dhcp_lease:
+    type: lease
+    ip: "{{ dhcp_lease_ip }}"
+    scope_id: "{{ dhcp_scope_id }}"
+    mac: "{{ dhcp_lease_mac }}"
+    dns_hostname: "{{ dhcp_lease_hostname }}"
+    dns_regtype: noreg
+    description: This is a description!
+  register: create_lease
+  failed_when: create_lease.changed != false
+
+- name: Validate the Lease
+  ansible.windows.win_shell: |
+    Get-DhcpServerv4Scope | Get-DhcpServerv4Lease | Where-Object IPAddress -eq {{ dhcp_lease_ip }}
+  register: validate_lease_out
+  failed_when: validate_lease_out.stdout == ""
+
+- name: Convert Lease to Reservation
+  ansible.windows.win_dhcp_lease:
+    type: reservation
+    ip: "{{ dhcp_lease_ip }}"
+
+- name: Convert Lease to Reservation (Idempotentcy Check) - Changed should equal false
+  ansible.windows.win_dhcp_lease:
+    type: reservation
+    ip: "{{ dhcp_lease_ip }}"
+  register: convert_lease_to_reservation
+  failed_when: convert_lease_to_reservation.changed != false
+
+- name: Validate the Reservation
+  ansible.windows.win_shell: |
+    Get-DhcpServerv4Scope | Get-DhcpServerv4Reservation | Where-Object IPAddress -eq {{ dhcp_lease_ip }}
+  register: validate_reservation_out
+  failed_when: validate_reservation_out.stdout == ""
+
+- name: Update Reservation Description
+  ansible.windows.win_dhcp_lease:
+    type: reservation
+    mac: "{{ dhcp_lease_mac }}"
+    description: Changed Description!
+
+- name: Update Reservation Description (Idempotentcy Check) - Changed should equal false
+  ansible.windows.win_dhcp_lease:
+    type: reservation
+    mac: "{{ dhcp_lease_mac }}"
+    description: Changed Description!
+  register: update_reservation_description
+  failed_when: update_reservation_description.changed != false
+
+- name: Validate the Description
+  ansible.windows.win_shell: |
+    Get-DhcpServerv4Scope | Get-DhcpServerv4Lease | Where-Object {($_.ClientId -eq "{{ dhcp_lease_mac }}") -and ($_.Description -eq "Changed Description!")}
+  register: validate_description_out
+  failed_when: validate_description_out.stdout == ""
+
+- name: Convert Reservation to Lease
+  ansible.windows.win_dhcp_lease:
+    type: lease
+    ip: "{{ dhcp_lease_ip }}"
+
+- name: Convert Reservation to Lease (Idempotentcy Check) - Changed should equal false
+  ansible.windows.win_dhcp_lease:
+    type: lease
+    ip: "{{ dhcp_lease_ip }}"
+  register: convert_reservation_to_lease
+  failed_when: convert_reservation_to_lease.changed != false
+
+- name: Remove DHCP Reservation
+  ansible.windows.win_dhcp_lease:
+    state: absent
+    mac: "{{ dhcp_lease_mac }}"
+
+- name: Remove DHCP Reservation (Idempotentcy Check) - Changed should equal false
+  ansible.windows.win_dhcp_lease:
+    state: absent
+    mac: "{{ dhcp_lease_mac }}"
+  register: remove_reservation
+  failed_when: remove_reservation.changed != false
+
+- name: Validate the State
+  ansible.windows.win_shell: |
+    Get-DhcpServerv4Scope | Get-DhcpServerv4Reservation | Where-Object IPAddress -eq {{ dhcp_lease_ip }}
+  register: validate_state_out
+  failed_when: validate_state_out.stdout != ""
+
+# Test Reservation creation and name Update
+- name: Create Reservation with Name
+  win_dhcp_lease:
+    type: reservation
+    ip: "{{ dhcp_lease_ip }}"
+    scope_id: "{{ dhcp_scope_id }}"
+    mac: "{{ dhcp_lease_mac }}"
+    reservation_name: "original-name"
+
+- name: Update Reservation Name
+  win_dhcp_lease:
+    type: reservation
+    ip: "{{ dhcp_lease_ip }}"
+    mac: "{{ dhcp_lease_mac }}"
+    reservation_name: "updated-name"
+
+- name: Validate Reservation Name Update
+  ansible.windows.win_shell: |
+    $reservation = Get-DhcpServerv4Scope | Get-DhcpServerv4Reservation | Where-Object {($_.IPAddress -eq "{{ dhcp_lease_ip }}") -and ($_.Name -eq "updated-name")}
+    if (-not $reservation) { throw "Reservation name update failed" }
+  register: validate_name_update
+  failed_when: validate_name_update.stderr != ""
+
+- name: Remove DHCP Reservation
+  ansible.windows.win_dhcp_lease:
+    state: absent
+    mac: "{{ dhcp_lease_mac }}"
+
+# Test Error Handling - Invalid MAC Address
+- name: Attempt to Create Lease with Invalid MAC
+  win_dhcp_lease:
+    type: lease
+    ip: "{{ dhcp_lease_ip }}"
+    scope_id: "{{ dhcp_scope_id }}"
+    mac: "invalid-mac"
+  register: invalid_mac_result
+  failed_when: invalid_mac_result.failed == false
+
+# Test Error Handling - IP Outside Scope
+- name: Attempt to Create Lease with IP Outside Scope
+  win_dhcp_lease:
+    type: lease
+    ip: "177.16.99.1"
+    scope_id: "{{ dhcp_scope_id }}"
+    mac: "{{ dhcp_lease_mac }}"
+  register: invalid_ip_result
+  failed_when: invalid_ip_result.failed == false

--- a/tests/integration/targets/win_dhcp_lease/tasks/tests_checkmode.yml
+++ b/tests/integration/targets/win_dhcp_lease/tasks/tests_checkmode.yml
@@ -1,0 +1,52 @@
+---
+- name: Check DHCP Service/Role Install State
+  ansible.windows.win_feature:
+    name: DHCP
+    state: present
+    include_management_tools: yes
+  register: dhcp_role
+  check_mode: true
+
+- name: Reboot if Necessary
+  ansible.windows.win_reboot:
+  when: dhcp_role.reboot_required
+  check_mode: true
+
+- name: Remove DHCP Address by IP
+  win_dhcp_lease:
+    state: absent
+    ip: "{{ dhcp_lease_ip }}"
+  check_mode: true
+
+- name: Create Lease
+  win_dhcp_lease:
+    type: lease
+    ip: "{{ dhcp_lease_ip }}"
+    scope_id: "{{ dhcp_scope_id }}"
+    mac: "{{ dhcp_lease_mac }}"
+    dns_hostname: "{{ dhcp_lease_hostname }}"
+    dns_regtype: noreg
+    description: This is a description!
+  check_mode: true
+
+- name: Create Reservation
+  win_dhcp_lease:
+    type: reservation
+    ip: "{{ dhcp_lease_ip }}"
+    mac: "{{ dhcp_lease_mac }}"
+    scope_id: "{{ dhcp_scope_id }}"
+  check_mode: true
+
+- name: Create Reservation w/Description
+  win_dhcp_lease:
+    type: reservation
+    ip: "{{ dhcp_lease_ip }}"
+    mac: "{{ dhcp_lease_mac }}"
+    scope_id: "{{ dhcp_scope_id }}"
+    description: This is a Description!
+  check_mode: true
+
+- name: Remove DHCP Reservation by MAC
+  win_dhcp_lease:
+    state: absent
+    mac: "{{ dhcp_lease_mac }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Migrated win_dhcp_lease module from ansible.community to ansible.windows
- Bug fixed - when creating a reservation from scratch, reservation name is not being applied. In addition lease was being created and then converted to reservation which is insufficient. 
- Extra tests added: 
  1) Validating failure when wrong formatted mac inputted.
  2) Validating failure when IP that is out of scope is inputted.
  3) Validate the creation and name update of a reservation from scratch.
- Added extra example to documentation to cover the update scenario of a lease.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_dhcp_lease
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
