### PR TITLE
win_get_url - Make checksum work more like ansible.builtin.get_url

### DIFF
--- a/changelogs/fragments/717-win_get_url-checksum.yml
+++ b/changelogs/fragments/717-win_get_url-checksum.yml
@@ -1,0 +1,7 @@
+minor_changes:
+  - win_get_url - if checksum is passed and destination file exists with
+    identical checksum no download is done unless force=yes
+    (https://github.com/ansible-collections/ansible.windows/issues/717)
+  - win_get_url - if checksum is passed and destination file exists with
+    different checksum file is always downloaded
+    (https://github.com/ansible-collections/ansible.windows/issues/717)

--- a/plugins/modules/win_get_url.py
+++ b/plugins/modules/win_get_url.py
@@ -43,7 +43,8 @@ options:
         file in C(dest) exists then C(checksum_dest) is calculated.
         If C(checksum_dest) equals the checksum no download is done unless
         C(force) is C(true). If the checksum does not match the file is always
-        downloaded, as if C(force) was set.
+        downloaded, as if C(force) was set. This behaviour was added in the
+        C(2.7.0) release of this collection.
       - This option cannot be set with I(checksum_url).
     type: str
   checksum_algorithm:

--- a/plugins/modules/win_get_url.py
+++ b/plugins/modules/win_get_url.py
@@ -39,6 +39,11 @@ options:
       - If a I(checksum) is passed to this parameter, the digest of the
         destination file will be calculated after it is downloaded to ensure
         its integrity and verify that the transfer completed successfully.
+      - If a checksum is passed in this parameter or via C(checksum_url) and the
+        file in C(dest) exists then C(checksum_dest) is calculated.
+        If C(checksum_dest) equals the checksum no download is done unless
+        C(force) is C(true). If the checksum does not match the file is always
+        downloaded, as if C(force) was set.
       - This option cannot be set with I(checksum_url).
     type: str
   checksum_algorithm:

--- a/tests/integration/targets/win_get_url/tasks/tests_checksum.yml
+++ b/tests/integration/targets/win_get_url/tasks/tests_checksum.yml
@@ -59,6 +59,15 @@
     checksum_algorithm: sha256
   register: download_sha256_value
 
+- name: re-downloading file with matching checksum should not do any downloads if force=no
+  win_get_url:
+    url: https://{{ httpbin_host }}/base64/cHR1eA==
+    dest: '{{ testing_dir }}\sha256.txt'
+    checksum: b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006
+    checksum_algorithm: sha256
+    force: false
+  register: redownload_sha256
+
 - name: assert download file with sha256 checksum
   assert:
     that:
@@ -71,6 +80,7 @@
     - not download_sha256_value is changed
     - download_sha256_value.status_code == 200
     - download_sha256_value.checksum_dest == 'b1b6ce5073c8fac263a8fc5edfffdbd5dec1980c784e09c5bc69f8fb6056f006'
+    - "'status_code' not in redownload_sha256"
 
 - name: fail download with invalid checksum and force=no
   win_get_url:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Makes checksum handling behave more like ansible.builtin.get_url

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #717 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_get_url

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

I'm not 100% sure about the logic to trigger collecting `$dest_checksum`, it is technically called in some circumstances it wasn't before, though if I read the code right that was only in error cases since all normal exits would calculate it at the end of the script.