### PR TITLE
win_group - Migrate to Ansible.Basic framework

### DIFF
--- a/changelogs/fragments/win_group-basic.yml
+++ b/changelogs/fragments/win_group-basic.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - >-
+    win_group - Migrate to newer Ansible.Basic fragment for better input validation and testing support.

--- a/plugins/modules/win_group.ps1
+++ b/plugins/modules/win_group.ps1
@@ -3,52 +3,62 @@
 # Copyright: (c) 2014, Chris Hoffman <choffman@chathamfinancial.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -CSharpUtil Ansible.Basic
 
-$params = Parse-Args $args -supports_check_mode $true
-$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
-
-$name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
-$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present", "absent"
-$description = Get-AnsibleParam -obj $params -name "description" -type "str"
-
-$result = @{
-    changed = $false
+$spec = @{
+    options = @{
+        description = @{
+            type = 'str'
+        }
+        name = @{
+            type = 'str'
+            required = $true
+        }
+        state = @{
+            type = 'str'
+            default = 'present'
+            choices = 'absent', 'present'
+        }
+    }
+    supports_check_mode = $true
 }
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$name = $module.Params.name
+$state = $module.Params.state
+$description = $module.Params.description
 
 $adsi = [ADSI]"WinNT://$env:COMPUTERNAME"
 $group = $adsi.Children | Where-Object { $_.SchemaClassName -eq 'group' -and $_.Name -eq $name }
 
-try {
-    If ($state -eq "present") {
-        If (-not $group) {
-            If (-not $check_mode) {
-                $group = $adsi.Create("Group", $name)
-                $group.SetInfo()
-            }
-
-            $result.changed = $true
+if ($state -eq "present") {
+    if (-not $group) {
+        if (-not $module.CheckMode) {
+            $group = $adsi.Create("Group", $name)
+            $group.SetInfo()
         }
 
-        If ($null -ne $description) {
-            IF (-not $group.description -or $group.description -ne $description) {
-                If (-not $check_mode) {
+        $module.Result.changed = $true
+    }
+
+    # If in check mode and the group was created we skip the extra checks
+    if ($group) {
+        if ($null -ne $description) {
+            if (-not $group.description -or $group.description -ne $description) {
+                if (-not $module.CheckMode) {
                     $group.description = $description
                     $group.SetInfo()
                 }
-                $result.changed = $true
+                $module.Result.changed = $true
             }
         }
     }
-    ElseIf ($state -eq "absent" -and $group) {
-        If (-not $check_mode) {
-            $adsi.delete("Group", $group.Name.Value)
-        }
-        $result.changed = $true
-    }
 }
-catch {
-    Fail-Json $result $_.Exception.Message
+elseif ($state -eq "absent" -and $group) {
+    if (-not $module.CheckMode) {
+        $adsi.delete("Group", $group.Name.Value)
+    }
+    $module.Result.changed = $true
 }
 
-Exit-Json $result
+$module.ExitJson()


### PR DESCRIPTION
##### SUMMARY
Migrates the module to use the newer Ansible.Basic framework which has better input validation, support for module/doc validation, and other benefits. This is in preparation of migrating the win_group_membership functionality into the one module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_group