### PR TITLE
Migrate win_hosts module to ansible.windows repo from ansible.community repo

### DIFF
--- a/plugins/modules/win_hosts.ps1
+++ b/plugins/modules/win_hosts.ps1
@@ -1,0 +1,267 @@
+#!powershell
+
+# Copyright: (c) 2018, Micah Hunsberger (@mhunsber)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+Set-StrictMode -Version 2
+$ErrorActionPreference = "Stop"
+
+$spec = @{
+    options = @{
+        state = @{ type = "str"; choices = "absent", "present"; default = "present" }
+        aliases = @{ type = "list"; elements = "str" }
+        canonical_name = @{ type = "str" }
+        ip_address = @{ type = "str" }
+        action = @{ type = "str"; choices = "add", "remove", "set"; default = "set" }
+    }
+    required_if = @(, @( "state", "present", @("canonical_name", "ip_address")))
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$state = $module.Params.state
+$aliases = $module.Params.aliases
+$canonical_name = $module.Params.canonical_name
+$ip_address = $module.Params.ip_address
+$action = $module.Params.action
+
+$tmp = [ipaddress]::None
+if ($ip_address -and -not [ipaddress]::TryParse($ip_address, [ref]$tmp)) {
+    $module.FailJson("win_hosts: Argument ip_address needs to be a valid ip address, but was $ip_address")
+}
+$ip_address_type = $tmp.AddressFamily
+
+$hosts_file = Get-Item -LiteralPath "$env:SystemRoot\System32\drivers\etc\hosts"
+
+Function Get-CommentIndex($line) {
+    $c_index = $line.IndexOf('#')
+    if ($c_index -lt 0) {
+        $c_index = $line.Length
+    }
+    return $c_index
+}
+
+Function Get-HostEntryPart($line) {
+    $success = $true
+    $c_index = Get-CommentIndex -line $line
+    $pure_line = $line.Substring(0, $c_index).Trim()
+    $bits = $pure_line -split "\s+"
+    if ($bits.Length -lt 2) {
+        return @{
+            success = $false
+            ip_address = ""
+            ip_type = ""
+            canonical_name = ""
+            aliases = @()
+        }
+    }
+    $ip_obj = [ipaddress]::None
+    if (-not [ipaddress]::TryParse($bits[0], [ref]$ip_obj) ) {
+        $success = $false
+    }
+    $cname = $bits[1]
+    $als = New-Object string[] ($bits.Length - 2)
+    [array]::Copy($bits, 2, $als, 0, $als.Length)
+    return @{
+        success = $success
+        ip_address = $ip_obj.IPAddressToString
+        ip_type = $ip_obj.AddressFamily
+        canonical_name = $cname
+        aliases = $als
+    }
+}
+
+Function Find-HostName($line, $name) {
+    $c_idx = Get-CommentIndex -line $line
+    $re = New-Object regex ("\s+$($name.Replace('.',"\."))(\s|$)", [System.Text.RegularExpressions.RegexOptions]::IgnoreCase)
+    $match = $re.Match($line, 0, $c_idx)
+    return $match
+}
+
+Function Remove-HostEntry($list, $idx) {
+    $module.Result.changed = $true
+    $list.RemoveAt($idx)
+}
+
+Function Add-HostEntry($list, $cname, $aliases, $ip) {
+    $module.Result.changed = $true
+    $line = "$ip $cname $($aliases -join ' ')"
+    $list.Add($line) | Out-Null
+}
+
+Function Remove-HostnamesFromEntry($list, $idx, $aliases) {
+    $line = $list[$idx]
+    $line_removed = $false
+
+    foreach ($name in $aliases) {
+        $match = Find-HostName -line $line -name $name
+        if ($match.Success) {
+            $line = $line.Remove($match.Index + 1, $match.Length - 1)
+            # was this the last alias? (check for space characters after trimming)
+            if ($line.Substring(0, (Get-CommentIndex -line $line)).Trim() -inotmatch "\s") {
+                $list.RemoveAt($idx)
+                $line_removed = $true
+                # we're done
+                return @{
+                    line_removed = $line_removed
+                }
+            }
+        }
+    }
+    if ($line -ne $list[$idx]) {
+        $module.Result.changed = $true
+        $list[$idx] = $line
+    }
+    return @{
+        line_removed = $line_removed
+    }
+}
+
+Function Add-AliasesToEntry($list, $idx, $aliases) {
+    $line = $list[$idx]
+    foreach ($name in $aliases) {
+        $match = Find-HostName -line $line -name $name
+        if (-not $match.Success) {
+            # just add the alias before the comment
+            $line = $line.Insert((Get-CommentIndex -line $line), " $name ")
+        }
+    }
+    if ($line -ne $list[$idx]) {
+        $module.Result.changed = $true
+        $list[$idx] = $line
+    }
+}
+
+$hosts_lines = New-Object System.Collections.ArrayList
+
+Get-Content -LiteralPath $hosts_file.FullName | ForEach-Object { $hosts_lines.Add($_) } | Out-Null
+$module.Diff.before = ($hosts_lines -join "`n") + "`n"
+
+if ($state -eq 'absent') {
+    # go through and remove canonical_name and ip
+    for ($idx = 0; $idx -lt $hosts_lines.Count; $idx++) {
+        $entry = $hosts_lines[$idx]
+        # skip comment lines
+        if (-not $entry.Trim().StartsWith('#')) {
+            $entry_parts = Get-HostEntryPart -line $entry
+            if ($entry_parts.success) {
+                if (-not $ip_address -or $entry_parts.ip_address -eq $ip_address) {
+                    if (-not $canonical_name -or $entry_parts.canonical_name -eq $canonical_name) {
+                        Remove-HostEntry -list $hosts_lines -idx $idx
+                        # keep index correct if we removed the line
+                        $idx = $idx - 1
+                    }
+                }
+            }
+        }
+    }
+}
+if ($state -eq 'present') {
+    $entry_idx = -1
+    $aliases_to_keep = @()
+    # go through lines, find the entry and determine what to remove based on action
+    for ($idx = 0; $idx -lt $hosts_lines.Count; $idx++) {
+        $entry = $hosts_lines[$idx]
+        # skip comment lines
+        if (-not $entry.Trim().StartsWith('#')) {
+            $entry_parts = Get-HostEntryPart -line $entry
+            if ($entry_parts.success) {
+                $aliases_to_remove = @()
+                if ($entry_parts.ip_address -eq $ip_address) {
+                    if ($entry_parts.canonical_name -eq $canonical_name) {
+                        $entry_idx = $idx
+
+                        if ($action -eq 'set') {
+                            $aliases_to_remove = $entry_parts.aliases | Where-Object { $aliases -notcontains $_ }
+                        }
+                        elseif ($action -eq 'remove') {
+                            $aliases_to_remove = $aliases
+                        }
+                    }
+                    else {
+                        # this is the right ip_address, but not the cname we were looking for.
+                        # we need to make sure none of aliases or canonical_name exist for this entry
+                        # since the given canonical_name should be an A/AAAA record,
+                        # and aliases should be cname records for the canonical_name.
+                        $aliases_to_remove = $aliases + $canonical_name
+                    }
+                }
+                else {
+                    # this is not the ip_address we are looking for
+                    if ($ip_address_type -eq $entry_parts.ip_type) {
+                        if ($entry_parts.canonical_name -eq $canonical_name) {
+                            Remove-HostEntry -list $hosts_lines -idx $idx
+                            $idx = $idx - 1
+                            if ($action -ne "set") {
+                                # keep old aliases intact
+                                $aliases_to_keep += $entry_parts.aliases | Where-Object { ($aliases + $aliases_to_keep + $canonical_name) -notcontains $_ }
+                            }
+                        }
+                        elseif ($action -eq "remove") {
+                            $aliases_to_remove = $canonical_name
+                        }
+                        elseif ($aliases -contains $entry_parts.canonical_name) {
+                            Remove-HostEntry -list $hosts_lines -idx $idx
+                            $idx = $idx - 1
+                            if ($action -eq "add") {
+                                # keep old aliases intact
+                                $aliases_to_keep += $entry_parts.aliases | Where-Object { ($aliases + $aliases_to_keep + $canonical_name) -notcontains $_ }
+                            }
+                        }
+                        else {
+                            $aliases_to_remove = $aliases + $canonical_name
+                        }
+                    }
+                    else {
+                        # TODO: Better ipv6 support. There is odd behavior for when an alias can be used for both ipv6 and ipv4
+                    }
+                }
+
+                if ($aliases_to_remove) {
+                    if ((Remove-HostnamesFromEntry -list $hosts_lines -idx $idx -aliases $aliases_to_remove).line_removed) {
+                        $idx = $idx - 1
+                    }
+                }
+            }
+        }
+    }
+
+    if ($entry_idx -ge 0) {
+        $aliases_to_add = @()
+        $entry_parts = Get-HostEntryPart -line $hosts_lines[$entry_idx]
+        if ($action -eq 'remove') {
+            $aliases_to_add = $aliases_to_keep | Where-Object { $entry_parts.aliases -notcontains $_ }
+        }
+        else {
+            $aliases_to_add = ($aliases + $aliases_to_keep) | Where-Object { $entry_parts.aliases -notcontains $_ }
+        }
+
+        if ($aliases_to_add) {
+            Add-AliasesToEntry -list $hosts_lines -idx $entry_idx -aliases $aliases_to_add
+        }
+    }
+    else {
+        # add the entry at the end
+        if ($action -eq 'remove') {
+            if ($aliases_to_keep) {
+                Add-HostEntry -list $hosts_lines -ip $ip_address -cname $canonical_name -aliases $aliases_to_keep
+            }
+            else {
+                Add-HostEntry -list $hosts_lines -ip $ip_address -cname $canonical_name
+            }
+        }
+        else {
+            Add-HostEntry -list $hosts_lines -ip $ip_address -cname $canonical_name -aliases ($aliases + $aliases_to_keep)
+        }
+    }
+}
+
+$module.Diff.after = ($hosts_lines -join "`n") + "`n"
+if ( $module.Result.changed -and -not $module.CheckMode ) {
+    Set-Content -LiteralPath $hosts_file.FullName -Value $hosts_lines
+}
+
+$module.ExitJson()

--- a/plugins/modules/win_hosts.py
+++ b/plugins/modules/win_hosts.py
@@ -1,0 +1,120 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2018, Micah Hunsberger (@mhunsber)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r'''
+---
+module: win_hosts
+short_description: Manages hosts file entries on Windows.
+description:
+  - Manages hosts file entries on Windows.
+  - Maps IPv4 or IPv6 addresses to canonical names.
+  - Adds, removes, or sets cname records for ip and hostname pairs.
+  - Modifies %windir%\\system32\\drivers\\etc\\hosts.
+version_added: 2.6.0
+options:
+  state:
+    description:
+      - Whether the entry should be present or absent.
+      - If only I(canonical_name) is provided when C(state=absent), then
+        all hosts entries with the canonical name of I(canonical_name)
+        will be removed.
+      - If only I(ip_address) is provided when C(state=absent), then all
+        hosts entries with the ip address of I(ip_address) will be removed.
+      - If I(ip_address) and I(canonical_name) are both omitted when
+        C(state=absent), then all hosts entries will be removed.
+    choices:
+      - absent
+      - present
+    default: present
+    type: str
+  canonical_name:
+    description:
+      - A canonical name for the host entry.
+      - required for C(state=present).
+    type: str
+  ip_address:
+    description:
+      - The ip address for the host entry.
+      - Can be either IPv4 (A record) or IPv6 (AAAA record).
+      - Required for C(state=present).
+    type: str
+  aliases:
+    description:
+      - A list of additional names (cname records) for the host entry.
+      - Only applicable when C(state=present).
+    type: list
+    elements: str
+  action:
+    choices:
+      - add
+      - remove
+      - set
+    description:
+      - Controls the behavior of I(aliases).
+      - Only applicable when C(state=present).
+      - If C(add), each alias in I(aliases) will be added to the host entry.
+      - If C(set), each alias in I(aliases) will be added to the host entry,
+        and other aliases will be removed from the entry.
+    default: set
+    type: str
+author:
+  - Micah Hunsberger (@mhunsber)
+notes:
+  - Each canonical name can only be mapped to one IPv4 and one IPv6 address.
+    If I(canonical_name) is provided with C(state=present) and is found
+    to be mapped to another IP address that is the same type as, but unique
+    from I(ip_address), then I(canonical_name) and all I(aliases) will
+    be removed from the entry and added to an entry with the provided IP address.
+  - Each alias can only be mapped to one canonical name. If I(aliases) is provided
+    with C(state=present) and an alias is found to be mapped to another canonical
+    name, then the alias will be removed from the entry and either added to or removed
+    from (depending on I(action)) an entry with the provided canonical name.
+seealso:
+  - module: ansible.windows.win_template
+  - module: ansible.windows.win_file
+  - module: ansible.windows.win_copy
+'''
+
+EXAMPLES = r'''
+- name: Add 127.0.0.1 as an A record for localhost
+  ansible.windows.win_hosts:
+    state: present
+    canonical_name: localhost
+    ip_address: 127.0.0.1
+
+- name: Add ::1 as an AAAA record for localhost
+  ansible.windows.win_hosts:
+    state: present
+    canonical_name: localhost
+    ip_address: '::1'
+
+- name: Remove 'bar' and 'zed' from the list of aliases for foo (192.168.1.100)
+  ansible.windows.win_hosts:
+    state: present
+    canonical_name: foo
+    ip_address: 192.168.1.100
+    action: remove
+    aliases:
+      - bar
+      - zed
+
+- name: Remove hosts entries with canonical name 'bar'
+  ansible.windows.win_hosts:
+    state: absent
+    canonical_name: bar
+
+- name: Remove 10.2.0.1 from the list of hosts
+  ansible.windows.win_hosts:
+    state: absent
+    ip_address: 10.2.0.1
+
+- name: Ensure all name resolution is handled by DNS
+  ansible.windows.win_hosts:
+    state: absent
+'''
+
+RETURN = r'''
+'''

--- a/tests/integration/targets/win_hosts/aliases
+++ b/tests/integration/targets/win_hosts/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group1

--- a/tests/integration/targets/win_hosts/defaults/main.yml
+++ b/tests/integration/targets/win_hosts/defaults/main.yml
@@ -1,0 +1,13 @@
+---
+test_win_hosts_cname: testhost
+test_win_hosts_ip: 192.168.168.1
+
+test_win_hosts_aliases_set:
+  - alias1
+  - alias2
+  - alias3
+  - alias4
+
+test_win_hosts_aliases_remove:
+  - alias3
+  - alias4

--- a/tests/integration/targets/win_hosts/meta/main.yml
+++ b/tests/integration/targets/win_hosts/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- setup_remote_tmp_dir

--- a/tests/integration/targets/win_hosts/tasks/main.yml
+++ b/tests/integration/targets/win_hosts/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: take a copy of the original hosts file
+  ansible.windows.win_copy:
+    src: C:\Windows\System32\drivers\etc\hosts
+    dest: '{{ remote_tmp_dir }}\hosts'
+    remote_src: yes
+
+- block:
+  - name: run tests
+    include_tasks: tests.yml
+
+  always:
+  - name: restore hosts file
+    ansible.windows.win_copy:
+      src: '{{ remote_tmp_dir }}\hosts'
+      dest: C:\Windows\System32\drivers\etc\hosts
+      remote_src: yes

--- a/tests/integration/targets/win_hosts/tasks/tests.yml
+++ b/tests/integration/targets/win_hosts/tasks/tests.yml
@@ -1,0 +1,189 @@
+---
+
+- name: add a simple host with address
+  win_hosts:
+    state: present
+    ip_address: "{{ test_win_hosts_ip }}"
+    canonical_name: "{{ test_win_hosts_cname }}"
+  register: add_ip
+
+- assert:
+    that:
+      - "add_ip.changed == true"
+
+- name: get actual dns result
+  ansible.windows.win_shell: "try{ [array]$t = [Net.DNS]::GetHostEntry('{{ test_win_hosts_cname }}') } catch { return 'false' } if ($t[0].HostName -eq '{{ test_win_hosts_cname }}' -and $t[0].AddressList[0].toString() -eq '{{ test_win_hosts_ip }}'){ return 'true' } else { return 'false' }"
+  register: add_ip_actual
+
+- assert:
+    that:
+      - "add_ip_actual.stdout_lines[0]|lower == 'true'"
+
+- name: add a simple host with ipv4 address (idempotent)
+  win_hosts:
+    state: present
+    ip_address: "{{ test_win_hosts_ip }}"
+    canonical_name: "{{ test_win_hosts_cname }}"
+  register: add_ip
+
+- assert:
+    that:
+      - "add_ip.changed == false"
+
+- name: remove simple host
+  win_hosts:
+    state: absent
+    ip_address: "{{ test_win_hosts_ip }}"
+    canonical_name: "{{ test_win_hosts_cname }}"
+  register: remove_ip
+
+- assert:
+    that:
+      - "remove_ip.changed == true"
+
+- name: get actual dns result
+  ansible.windows.win_shell: "try{ [array]$t = [Net.DNS]::GetHostEntry('{{ test_win_hosts_cname}}') } catch { return 'false' } if ($t[0].HostName -eq '{{ test_win_hosts_cname }}' -and $t[0].AddressList[0].toString() -eq '{{ test_win_hosts_ip }}'){ return 'true' } else { return 'false' }"
+  register: remove_ip_actual
+  failed_when: "remove_ip_actual.rc == 0"
+
+- assert:
+    that:
+      - "remove_ip_actual.stdout_lines[0]|lower == 'false'"
+
+- name: remove simple host (idempotent)
+  win_hosts:
+    state: absent
+    ip_address: "{{ test_win_hosts_ip }}"
+    canonical_name: "{{ test_win_hosts_cname }}"
+  register: remove_ip
+
+- assert:
+    that:
+      - "remove_ip.changed == false"
+
+- name: add host and set aliases
+  win_hosts:
+    state: present
+    ip_address: "{{ test_win_hosts_ip }}"
+    canonical_name: "{{ test_win_hosts_cname }}"
+    aliases: "{{ test_win_hosts_aliases_set | union(test_win_hosts_aliases_remove) }}"
+    action: set
+  register: set_aliases
+
+- assert:
+    that:
+      - "set_aliases.changed == true"
+
+- name: get actual dns result for host
+  ansible.windows.win_shell: "try{ [array]$t = [Net.DNS]::GetHostEntry('{{ test_win_hosts_cname }}') } catch { return 'false' } if ($t[0].HostName -eq '{{ test_win_hosts_cname }}' -and $t[0].AddressList[0].toString() -eq '{{ test_win_hosts_ip }}'){ return 'true' } else { return 'false' }"
+  register: set_aliases_actual_host
+
+- assert:
+    that:
+      - "set_aliases_actual_host.stdout_lines[0]|lower == 'true'"
+
+- name: get actual dns results for aliases
+  ansible.windows.win_shell: "try{ [array]$t = [Net.DNS]::GetHostEntry('{{ item }}') } catch { return 'false' } if ($t[0].HostName -eq '{{ test_win_hosts_cname }}' -and $t[0].AddressList[0].toString() -eq '{{ test_win_hosts_ip }}'){ return 'true' } else { return 'false' }"
+  register: set_aliases_actual
+  with_items: "{{ test_win_hosts_aliases_set | union(test_win_hosts_aliases_remove) }}"
+
+- assert:
+    that:
+      - "item.stdout_lines[0]|lower == 'true'"
+  with_items: "{{ set_aliases_actual.results }}"
+
+- name: add host and set aliases (idempotent)
+  win_hosts:
+    state: present
+    ip_address: "{{ test_win_hosts_ip }}"
+    canonical_name: "{{ test_win_hosts_cname }}"
+    aliases: "{{ test_win_hosts_aliases_set | union(test_win_hosts_aliases_remove) }}"
+    action: set
+  register: set_aliases
+
+- assert:
+    that:
+      - "set_aliases.changed == false"
+
+- name: remove aliases from the list
+  win_hosts:
+    state: present
+    ip_address: "{{ test_win_hosts_ip }}"
+    canonical_name: "{{ test_win_hosts_cname }}"
+    aliases: "{{ test_win_hosts_aliases_remove }}"
+    action: remove
+  register: remove_aliases
+
+- assert:
+    that:
+      - "remove_aliases.changed == true"
+
+- name: get actual dns result for removed aliases
+  ansible.windows.win_shell: "try{ [array]$t = [Net.DNS]::GetHostEntry('{{ item }}') } catch { return 'false' } if ($t[0].HostName -eq '{{ test_win_hosts_cname }}' -and $t[0].AddressList[0].toString() -eq '{{ test_win_hosts_ip }}'){ return 'true' } else { return 'false' }"
+  register: remove_aliases_removed_actual
+  failed_when: "remove_aliases_removed_actual.rc == 0"
+  with_items: "{{ test_win_hosts_aliases_remove }}"
+
+- assert:
+    that:
+      - "item.stdout_lines[0]|lower == 'false'"
+  with_items: "{{ remove_aliases_removed_actual.results }}"
+
+- name: get actual dns result for remaining aliases
+  ansible.windows.win_shell: "try{ [array]$t = [Net.DNS]::GetHostEntry('{{ item }}') } catch { return 'false' } if ($t[0].HostName -eq '{{ test_win_hosts_cname }}' -and $t[0].AddressList[0].toString() -eq '{{ test_win_hosts_ip }}'){ return 'true' } else { return 'false' }"
+  register: remove_aliases_remain_actual
+  with_items: "{{ test_win_hosts_aliases_set | difference(test_win_hosts_aliases_remove) }}"
+
+- assert:
+    that:
+      - "item.stdout_lines[0]|lower == 'true'"
+  with_items: "{{ remove_aliases_remain_actual.results }}"
+
+- name: remove aliases from the list (idempotent)
+  win_hosts:
+    state: present
+    ip_address: "{{ test_win_hosts_ip }}"
+    canonical_name: "{{ test_win_hosts_cname }}"
+    aliases: "{{ test_win_hosts_aliases_remove }}"
+    action: remove
+  register: remove_aliases
+
+- assert:
+    that:
+      - "remove_aliases.changed == false"
+
+- name: add aliases back
+  win_hosts:
+    state: present
+    ip_address: "{{ test_win_hosts_ip }}"
+    canonical_name: "{{ test_win_hosts_cname }}"
+    aliases: "{{ test_win_hosts_aliases_remove }}"
+    action: add
+  register: add_aliases
+
+- assert:
+    that:
+      - "add_aliases.changed == true"
+
+- name: get actual dns results for aliases
+  ansible.windows.win_shell: "try{ [array]$t = [Net.DNS]::GetHostEntry('{{ item }}') } catch { return 'false' } if ($t[0].HostName -eq '{{ test_win_hosts_cname }}' -and $t[0].AddressList[0].toString() -eq '{{ test_win_hosts_ip }}'){ return 'true' } else { return 'false' }"
+  register: add_aliases_actual
+  with_items: "{{ test_win_hosts_aliases_set | union(test_win_hosts_aliases_remove) }}"
+
+- assert:
+    that:
+      - "item.stdout_lines[0]|lower == 'true'"
+  with_items: "{{ add_aliases_actual.results }}"
+
+- name: add aliases back (idempotent)
+  win_hosts:
+    state: present
+    ip_address: "{{ test_win_hosts_ip }}"
+    canonical_name: "{{ test_win_hosts_cname }}"
+    aliases: "{{ test_win_hosts_aliases_remove }}"
+    action: add
+  register: add_aliases
+
+- assert:
+    that:
+      - "add_aliases.changed == false"


### PR DESCRIPTION
##### SUMMARY
- Migration of win_hosts module from community repo to ansible.windows repo.
- Bug Fix: Fixed issue where not all lines were removed when removing multiple entries from the hosts file due to incorrect $idx handling.

##### ISSUE TYPE
- New Module Pull Request
##### COMPONENT NAME
- win_hosts
##### ADDITIONAL INFORMATION
- Ansible windows module win_hosts migration
- As part of community.windows to ansible.windows migration.