### PR TITLE
win_group_membership - Fix duplicate member

### DIFF
--- a/changelogs/fragments/win_group_membership-unique.yml
+++ b/changelogs/fragments/win_group_membership-unique.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    win_group_membership - Fix bug when input ``members`` contained duplicate members that were not already present in the group -
+    https://github.com/ansible-collections/ansible.windows/issues/736

--- a/tests/integration/targets/win_group_membership/tasks/tests.yml
+++ b/tests/integration/targets/win_group_membership/tasks/tests.yml
@@ -53,6 +53,7 @@
     members:
       - "{{ admin_account_name }}"
       - "{{ win_local_user }}"
+      - "{{ admin_account_name }}"
       - NT AUTHORITY\SYSTEM
     state: present
   register: add_users_to_group
@@ -271,6 +272,7 @@
     members:
       - "{{ admin_account_name }}"
       - NT AUTHORITY\NETWORK SERVICE
+      - "{{ admin_account_name }}"
   check_mode: false
 
 - name: Define users as pure


### PR DESCRIPTION
##### SUMMARY
Fixes issue when attempting to add a member that is listed twice in the input `members` option.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/736

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_group_membership