### PR TITLE
Fix up runtime ansible_requires version

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
-requires_ansible: ">=2.15"
+requires_ansible: ">=2.15.0"
 plugin_routing:
   modules:
     win_domain_controller:


### PR DESCRIPTION
##### SUMMARY
The runtime `requires_ansible` version should include the patch/build version which is `.0`.

##### ISSUE TYPE
- Bugfix Pull Request