### PR TITLE
win_timezone - ensure original timezone is restored at end of test

### DIFF
--- a/tests/integration/targets/win_timezone/tasks/main.yml
+++ b/tests/integration/targets/win_timezone/tasks/main.yml
@@ -1,19 +1,17 @@
-- name: Determine if server has tzutil.exe installed
-  ansible.windows.win_command: tzutil.exe /l
-  register: tzutil
-  ignore_errors: yes
+- name: get current timezone
+  win_command: tzutil.exe /g
+  register: original_timezone
+  changed_when: false
 
-- name: Only run tests if tzutil.exe is installed
-  when: tzutil.rc == 0
-  block:
+- block:
+  - name: Change starting timezone to GMT for test baseline
+    win_timezone:
+      timezone: GMT Standard Time
 
-  - name: Test in normal mode
+  - name: run tests
     import_tasks: tests.yml
-    vars:
-      in_check_mode: no
 
-  - name: Test in check-mode
-    import_tasks: tests.yml
-    vars:
-      in_check_mode: yes
-    check_mode: yes
+  always:
+  - name: reset timezone back to defaults
+    win_timezone:
+      timezone: "{{ original_timezone.stdout | trim }}"

--- a/tests/integration/targets/win_timezone/tasks/tests.yml
+++ b/tests/integration/targets/win_timezone/tasks/tests.yml
@@ -1,88 +1,149 @@
-# NOTE: Set to a known starting value, store original
-- name: Change starting timezone to GMT
+- name: Change timezone to GMT+1 - check mode
   win_timezone:
-    timezone: GMT Standard Time
-  register: original
+    timezone: Romance Standard Time
+  register: romance_check
+  check_mode: true
 
-# NOTE: We don't know if it changed, we don't care
-- name: Test GMT timezone
+- name: Get result of change timezone to GMT+1 - check mode
+  win_command: tzutil.exe /g
+  register: romance_actual_check
+  changed_when: false
+
+- name: Test GMT+1 timezone - check mode
   assert:
     that:
-    - original.timezone == 'GMT Standard Time'
+    - romance_check is change
+    - romance_check.previous_timezone == 'GMT Standard Time'
+    - romance_check.timezone == 'Romance Standard Time'
+    - romance_actual_check.stdout == 'GMT Standard Time'
 
 - name: Change timezone to GMT+1
   win_timezone:
     timezone: Romance Standard Time
   register: romance
 
-- name: Test GMT+1 timezone
-  assert:
-    that:
-    - romance is changed
-    - romance.previous_timezone == 'GMT Standard Time'
-    - romance.timezone == 'Romance Standard Time'
-  when: not in_check_mode
+- name: Get result of change timezone to GMT+1
+  win_command: tzutil.exe /g
+  register: romance_actual
+  changed_when: false
 
 - name: Test GMT+1 timezone
   assert:
     that:
-    - romance is changed
-    - romance.previous_timezone == original.timezone
+    - romance is change
+    - romance.previous_timezone == 'GMT Standard Time'
     - romance.timezone == 'Romance Standard Time'
-  when: in_check_mode
+    - romance_actual.stdout == 'Romance Standard Time'
 
 - name: Change timezone to GMT+1 again
   win_timezone:
     timezone: Romance Standard Time
-  register: romance
+  register: romance_again
 
-- name: Test GMT+1 timezone
+- name: Test GMT+1 timezone again
   assert:
     that:
-    - romance is not changed
-    - romance.previous_timezone == 'Romance Standard Time'
-    - romance.timezone == 'Romance Standard Time'
-  when: not in_check_mode
+    - not romance_again is changed
+    - romance_again.timezone == 'Romance Standard Time'
+    - romance_again.previous_timezone == 'Romance Standard Time'
 
-- name: Test GMT+1 timezone
+- name: Change timezone to GMT+6 - check
+  win_timezone:
+    timezone: Central Standard Time
+  register: central_check
+  check_mode: true
+
+- name: Get result of change timezone to GMT+6 - check
+  win_command: tzutil.exe /g
+  register: central_actual_check
+  changed_when: false
+
+- name: Test GMT+6 timezone - check
   assert:
     that:
-    - romance is changed
-    - romance.previous_timezone == original.timezone
-    - romance.timezone == 'Romance Standard Time'
-  when: in_check_mode
+    - central_check is change
+    - central_check.previous_timezone == 'Romance Standard Time'
+    - central_check.timezone == 'Central Standard Time'
+    - central_actual_check.stdout == 'Romance Standard Time'
 
 - name: Change timezone to GMT+6
   win_timezone:
     timezone: Central Standard Time
   register: central
 
-- name: Test GMT-6 timezone
+- name: Get result of change timezone to GMT+6
+  win_command: tzutil.exe /g
+  register: central_actual
+  changed_when: false
+
+- name: Test GMT+6 timezone
   assert:
     that:
     - central is changed
     - central.previous_timezone == 'Romance Standard Time'
     - central.timezone == 'Central Standard Time'
-  when: not in_check_mode
+    - central_actual.stdout == 'Central Standard Time'
 
-- name: Test GMT+1 timezone
+- name: Change timezone to GMT+6 again
+  win_timezone:
+    timezone: Central Standard Time
+  register: central_again
+
+- name: Test GMT+6 timezone again
   assert:
     that:
-    - central is changed
-    - central.previous_timezone == original.timezone
-    - central.timezone == 'Central Standard Time'
-  when: in_check_mode
+    - not central_again is changed
+    - central_again.timezone == 'Central Standard Time'
+    - central_again.previous_timezone == 'Central Standard Time'
+
+- name: Change timezone to dstoff - check
+  win_timezone:
+    timezone: Eastern Standard Time_dstoff
+  register: dstoff_check
+  check_mode: true
+
+- name: Get result of change timezone to dstoff - check
+  win_command: tzutil.exe /g
+  register: dstoff_actual_check
+  changed_when: false
+
+- name: Test dstoff timezone - check
+  assert:
+    that:
+    - dstoff_check is change
+    - dstoff_check.previous_timezone == 'Central Standard Time'
+    - dstoff_check.timezone == 'Eastern Standard Time_dstoff'
+    - dstoff_actual_check.stdout == 'Central Standard Time'
 
 - name: Change timezone to dstoff
   win_timezone:
     timezone: Eastern Standard Time_dstoff
-  register: dstoff_result
+  register: dstoff
+
+- name: Get result of change timezone to dstoff
+  win_command: tzutil.exe /g
+  register: dstoff_actual
+  changed_when: false
 
 - name: Test dstoff timezone
   assert:
     that:
-    - dstoff_result is changed
-    - dstoff_result.timezone == 'Eastern Standard Time_dstoff'
+    - dstoff is changed
+    - dstoff.previous_timezone == 'Central Standard Time'
+    - dstoff.timezone == 'Eastern Standard Time_dstoff'
+    - dstoff_actual.stdout == 'Eastern Standard Time_dstoff'
+
+- name: Change timezone to GMT+666 again
+  win_timezone:
+    timezone: Eastern Standard Time_dstoff
+  register: dstoff_again
+
+- name: Test GMT+666 timezone again
+  assert:
+    that:
+    - not dstoff_again is changed
+    - dstoff_again.timezone == 'Eastern Standard Time_dstoff'
+    - dstoff_again.previous_timezone == 'Eastern Standard Time_dstoff'
 
 - name: Change timezone to GMT+666
   win_timezone:
@@ -94,7 +155,3 @@
   assert:
     that:
     - dag is failed
-
-- name: Restore original timezone
-  win_timezone:
-    timezone: '{{ original.timezone }}'


### PR DESCRIPTION
##### SUMMARY
Fixes the `win_timezone` test to actually restore the original timezone.

##### ISSUE TYPE
- Test Pull Request