### PR TITLE
win_powershell - Add defensive GetType() check

### DIFF
--- a/changelogs/fragments/win_powershell-type.yml
+++ b/changelogs/fragments/win_powershell-type.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    ansible.windows.win_powershell - Add extra checks to avoid ``GetType`` error when converting the output object
+    - ttps://github.com/ansible-collections/ansible.windows/issues/708

--- a/plugins/modules/win_powershell.ps1
+++ b/plugins/modules/win_powershell.ps1
@@ -363,7 +363,9 @@ Function Convert-OutputObject {
         elseif (&$isType -InputObject $InputObject -Type ([switch])) {
             $InputObject.IsPresent
         }
-        elseif ($InputObject.GetType().IsValueType) {
+        # Have a defensive check to see if GetType() exists as a method on the object.
+        # https://github.com/ansible-collections/ansible.windows/issues/708
+        elseif ('GetType' -in $InputObject.PSObject.Methods.Name -and $InputObject.GetType().IsValueType) {
             # We want to display just this value and not any properties it has (if any).
             $InputObject.PSObject.BaseObject
         }


### PR DESCRIPTION
##### SUMMARY
Some unique types may fail when calling the GetType() method. This commit adds a check to ensure the GetType() method exists before calling it to avoid an error when trying to process the output object.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/708

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_powershell