### PR TITLE
Migrate win_timezone module to ansible.windows repo from ansible.community repo

### DIFF
--- a/plugins/modules/win_timezone.ps1
+++ b/plugins/modules/win_timezone.ps1
@@ -1,0 +1,73 @@
+#!powershell
+
+# Copyright: (c) 2015, Phil Schwartz <schwartzmx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+
+$params = Parse-Args $args -supports_check_mode $true
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
+$diff_support = Get-AnsibleParam -obj $params -name "_ansible_diff" -type "bool" -default $false
+
+$timezone = Get-AnsibleParam -obj $params -name "timezone" -type "str" -failifempty $true
+
+$result = @{
+    changed = $false
+    previous_timezone = $timezone
+    timezone = $timezone
+}
+
+Try {
+    # Get the current timezone set
+    $result.previous_timezone = $(tzutil.exe /g)
+    If ($LASTEXITCODE -ne 0) {
+        Throw "An error occurred when getting the current machine's timezone setting."
+    }
+
+    if ( $result.previous_timezone -eq $timezone ) {
+        Exit-Json $result "Timezone '$timezone' is already set on this machine"
+    }
+    Else {
+        # Check that timezone is listed as an available timezone to the machine
+        $tzList = $(tzutil.exe /l).ToLower()
+        If ($LASTEXITCODE -ne 0) {
+            Throw "An error occurred when listing the available timezones."
+        }
+
+        $tzExists = $tzList.Contains(($timezone -Replace '_dstoff').ToLower())
+        if (-not $tzExists) {
+            Fail-Json $result "The specified timezone: $timezone isn't supported on the machine."
+        }
+
+        if ($check_mode) {
+            $result.changed = $true
+        }
+        else {
+            tzutil.exe /s "$timezone"
+            if ($LASTEXITCODE -ne 0) {
+                Throw "An error occurred when setting the specified timezone with tzutil."
+            }
+
+            $new_timezone = $(tzutil.exe /g)
+            if ($LASTEXITCODE -ne 0) {
+                Throw "An error occurred when getting the current machine's timezone setting."
+            }
+
+            if ($timezone -eq $new_timezone) {
+                $result.changed = $true
+            }
+        }
+
+        if ($diff_support) {
+            $result.diff = @{
+                before = "$($result.previous_timezone)`n"
+                after = "$timezone`n"
+            }
+        }
+    }
+}
+Catch {
+    Fail-Json $result "Error setting timezone to: $timezone."
+}
+
+Exit-Json $result

--- a/plugins/modules/win_timezone.py
+++ b/plugins/modules/win_timezone.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2015, Phil Schwartz <schwartzmx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r'''
+---
+module: win_timezone
+short_description: Sets Windows machine timezone
+description:
+- Sets machine time to the specified timezone.
+options:
+  timezone:
+    description:
+    - Timezone to set to.
+    - 'Example: Central Standard Time'
+    - To disable Daylight Saving time, add the suffix C(_dstoff) on timezones that support this.
+    type: str
+    required: yes
+notes:
+- The module will check if the provided timezone is supported on the machine.
+- A list of possible timezones is available from C(tzutil.exe /l) and from
+  U(https://msdn.microsoft.com/en-us/library/ms912391.aspx)
+- If running on Server 2008 the hotfix
+  U(https://support.microsoft.com/en-us/help/2556308/tzutil-command-line-tool-is-added-to-windows-vista-and-to-windows-server-2008)
+  needs to be installed to be able to run this module.
+seealso:
+- module: community.windows.win_region
+author:
+- Phil Schwartz (@schwartzmx)
+'''
+
+EXAMPLES = r'''
+- name: Set timezone to 'Romance Standard Time' (GMT+01:00)
+  community.windows.win_timezone:
+    timezone: Romance Standard Time
+
+- name: Set timezone to 'GMT Standard Time' (GMT)
+  community.windows.win_timezone:
+    timezone: GMT Standard Time
+
+- name: Set timezone to 'Central Standard Time' (GMT-06:00)
+  community.windows.win_timezone:
+    timezone: Central Standard Time
+
+- name: Set timezime to Pacific Standard time and disable Daylight Saving time adjustments
+  community.windows.win_timezone:
+    timezone: Pacific Standard Time_dstoff
+'''
+
+RETURN = r'''
+previous_timezone:
+    description: The previous timezone if it was changed, otherwise the existing timezone.
+    returned: success
+    type: str
+    sample: Central Standard Time
+timezone:
+    description: The current timezone (possibly changed).
+    returned: success
+    type: str
+    sample: Central Standard Time
+'''

--- a/plugins/modules/win_timezone.py
+++ b/plugins/modules/win_timezone.py
@@ -10,6 +10,7 @@ module: win_timezone
 short_description: Sets Windows machine timezone
 description:
 - Sets machine time to the specified timezone.
+version_added: 2.6.0
 options:
   timezone:
     description:
@@ -33,19 +34,19 @@ author:
 
 EXAMPLES = r'''
 - name: Set timezone to 'Romance Standard Time' (GMT+01:00)
-  community.windows.win_timezone:
+  ansible.windows.win_timezone:
     timezone: Romance Standard Time
 
 - name: Set timezone to 'GMT Standard Time' (GMT)
-  community.windows.win_timezone:
+  ansible.windows.win_timezone:
     timezone: GMT Standard Time
 
 - name: Set timezone to 'Central Standard Time' (GMT-06:00)
-  community.windows.win_timezone:
+  ansible.windows.win_timezone:
     timezone: Central Standard Time
 
 - name: Set timezime to Pacific Standard time and disable Daylight Saving time adjustments
-  community.windows.win_timezone:
+  ansible.windows.win_timezone:
     timezone: Pacific Standard Time_dstoff
 '''
 

--- a/tests/integration/targets/win_timezone/aliases
+++ b/tests/integration/targets/win_timezone/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group4

--- a/tests/integration/targets/win_timezone/aliases
+++ b/tests/integration/targets/win_timezone/aliases
@@ -1,1 +1,1 @@
-shippable/windows/group4
+shippable/windows/group2

--- a/tests/integration/targets/win_timezone/tasks/main.yml
+++ b/tests/integration/targets/win_timezone/tasks/main.yml
@@ -1,0 +1,19 @@
+- name: Determine if server has tzutil.exe installed
+  ansible.windows.win_command: tzutil.exe /l
+  register: tzutil
+  ignore_errors: yes
+
+- name: Only run tests if tzutil.exe is installed
+  when: tzutil.rc == 0
+  block:
+
+  - name: Test in normal mode
+    import_tasks: tests.yml
+    vars:
+      in_check_mode: no
+
+  - name: Test in check-mode
+    import_tasks: tests.yml
+    vars:
+      in_check_mode: yes
+    check_mode: yes

--- a/tests/integration/targets/win_timezone/tasks/tests.yml
+++ b/tests/integration/targets/win_timezone/tasks/tests.yml
@@ -1,0 +1,100 @@
+# NOTE: Set to a known starting value, store original
+- name: Change starting timezone to GMT
+  win_timezone:
+    timezone: GMT Standard Time
+  register: original
+
+# NOTE: We don't know if it changed, we don't care
+- name: Test GMT timezone
+  assert:
+    that:
+    - original.timezone == 'GMT Standard Time'
+
+- name: Change timezone to GMT+1
+  win_timezone:
+    timezone: Romance Standard Time
+  register: romance
+
+- name: Test GMT+1 timezone
+  assert:
+    that:
+    - romance is changed
+    - romance.previous_timezone == 'GMT Standard Time'
+    - romance.timezone == 'Romance Standard Time'
+  when: not in_check_mode
+
+- name: Test GMT+1 timezone
+  assert:
+    that:
+    - romance is changed
+    - romance.previous_timezone == original.timezone
+    - romance.timezone == 'Romance Standard Time'
+  when: in_check_mode
+
+- name: Change timezone to GMT+1 again
+  win_timezone:
+    timezone: Romance Standard Time
+  register: romance
+
+- name: Test GMT+1 timezone
+  assert:
+    that:
+    - romance is not changed
+    - romance.previous_timezone == 'Romance Standard Time'
+    - romance.timezone == 'Romance Standard Time'
+  when: not in_check_mode
+
+- name: Test GMT+1 timezone
+  assert:
+    that:
+    - romance is changed
+    - romance.previous_timezone == original.timezone
+    - romance.timezone == 'Romance Standard Time'
+  when: in_check_mode
+
+- name: Change timezone to GMT+6
+  win_timezone:
+    timezone: Central Standard Time
+  register: central
+
+- name: Test GMT-6 timezone
+  assert:
+    that:
+    - central is changed
+    - central.previous_timezone == 'Romance Standard Time'
+    - central.timezone == 'Central Standard Time'
+  when: not in_check_mode
+
+- name: Test GMT+1 timezone
+  assert:
+    that:
+    - central is changed
+    - central.previous_timezone == original.timezone
+    - central.timezone == 'Central Standard Time'
+  when: in_check_mode
+
+- name: Change timezone to dstoff
+  win_timezone:
+    timezone: Eastern Standard Time_dstoff
+  register: dstoff_result
+
+- name: Test dstoff timezone
+  assert:
+    that:
+    - dstoff_result is changed
+    - dstoff_result.timezone == 'Eastern Standard Time_dstoff'
+
+- name: Change timezone to GMT+666
+  win_timezone:
+    timezone: Dag's Standard Time
+  register: dag
+  ignore_errors: yes
+
+- name: Test GMT+666 timezone
+  assert:
+    that:
+    - dag is failed
+
+- name: Restore original timezone
+  win_timezone:
+    timezone: '{{ original.timezone }}'


### PR DESCRIPTION
##### SUMMARY
- Promote the win_timezone Module from community with git history

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
- plugins/modules/win_timezone.ps1
- plugins/modules/win_timezone.py
- tests/integration/targets/win_timezone/aliases
- tests/integration/targets/win_timezone/tasks/main.yml
- tests/integration/targets/win_timezone/tasks/tests.yml

##### ADDITIONAL INFORMATION
- Migrating all history commits related to files/folders of win_timezone module 