### PR TITLE
win_powershell - fix empty array result value

### DIFF
--- a/changelogs/fragments/win_powershell-result-array.yml
+++ b/changelogs/fragments/win_powershell-result-array.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    win_powershell - Ensure ``$Ansible.Result = @()`` as an empty array is returned as an empty list and not null
+    - https://github.com/ansible-collections/ansible.windows/issues/686

--- a/plugins/modules/win_powershell.ps1
+++ b/plugins/modules/win_powershell.ps1
@@ -801,7 +801,7 @@ $OutputEncoding = [Console]::InputEncoding = [Console]::OutputEncoding = $utf8No
     # https://github.com/ansible-collections/ansible.windows/issues/642
     $resultPipeline = [PowerShell]::Create()
     $resultPipeline.Runspace = $runspace
-    $result = $resultPipeline.AddScript('$Ansible').Invoke()
+    $result = $resultPipeline.AddScript('$Ansible').Invoke()[0]
 }
 finally {
     if (-not $processId) {

--- a/tests/integration/targets/win_powershell/tasks/tests.yml
+++ b/tests/integration/targets/win_powershell/tasks/tests.yml
@@ -268,6 +268,19 @@
     - result_ansible.output == []
     - result_ansible.result == ['1970-01-01T00:00:00.0000000Z', 'string']
 
+- name: set empty array as Ansible.Result
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    script: $Ansible.Result = @()
+  register: result_ansible
+
+- name: assert set empty array as Ansible.Result
+  assert:
+    that:
+    - result_ansible is changed
+    - result_ansible.output == []
+    - result_ansible.result == []
+
 - name: get temporary directory
   win_powershell:
     executable: '{{ pwsh_executable | default(omit) }}'


### PR DESCRIPTION
##### SUMMARY
Fix to ensure `$Ansible.Result = @()` is returned as an empty array and not null. This was a regression on a previous fix and this change goes back to the original behaviour.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/686

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_powershell