### PR TITLE
Update win_reboot.py

### DIFF
--- a/plugins/modules/win_reboot.py
+++ b/plugins/modules/win_reboot.py
@@ -102,7 +102,7 @@ EXAMPLES = r'''
 # Or you can make win_reboot validate exactly what you need to work before running the next task
 - name: Validate that the netlogon service has started, before running the next task
   ansible.windows.win_reboot:
-    test_command: 'exit (Get-Service -Name Netlogon).Status -ne "Running"'
+    test_command: '(Get-Service -Name Netlogon).Status -ne "Running"'
 '''
 
 RETURN = r'''


### PR DESCRIPTION

##### SUMMARY
The included example for testing if the rebooted system is ready does not work.  Removing the exit from the command fixes this.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
win_reboot.py

##### ADDITIONAL INFORMATION
If you use the included example you will retry until the default 600 second timeout.