### PR TITLE
win_timezone - Upgrade to Ansible.Basic style

### DIFF
--- a/plugins/modules/win_timezone.ps1
+++ b/plugins/modules/win_timezone.ps1
@@ -3,71 +3,75 @@
 # Copyright: (c) 2015, Phil Schwartz <schwartzmx@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -CSharpUtil Ansible.Basic
 
-$params = Parse-Args $args -supports_check_mode $true
-$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
-$diff_support = Get-AnsibleParam -obj $params -name "_ansible_diff" -type "bool" -default $false
-
-$timezone = Get-AnsibleParam -obj $params -name "timezone" -type "str" -failifempty $true
-
-$result = @{
-    changed = $false
-    previous_timezone = $timezone
-    timezone = $timezone
-}
-
-Try {
-    # Get the current timezone set
-    $result.previous_timezone = $(tzutil.exe /g)
-    If ($LASTEXITCODE -ne 0) {
-        Throw "An error occurred when getting the current machine's timezone setting."
-    }
-
-    if ( $result.previous_timezone -eq $timezone ) {
-        Exit-Json $result "Timezone '$timezone' is already set on this machine"
-    }
-    Else {
-        # Check that timezone is listed as an available timezone to the machine
-        $tzList = $(tzutil.exe /l).ToLower()
-        If ($LASTEXITCODE -ne 0) {
-            Throw "An error occurred when listing the available timezones."
-        }
-
-        $tzExists = $tzList.Contains(($timezone -Replace '_dstoff').ToLower())
-        if (-not $tzExists) {
-            Fail-Json $result "The specified timezone: $timezone isn't supported on the machine."
-        }
-
-        if ($check_mode) {
-            $result.changed = $true
-        }
-        else {
-            tzutil.exe /s "$timezone"
-            if ($LASTEXITCODE -ne 0) {
-                Throw "An error occurred when setting the specified timezone with tzutil."
-            }
-
-            $new_timezone = $(tzutil.exe /g)
-            if ($LASTEXITCODE -ne 0) {
-                Throw "An error occurred when getting the current machine's timezone setting."
-            }
-
-            if ($timezone -eq $new_timezone) {
-                $result.changed = $true
-            }
-        }
-
-        if ($diff_support) {
-            $result.diff = @{
-                before = "$($result.previous_timezone)`n"
-                after = "$timezone`n"
-            }
+$spec = @{
+    options = @{
+        timezone = @{
+            required = $true
+            type = "str"
         }
     }
-}
-Catch {
-    Fail-Json $result "Error setting timezone to: $timezone."
+    supports_check_mode = $true
 }
 
-Exit-Json $result
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$timezone = $module.Params.timezone
+
+$module.Result.previous_timezone = $null
+$module.Result.timezone = $timezone
+
+Function Invoke-TzUtil {
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory)]
+        [object]
+        $Module,
+
+        [Parameter(Mandatory)]
+        [string]
+        $Action,
+
+        [Parameter(ValueFromRemainingArguments)]
+        [string[]]
+        $ArgumentList
+    )
+
+    $stdout = $null
+    $stderr = . { tzutil.exe @ArgumentList | Set-Variable -Name stdout } 2>&1 | ForEach-Object ToString
+
+    if ($LASTEXITCODE) {
+        $Module.Result.stdout = $stdout -join "`n"
+        $Module.Result.stderr = $stderr -join "`n"
+        $Module.Result.rc = $LASTEXITCODE
+        $Module.FailJson("An error occurred when $Action.")
+    }
+
+    $stdout
+}
+
+# Get the current timezone set
+$previousTz = Invoke-TzUtil /g -Module $module -Action "getting the current machine's timezone setting"
+$module.Result.previous_timezone = $previousTz
+
+if ($module.DiffMode) {
+    $module.Diff.before = "$previousTz`n"
+    $module.Diff.after = "$timezone`n"
+}
+
+if ($previousTz -ne $timezone) {
+    # Check that timezone is listed as an available timezone to the machine
+    $tzList = Invoke-TzUtil /l -Module $module -Action "listing the available timezones"
+
+    if ($tzList -notcontains ($timezone -replace '_dstoff')) {
+        $module.FailJson("The specified timezone: $timezone isn't supported on the machine.")
+    }
+
+    if (-not $module.CheckMode) {
+        $null = Invoke-TzUtil /s $timezone -Module $module -Action "setting the specified timezone"
+    }
+    $module.Result.changed = $true
+}
+
+$module.ExitJson()


### PR DESCRIPTION
##### SUMMARY
Upgrades the win_timzone module to the Ansible.Basic style module. This cleans up the older legacy module_util code and aligns it with the newer standards we try to write new modules in.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_timezone

##### ADDITIONAL INFORMATION
Typically I would have to create a changelog fragment for this change but as this is a new module that has not been released yet there are no public facing changes for users so it does not need one.