### PR TITLE
win_group - membership and sid return value

### DIFF
--- a/changelogs/fragments/win_group-sid.yml
+++ b/changelogs/fragments/win_group-sid.yml
@@ -1,0 +1,6 @@
+minor_changes:
+  - >-
+      win_group - Added ``sid`` return value representing the security identifier of the group when ``state=present``.
+  - >-
+      win_group - Added ``members`` option to set the group membership. This is designed to replace the functionality
+      of the ``win_group_membership`` module.

--- a/plugins/modules/win_group.ps1
+++ b/plugins/modules/win_group.ps1
@@ -10,6 +10,29 @@ $spec = @{
         description = @{
             type = 'str'
         }
+        members = @{
+            type = 'dict'
+            options = @{
+                add = @{
+                    type = 'list'
+                    elements = 'str'
+                    default = @()
+                }
+                remove = @{
+                    type = 'list'
+                    elements = 'str'
+                    default = @()
+                }
+                set = @{
+                    type = 'list'
+                    elements = 'str'
+                }
+            }
+            mutually_exclusive = @(
+                , @('set', 'add')
+                , @('set', 'remove')
+            )
+        }
         name = @{
             type = 'str'
             required = $true
@@ -27,18 +50,111 @@ $module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
 $name = $module.Params.name
 $state = $module.Params.state
 $description = $module.Params.description
+$members = $module.Params.members
 
 $module.Diff.before = $null
 $module.Diff.after = $null
+$module.Result.sid = $null
+
+Function ConvertTo-NTAccount {
+    [OutputType([string])]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [string[]]
+        $InputObject
+    )
+
+    process {
+        foreach ($sid in $InputObject) {
+            $sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList $sid
+            try {
+                $sid.Translate([System.Security.Principal.NTAccount]).Value
+            }
+            catch [System.Security.Principal.IdentityNotMappedException] {
+                $sid.Value
+            }
+        }
+    }
+}
+
+Function ConvertTo-SecurityIdentifier {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSAvoidUsingEmptyCatchBlock", "",
+        Justification = "We are using this to check if the input is a valid SID value.")]
+    [OutputType([string])]
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [string[]]
+        $InputObject
+    )
+
+    process {
+        foreach ($name in $InputObject) {
+            try {
+                $sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList $name
+                $sid.Value
+                continue
+            }
+            catch [System.ArgumentException] {}
+
+            $domain = $null
+            $username = $name
+            if ($username -like '*\*') {
+                $domain, $username = $username -split '\\', 2
+                if ($domain -eq '.') {
+                    $domain = $env:COMPUTERNAME
+                }
+            }
+
+            $account = New-Object -TypeName System.Security.Principal.NTAccount -ArgumentList @(
+                if ($domain) {
+                    $domain
+                }
+                $username
+            )
+
+            try {
+                $account.Translate([System.Security.Principal.SecurityIdentifier]).Value
+            }
+            catch {
+                $exp = New-Object -TypeName System.ArgumentException -ArgumentList @(
+                    "Failed to translate '$name' to a SecurityIdentifier: $_",
+                    $_.Exception
+                )
+                $err = New-Object -TypeName System.Management.Automation.ErrorRecord -ArgumentList @(
+                    $exp,
+                    'FailedToTranslateAccount',
+                    'InvalidArgument',
+                    $name)
+                $PSCmdlet.WriteError($err)
+            }
+        }
+    }
+}
 
 $adsi = [ADSI]"WinNT://$env:COMPUTERNAME"
 $group = $adsi.Children | Where-Object { $_.SchemaClassName -eq 'group' -and $_.Name -eq $name }
+
+[string[]]$existingSids = @()
 if ($group) {
+    $adsiMembers = $Group.PSBase.Invoke("Members")
+    $existingSids = @(
+        foreach ($member in $adsiMembers) {
+            $sidBytes = ([ADSI]$member).InvokeGet("objectSID")
+            $sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList $sidBytes, 0
+            $sid.Value
+        }
+    )
+
     $module.Diff.before = @{
         name = $name
         # ADSI returns a collection for values even if they are single valued,
         # this ensures it's a single value in the diff output
         description = $group.Description | Select-Object -First 1
+        members = @(
+            $existingSids | ConvertTo-NTAccount | Sort-Object
+        )
     }
 }
 
@@ -48,12 +164,21 @@ if ($state -eq "present") {
             $group = $adsi.Create("Group", $name)
             $group.SetInfo()
         }
+        else {
+            $module.Result.sid = "S-1-5-0000"
+        }
 
         $module.Result.changed = $true
     }
 
+    [System.Collections.Generic.HashSet[string]]$diffMembers = @()
+
     # If in check mode and the group was created we skip the extra checks
     if ($group) {
+        $sidBytes = ([ADSI]$group).InvokeGet("objectSID")
+        $sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList $sidBytes, 0
+        $module.Result.sid = $sid.Value
+
         $existingDescription = $group.Description | Select-Object -First 1
 
         if ($null -ne $description) {
@@ -69,16 +194,56 @@ if ($state -eq "present") {
             # For diff output
             $description = $existingDescription
         }
+
+        [System.Collections.Generic.HashSet[string]]$toAdd = @()
+        [System.Collections.Generic.HashSet[string]]$toRemove = @()
+        if ($null -ne $members.set) {
+            [string[]]$setMembers = @($members.set | ConvertTo-SecurityIdentifier)
+
+            $toAdd = [System.Linq.Enumerable]::Except($setMembers, $existingSids)
+            $toRemove = [System.Linq.Enumerable]::Except($existingSids, $setMembers)
+        }
+        else {
+            if ($members.add) {
+                [string[]]$addMembers = $members.add | ConvertTo-SecurityIdentifier
+                $toAdd = [System.Linq.Enumerable]::Except($addMembers, $existingSids)
+            }
+            if ($members.remove) {
+                [string[]]$removeMembers = $members.remove | ConvertTo-SecurityIdentifier
+                $toRemove = [System.Linq.Enumerable]::Intersect($removeMembers, $existingSids)
+
+
+            }
+        }
+
+        $diffMembers = $existingSids
+        $toAdd | ForEach-Object {
+            if (-not $module.CheckMode) {
+                $group.Add("WinNT://$_")
+            }
+            $module.Result.changed = $true
+            $null = $diffMembers.Add($_)
+        }
+        $toRemove | ForEach-Object {
+            if (-not $module.CheckMode) {
+                $group.Remove("WinNT://$_")
+            }
+            $module.Result.changed = $true
+            $null = $diffMembers.Remove($_)
+        }
     }
 
     $module.Diff.after = @{
         name = $name
         description = $description
+        members = @(
+            $diffMembers | ConvertTo-NTAccount | Sort-Object -Unique
+        )
     }
 }
 elseif ($state -eq "absent" -and $group) {
     if (-not $module.CheckMode) {
-        $adsi.delete("Group", $group.Name.Value)
+        $adsi.Delete("Group", $group.Name.Value)
     }
     $module.Result.changed = $true
 }

--- a/plugins/modules/win_group.py
+++ b/plugins/modules/win_group.py
@@ -9,8 +9,9 @@ DOCUMENTATION = r'''
 module: win_group
 short_description: Add and remove local groups
 description:
-    - Add and remove local groups.
-    - For non-Windows targets, please use the M(ansible.builtin.group) module instead.
+  - Add and remove local groups.
+  - Adds and removes members of local groups.
+  - For non-Windows targets, please use the M(ansible.builtin.group) module instead.
 options:
   name:
     description:
@@ -22,6 +23,47 @@ options:
       - Description of the group.
       - Set to an empty string C("") to unset the description.
     type: str
+  members:
+    description:
+      - The members of the group to set.
+      - The value is a dictionary that contains 3 keys, I(add), I(remove),
+        or I(set).
+      - Each subkey value is a list of users or domain groups to add, remove,
+        or set respectively.
+      - The members can either be the username in the form of C(SERVER\user),
+        C(DOMAIN\user), C(.\user) to represent a local user, a UPN
+        C(user@DOMAIN.COM), or a security identifier C(S-1-5-....).
+      - A local group member cannot be another local group, it must be either a
+        local user, domain user, or a domain group.
+      - The I(add) and I(remove) keys can be set together but I(set) can only
+        be set by itself.
+    type: dict
+    version_added: 2.7.0
+    suboptions:
+      add:
+        description:
+          - The members to add to the group.
+          - This will add the members without removing any existing members
+            not listed.
+        default: []
+        type: list
+        elements: str
+      remove:
+        description:
+          - The members to remove.
+          - This will remove the members from the group without removing any
+            existing members not listed.
+        default: []
+        type: list
+        elements: str
+      set:
+        description:
+          - The members to set the group to.
+          - This will replace the existing membership with the users provided
+            in this value.
+          - Can be set to C([]) to clear all members from the group.
+        type: list
+        elements: str
   state:
     description:
       - Create or remove the group.
@@ -29,11 +71,10 @@ options:
     choices: [ absent, present ]
     default: present
 seealso:
-- module: ansible.builtin.group
-- module: community.windows.win_domain_group
-- module: ansible.windows.win_group_membership
+  - module: ansible.builtin.group
+  - module: community.windows.win_domain_group
 author:
-- Chris Hoffman (@chrishoffman)
+  - Chris Hoffman (@chrishoffman)
 '''
 
 EXAMPLES = r'''
@@ -53,4 +94,49 @@ EXAMPLES = r'''
     name: MyGroup
     description: ""
     state: present
+
+- name: Add a user to a group
+  ansible.windows.win_group:
+    name: deploy
+    members:
+      add:
+        - .\LocalUser1
+        - LocalUser2
+        - DOMAIN\User
+        - user@DOMAIN.COM
+        - S-1-5-0-10-204-0189-500
+    state: present
+
+- name: Remove a user from a group
+  ansible.windows.win_group:
+    name: deploy
+    members:
+      remove:
+        - .\LocalUser1
+
+- name: Set the members of a group
+  ansible.windows.win_group:
+    name: deploy
+    members:
+      set:
+        - .\LocalUser1
+        - LocalUser2
+        - DOMAIN\User
+
+- name: Remove all members of a group
+  ansible.windows.win_group:
+    name: deploy
+    members:
+      set: []
+'''
+
+RETURN = r'''
+sid:
+  description:
+    - The Security Identifier (SID) of the group being managed.
+    - If a new group was created in check mode, the SID will be C(S-1-5-0000).
+    - When the group is not present, the SID will be C(None).
+  returned: always
+  type: str
+  sample: S-1-5-21-2528685370-1724360342-165486190-1208
 '''

--- a/tests/integration/targets/win_group/tasks/main.yml
+++ b/tests/integration/targets/win_group/tasks/main.yml
@@ -1,14 +1,34 @@
-- name: remove test group before test
-  win_group:
-    name: '{{ test_win_group_name }}'
-    state: absent
-
 - block:
+  - name: remove test group before test
+    win_group:
+      name: '{{ test_win_group_name }}'
+      state: absent
+
+  - name: create test users
+    win_user:
+      name: '{{ item }}'
+      state: present
+      password: 7a4e3943-3f80-4b6b-baed-408c2d763c8f
+    register: test_users
+    loop:
+    - LocalUser1
+    - LocalUser2
+    - LocalUser3
+
   - name: run tests
     import_tasks: tests.yml
+
+  - name: run membership tests
+    import_tasks: members.yml
 
   always:
   - name: remove test group after test
     win_group:
       name: '{{ test_win_group_name }}'
       state: absent
+
+  - name: remove test users after test
+    win_user:
+      name: '{{ item.name }}'
+      state: absent
+    loop: '{{ test_users.results | default([]) }}'

--- a/tests/integration/targets/win_group/tasks/members.yml
+++ b/tests/integration/targets/win_group/tasks/members.yml
@@ -1,0 +1,289 @@
+- name: set get local users script
+  set_fact:
+    get_local_users: |
+      param(
+          [Parameter(Mandatory)]
+          [string]
+          $Name
+      )
+
+      Get-LocalGroup -Name $Name -ErrorAction SilentlyContinue |
+          Get-LocalGroupMember |
+          ForEach-Object -Process {
+              $domain, $user = $_.Name -split '\\', 2
+              if ($domain -eq $env:COMPUTERNAME) {
+                  $domain = '.'
+              }
+
+              [PSCustomObject]@{
+                  Name = "$domain\$user"
+                  SID = $_.SID.Value
+              }
+          } | Sort-Object { $_.Name }
+
+- name: fail when add and set together
+  win_group:
+    name: '{{ test_win_group_name }}'
+    members:
+      add:
+      - LocalUser1
+      set:
+      - LocalUser2
+  register: add_set_fail
+  failed_when: >-
+    add_set_fail is successful or
+    add_set_fail.msg != "parameters are mutually exclusive: set, add found in members"
+
+- name: fail when remove and set together
+  win_group:
+    name: '{{ test_win_group_name }}'
+    members:
+      remove:
+      - LocalUser1
+      set:
+      - LocalUser2
+  register: remove_set_fail
+  failed_when: >-
+    remove_set_fail is successful or
+    remove_set_fail.msg != "parameters are mutually exclusive: set, remove found in members"
+
+- name: create group with members - check mode
+  win_group:
+    name: '{{ test_win_group_name }}'
+    members:
+      add:
+      - LocalUser1
+      remove:
+      - .\LocalUser2
+  register: member_create_check
+  check_mode: true
+
+- name: get result of create group with members - check mode
+  win_powershell:
+    script: '{{ get_local_users }}'
+    parameters:
+      Name: '{{ test_win_group_name }}'
+  changed_when: false
+  register: member_create_check_actual
+
+- name: assert create group with members - check mode
+  assert:
+    that:
+    - member_create_check is changed
+    - member_create_check.sid == 'S-1-5-0000'
+    - member_create_check_actual.output == []
+
+- name: create group with members
+  win_group:
+    name: '{{ test_win_group_name }}'
+    members:
+      add:
+      - LocalUser1
+      remove:
+      - .\LocalUser2
+  register: member_create
+
+- name: get result of create group with members
+  win_powershell:
+    script: '{{ get_local_users }}'
+    parameters:
+      Name: '{{ test_win_group_name }}'
+  changed_when: false
+  register: member_create_actual
+
+- name: assert create group with members
+  assert:
+    that:
+    - member_create is changed
+    - member_create.sid is defined
+    - member_create_actual.output | length == 1
+    - member_create_actual.output[0].Name == '.\LocalUser1'
+    - member_create_actual.output[0].SID == test_users.results[0].sid
+
+- name: create group with members - idempotent
+  win_group:
+    name: '{{ test_win_group_name }}'
+    members:
+      add:
+      - LocalUser1
+      - LocalUser1
+      remove:
+      - .\LocalUser2
+  register: member_create_again
+
+- name: assert create group with members - idempotent
+  assert:
+    that:
+    - not member_create_again is changed
+
+- name: add and remove members - check mode
+  win_group:
+    name: '{{ test_win_group_name }}'
+    members:
+      add:
+      - LocalUser2
+      - .\LocalUser2
+      remove:
+      - LocalUser1
+  register: member_add_remove_check
+  check_mode: true
+
+- name: get result of add and remove members - check mode
+  win_powershell:
+    script: '{{ get_local_users }}'
+    parameters:
+      Name: '{{ test_win_group_name }}'
+  changed_when: false
+  register: member_add_remove_check_actual
+
+- name: assert add and remove members - check mode
+  assert:
+    that:
+    - member_add_remove_check is changed
+    - member_add_remove_check_actual.output | length == 1
+    - member_add_remove_check_actual.output[0].Name == '.\LocalUser1'
+    - member_add_remove_check_actual.output[0].SID == test_users.results[0].sid
+
+- name: add and remove members
+  win_group:
+    name: '{{ test_win_group_name }}'
+    members:
+      add:
+      - LocalUser2
+      - .\LocalUser2
+      remove:
+      - LocalUser1
+  register: member_add_remove
+
+- name: get result of add and remove members
+  win_powershell:
+    script: '{{ get_local_users }}'
+    parameters:
+      Name: '{{ test_win_group_name }}'
+  changed_when: false
+  register: member_add_remove_actual
+
+- name: assert add and remove members
+  assert:
+    that:
+    - member_add_remove is changed
+    - member_add_remove_actual.output | length == 1
+    - member_add_remove_actual.output[0].Name == '.\LocalUser2'
+    - member_add_remove_actual.output[0].SID == test_users.results[1].sid
+
+- name: set members - check mode
+  win_group:
+    name: '{{ test_win_group_name }}'
+    members:
+      set:
+      - LocalUser3
+      - '{{ test_users.results[0].sid }}'
+  register: member_set_check
+  check_mode: true
+
+- name: get result of set members - check mode
+  win_powershell:
+    script: '{{ get_local_users }}'
+    parameters:
+      Name: '{{ test_win_group_name }}'
+  changed_when: false
+  register: member_set_check_actual
+
+- name: assert set members - check mode
+  assert:
+    that:
+    - member_set_check is changed
+    - member_set_check_actual.output | length == 1
+    - member_set_check_actual.output[0].Name == '.\LocalUser2'
+    - member_set_check_actual.output[0].SID == test_users.results[1].sid
+
+- name: set members
+  win_group:
+    name: '{{ test_win_group_name }}'
+    members:
+      set:
+      - LocalUser3
+      - '{{ test_users.results[0].sid }}'
+  register: member_set
+
+- name: get result of set members
+  win_powershell:
+    script: '{{ get_local_users }}'
+    parameters:
+      Name: '{{ test_win_group_name }}'
+  changed_when: false
+  register: member_set_actual
+
+- name: assert set members
+  assert:
+    that:
+    - member_set is changed
+    - member_set_actual.output | length == 2
+    - member_set_actual.output[0].Name == '.\LocalUser1'
+    - member_set_actual.output[0].SID == test_users.results[0].sid
+    - member_set_actual.output[1].Name == '.\LocalUser3'
+    - member_set_actual.output[1].SID == test_users.results[2].sid
+
+- name: set members - idempotent
+  win_group:
+    name: '{{ test_win_group_name }}'
+    members:
+      set:
+      - LocalUser3
+      - '{{ test_users.results[0].sid }}'
+  register: member_set_again
+
+- name: assert set members - idempotent
+  assert:
+    that:
+    - not member_set_again is changed
+
+- name: expect failure when translating invalid member name
+  win_group:
+    name: '{{ test_win_group_name }}'
+    members:
+      set:
+      - LocalUser1
+      - InvalidUser
+  register: invalid_member
+  failed_when: >-
+    invalid_member is successful or
+    not invalid_member.msg is search(".*Failed to translate 'InvalidUser' to a SecurityIdentifier.*")
+
+- name: get result of set members
+  win_powershell:
+    script: '{{ get_local_users }}'
+    parameters:
+      Name: '{{ test_win_group_name }}'
+  changed_when: false
+  register: invalid_member_actual
+
+- name: assert group membership are translation failure
+  assert:
+    that:
+    - invalid_member_actual.output | length == 2
+    - invalid_member_actual.output[0].Name == '.\LocalUser1'
+    - invalid_member_actual.output[0].SID == test_users.results[0].sid
+    - invalid_member_actual.output[1].Name == '.\LocalUser3'
+    - invalid_member_actual.output[1].SID == test_users.results[2].sid
+
+- name: clear all members
+  win_group:
+    name: '{{ test_win_group_name }}'
+    members:
+      set: []
+  register: member_clear
+
+- name: get result of clear all members
+  win_powershell:
+    script: '{{ get_local_users }}'
+    parameters:
+      Name: '{{ test_win_group_name }}'
+  changed_when: false
+  register: member_clear_actual
+
+- name: assert clear all members
+  assert:
+    that:
+    - member_clear is changed
+    - member_clear_actual.output == []

--- a/tests/integration/targets/win_group/tasks/tests.yml
+++ b/tests/integration/targets/win_group/tasks/tests.yml
@@ -28,6 +28,7 @@
   assert:
     that:
     - create_check is changed
+    - create_check.sid == "S-1-5-0000"
     - create_check_actual.output == []
 
 - name: create group
@@ -50,9 +51,11 @@
   assert:
     that:
     - create is changed
+    - create.sid is defined
     - create_actual.output | length == 1
     - create_actual.output[0].Name == test_win_group_name
     - create_actual.output[0].Description == ""
+    - create_actual.output[0].SID.Value == create.sid
 
 - name: create group - idempotent
   win_group:
@@ -63,6 +66,7 @@
   assert:
     that:
     - not create_again is changed
+    - create_again.sid == create.sid
 
 - name: set description of existing group - check
   win_group:
@@ -86,6 +90,7 @@
   assert:
     that:
     - set_description_check is changed
+    - set_description_check.sid == create.sid
     - set_description_check_actual.output | length == 1
     - set_description_check_actual.output[0].Name == test_win_group_name
     - set_description_check_actual.output[0].Description == ""
@@ -111,6 +116,7 @@
   assert:
     that:
     - set_description is changed
+    - set_description.sid == create.sid
     - set_description_actual.output | length == 1
     - set_description_actual.output[0].Name == test_win_group_name
     - set_description_actual.output[0].Description == "My desc"
@@ -125,6 +131,7 @@
   assert:
     that:
     - not set_description_again is changed
+    - set_description_again.sid == create.sid
 
 - name: remove group - check mode
   win_group:
@@ -148,6 +155,7 @@
   assert:
     that:
     - remove_check is changed
+    - remove_check.sid == None
     - remove_check_actual.output | length == 1
 
 - name: remove group
@@ -171,6 +179,7 @@
   assert:
     that:
     - remove is changed
+    - remove.sid == None
     - remove_actual.output == []
 
 - name: remove group - idempotent
@@ -183,6 +192,7 @@
   assert:
     that:
     - not remove_again is changed
+    - remove_again.sid == None
 
 - name: create group with desc - check mode
   win_group:
@@ -206,6 +216,7 @@
   assert:
     that:
     - create_desc_check is changed
+    - create_desc_check.sid == "S-1-5-0000"
     - create_desc_check_actual.output == []
 
 - name: create group with desc
@@ -229,9 +240,11 @@
   assert:
     that:
     - create_desc is changed
+    - create_desc.sid is defined
     - create_desc_actual.output | length == 1
     - create_desc_actual.output[0].Name == test_win_group_name
     - create_desc_actual.output[0].Description == "My desc"
+    - create_desc_actual.output[0].SID.Value == create_desc.sid
 
 - name: create group with desc - idempotent
   win_group:
@@ -243,6 +256,7 @@
   assert:
     that:
     - not create_desc_again is changed
+    - create_desc_again.sid == create_desc.sid
 
 - name: remove description from group - check mode
   win_group:
@@ -266,6 +280,7 @@
   assert:
     that:
     - remove_desc_check is changed
+    - remove_desc_check.sid == create_desc.sid
     - remove_desc_check_actual.output | length == 1
     - remove_desc_check_actual.output[0].Name == test_win_group_name
     - remove_desc_check_actual.output[0].Description == "My desc"
@@ -291,6 +306,7 @@
   assert:
     that:
     - remove_desc is changed
+    - remove_desc.sid == create_desc.sid
     - remove_desc_actual.output | length == 1
     - remove_desc_actual.output[0].Name == test_win_group_name
     - remove_desc_actual.output[0].Description == ""
@@ -305,3 +321,9 @@
   assert:
     that:
     - not remove_desc_again is changed
+    - remove_desc_again.sid == create_desc.sid
+
+- name: remove group for subsequent tests
+  win_group:
+    name: '{{ test_win_group_name }}'
+    state: absent


### PR DESCRIPTION
##### SUMMARY
Adds the `members` option to the `win_group` module to add/remove/set the members of a group. Also adds the `sid` return value to help uniquely identify any groups made during runtime.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_group