### PR TITLE
Migrate to newer AnsibleRequires format

### DIFF
--- a/changelogs/fragments/ansible-requires.yml
+++ b/changelogs/fragments/ansible-requires.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - >-
+    Migrate all modules to the newer ``#AnsibleRequires`` format for module utils.

--- a/plugins/modules/async_status.ps1
+++ b/plugins/modules/async_status.ps1
@@ -2,7 +2,7 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
 
 $results = @{ changed = $false }
 

--- a/plugins/modules/slurp.ps1
+++ b/plugins/modules/slurp.ps1
@@ -2,7 +2,7 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
 
 $params = Parse-Args $args -supports_check_mode $true
 $src = Get-AnsibleParam -obj $params -name "src" -type "path" -aliases "path" -failifempty $true

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -7,10 +7,10 @@
 # Copyright: (c) 2023, Jordan Pitlor <jordan@pitlor.dev>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
-#Requires -Module Ansible.ModuleUtils.PrivilegeUtil
-#Requires -Module Ansible.ModuleUtils.SID
-#Requires -Module Ansible.ModuleUtils.LinkUtil
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.PrivilegeUtil
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.SID
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.LinkUtil
 #AnsibleRequires -CSharpUtil ansible_collections.ansible.windows.plugins.module_utils._CertACLHelper
 
 $ErrorActionPreference = "Stop"

--- a/plugins/modules/win_audit_policy_system.ps1
+++ b/plugins/modules/win_audit_policy_system.ps1
@@ -4,7 +4,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-##Requires -Module Ansible.ModuleUtils.AddType
 #AnsibleRequires -PowerShell ..module_utils.Process
 $spec = @{
     options = @{
@@ -31,7 +30,7 @@ Function Get-AuditPolicy {
     }
     $auditpolcsv = Start-AnsibleWindowsProcess @categoriesParams
     If ($($auditpolcsv.ExitCode) -eq 0) {
-        $Obj = ConvertFrom-CSV $($auditpolcsv.Stdout) | Select-Object @{
+        $Obj = ConvertFrom-Csv $($auditpolcsv.Stdout) | Select-Object @{
             n = 'subcategory'
             e = { $_.Subcategory.ToLower() }
         },

--- a/plugins/modules/win_auto_logon.ps1
+++ b/plugins/modules/win_auto_logon.ps1
@@ -5,7 +5,7 @@
 
 # All helper methods are written in a binary module and has to be loaded for consuming them.
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.AddType
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
 
 Set-StrictMode -Version 2.0
 

--- a/plugins/modules/win_command.ps1
+++ b/plugins/modules/win_command.ps1
@@ -5,7 +5,7 @@
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
 #AnsibleRequires -PowerShell ..module_utils.Process
-#Requires -Module Ansible.ModuleUtils.FileUtil
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.FileUtil
 
 $spec = @{
     options = @{

--- a/plugins/modules/win_copy.ps1
+++ b/plugins/modules/win_copy.ps1
@@ -4,8 +4,8 @@
 # Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
-#Requires -Module Ansible.ModuleUtils.Backup
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Backup
 
 $ErrorActionPreference = 'Stop'
 

--- a/plugins/modules/win_credential.ps1
+++ b/plugins/modules/win_credential.ps1
@@ -4,7 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.AddType
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
 
 $spec = @{
     options = @{

--- a/plugins/modules/win_dns_client.ps1
+++ b/plugins/modules/win_dns_client.ps1
@@ -2,7 +2,7 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
 
 Set-StrictMode -Version 2
 

--- a/plugins/modules/win_domain.ps1
+++ b/plugins/modules/win_domain.ps1
@@ -2,7 +2,7 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
 
 Set-StrictMode -Version 2
 $ErrorActionPreference = "Stop"

--- a/plugins/modules/win_domain_membership.ps1
+++ b/plugins/modules/win_domain_membership.ps1
@@ -3,7 +3,7 @@
 # Copyright: (c) 2017, Red Hat, Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
 
 Set-StrictMode -Version 2
 

--- a/plugins/modules/win_dsc.ps1
+++ b/plugins/modules/win_dsc.ps1
@@ -5,7 +5,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Version 5
 
 Function ConvertTo-ArgSpecType {
     <#

--- a/plugins/modules/win_eventlog.ps1
+++ b/plugins/modules/win_eventlog.ps1
@@ -3,7 +3,7 @@
 # Copyright: (c) 2017, Andrew Saraceni <andrew.saraceni@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
 
 $ErrorActionPreference = "Stop"
 

--- a/plugins/modules/win_feature.ps1
+++ b/plugins/modules/win_feature.ps1
@@ -3,7 +3,7 @@
 # Copyright: (c) 2014, Paul Durivage <paul.durivage@rackspace.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
 
 Import-Module -Name ServerManager
 

--- a/plugins/modules/win_file.ps1
+++ b/plugins/modules/win_file.ps1
@@ -3,7 +3,7 @@
 # Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
 #AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
 
 $ErrorActionPreference = "Stop"

--- a/plugins/modules/win_find.ps1
+++ b/plugins/modules/win_find.ps1
@@ -4,7 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.LinkUtil
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.LinkUtil
 
 $spec = @{
     options = @{

--- a/plugins/modules/win_get_url.ps1
+++ b/plugins/modules/win_get_url.ps1
@@ -8,7 +8,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.FileUtil
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.FileUtil
 #AnsibleRequires -PowerShell ..module_utils.WebRequest
 
 $spec = @{

--- a/plugins/modules/win_group_membership.ps1
+++ b/plugins/modules/win_group_membership.ps1
@@ -3,8 +3,8 @@
 # Copyright: (c) 2017, Andrew Saraceni <andrew.saraceni@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
-#Requires -Module Ansible.ModuleUtils.SID
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.SID
 
 $ErrorActionPreference = "Stop"
 

--- a/plugins/modules/win_hotfix.ps1
+++ b/plugins/modules/win_hotfix.ps1
@@ -3,7 +3,7 @@
 # Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
 
 $ErrorActionPreference = "Stop"
 

--- a/plugins/modules/win_http_proxy.ps1
+++ b/plugins/modules/win_http_proxy.ps1
@@ -4,7 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.AddType
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
 
 $spec = @{
     options = @{

--- a/plugins/modules/win_inet_proxy.ps1
+++ b/plugins/modules/win_inet_proxy.ps1
@@ -4,7 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.AddType
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
 
 $spec = @{
     options = @{

--- a/plugins/modules/win_mapped_drive.ps1
+++ b/plugins/modules/win_mapped_drive.ps1
@@ -5,7 +5,7 @@
 
 #AnsibleRequires -CSharpUtil Ansible.AccessToken
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.AddType
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
 
 $spec = @{
     options = @{

--- a/plugins/modules/win_package.ps1
+++ b/plugins/modules/win_package.ps1
@@ -5,7 +5,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.AddType
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
 #AnsibleRequires -PowerShell ..module_utils.Process
 #AnsibleRequires -PowerShell ..module_utils.WebRequest
 

--- a/plugins/modules/win_reg_stat.ps1
+++ b/plugins/modules/win_reg_stat.ps1
@@ -2,7 +2,7 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
 
 $ErrorActionPreference = "Stop"
 

--- a/plugins/modules/win_regedit.ps1
+++ b/plugins/modules/win_regedit.ps1
@@ -6,8 +6,8 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.AddType
-#Requires -Module Ansible.ModuleUtils.PrivilegeUtil
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.PrivilegeUtil
 
 $spec = @{
     options = @{

--- a/plugins/modules/win_share.ps1
+++ b/plugins/modules/win_share.ps1
@@ -3,8 +3,8 @@
 # Copyright: (c) 2015, Hans-Joachim Kliemeck <git@kliemeck.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
-#Requires -Module Ansible.ModuleUtils.SID
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.SID
 
 #Functions
 Function NormalizeAccounts {

--- a/plugins/modules/win_shell.ps1
+++ b/plugins/modules/win_shell.ps1
@@ -3,9 +3,9 @@
 # Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
-#Requires -Module Ansible.ModuleUtils.CommandUtil
-#Requires -Module Ansible.ModuleUtils.FileUtil
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.CommandUtil
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.FileUtil
 
 # TODO: add check mode support
 

--- a/plugins/modules/win_stat.ps1
+++ b/plugins/modules/win_stat.ps1
@@ -4,8 +4,8 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.FileUtil
-#Requires -Module Ansible.ModuleUtils.LinkUtil
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.FileUtil
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.LinkUtil
 
 function ConvertTo-Timestamp($start_date, $end_date) {
     if ($start_date -and $end_date) {

--- a/plugins/modules/win_uri.ps1
+++ b/plugins/modules/win_uri.ps1
@@ -5,9 +5,9 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.CamelConversion
-#Requires -Module Ansible.ModuleUtils.FileUtil
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.CamelConversion
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.FileUtil
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
 #AnsibleRequires -PowerShell ..module_utils.WebRequest
 
 $spec = @{

--- a/plugins/modules/win_user_right.ps1
+++ b/plugins/modules/win_user_right.ps1
@@ -4,7 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.AddType
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
 
 $spec = @{
     options = @{

--- a/plugins/modules/win_wait_for.ps1
+++ b/plugins/modules/win_wait_for.ps1
@@ -3,8 +3,8 @@
 # Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
-#Requires -Module Ansible.ModuleUtils.FileUtil
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.FileUtil
 
 $ErrorActionPreference = "Stop"
 

--- a/plugins/modules/win_whoami.ps1
+++ b/plugins/modules/win_whoami.ps1
@@ -5,7 +5,7 @@
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
 #AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
-#Requires -Module Ansible.ModuleUtils.CamelConversion
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.CamelConversion
 
 $ErrorActionPreference = "Stop"
 

--- a/tests/integration/targets/module_utils_SCManager/library/scmanager_tests.ps1
+++ b/tests/integration/targets/module_utils_SCManager/library/scmanager_tests.ps1
@@ -2,8 +2,8 @@
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
 #AnsibleRequires -CSharpUtil ansible_collections.ansible.windows.plugins.module_utils.SCManager
-#Requires -Module Ansible.ModuleUtils.ArgvParser
-#Requires -Module Ansible.ModuleUtils.CommandUtil
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.ArgvParser
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.CommandUtil
 
 $module = [Ansible.Basic.AnsibleModule]::Create($args, @{})
 

--- a/tests/integration/targets/setup_win_device/library/win_device.ps1
+++ b/tests/integration/targets/setup_win_device/library/win_device.ps1
@@ -1,7 +1,7 @@
 #!powershell
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.AddType
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
 
 $spec = @{
     options = @{

--- a/tests/integration/targets/win_auto_logon/library/test_autologon_info.ps1
+++ b/tests/integration/targets/win_auto_logon/library/test_autologon_info.ps1
@@ -1,7 +1,7 @@
 #!powershell
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.AddType
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
 
 $module = [Ansible.Basic.AnsibleModule]::Create($args, @{})
 

--- a/tests/integration/targets/win_credential/library/test_cred_facts.ps1
+++ b/tests/integration/targets/win_credential/library/test_cred_facts.ps1
@@ -4,7 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.AddType
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
 
 $spec = @{
     options = @{

--- a/tests/integration/targets/win_dsc/files/xTestDsc/1.0.0/DSCResources/ANSIBLE_xSetReboot/ANSIBLE_xSetReboot.psm1
+++ b/tests/integration/targets/win_dsc/files/xTestDsc/1.0.0/DSCResources/ANSIBLE_xSetReboot/ANSIBLE_xSetReboot.psm1
@@ -2,8 +2,6 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCDscTestsPresent", "")]
 param()
 
-#Requires -Version 5.0 -Modules CimCmdlets
-
 Function Get-TargetResource {
     [CmdletBinding()]
     [OutputType([Hashtable])]

--- a/tests/integration/targets/win_dsc/files/xTestDsc/1.0.0/DSCResources/ANSIBLE_xTestResource/ANSIBLE_xTestResource.psm1
+++ b/tests/integration/targets/win_dsc/files/xTestDsc/1.0.0/DSCResources/ANSIBLE_xTestResource/ANSIBLE_xTestResource.psm1
@@ -2,8 +2,6 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCDscTestsPresent", "")]
 param()
 
-#Requires -Version 5.0 -Modules CimCmdlets
-
 Function ConvertFrom-CimInstance {
     param(
         [Parameter(Mandatory = $true)][CimInstance]$Instance

--- a/tests/integration/targets/win_dsc/files/xTestDsc/1.0.1/DSCResources/ANSIBLE_xTestResource/ANSIBLE_xTestResource.psm1
+++ b/tests/integration/targets/win_dsc/files/xTestDsc/1.0.1/DSCResources/ANSIBLE_xTestResource/ANSIBLE_xTestResource.psm1
@@ -2,8 +2,6 @@
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSDSCDscTestsPresent", "")]
 param()
 
-#Requires -Version 5.0 -Modules CimCmdlets
-
 Function ConvertFrom-CimInstance {
     param(
         [Parameter(Mandatory = $true)][CimInstance]$Instance

--- a/tests/integration/targets/win_get_url/library/win_defender_exclusion.ps1
+++ b/tests/integration/targets/win_get_url/library/win_defender_exclusion.ps1
@@ -2,7 +2,7 @@
 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
 
 $params = Parse-Args $args -supports_check_mode $true
 

--- a/tests/integration/targets/win_inet_proxy/library/win_inet_proxy_info.ps1
+++ b/tests/integration/targets/win_inet_proxy/library/win_inet_proxy_info.ps1
@@ -4,7 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.AddType
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
 
 $spec = @{
     options = @{

--- a/tests/integration/targets/win_inet_proxy/library/win_phonebook_entry.ps1
+++ b/tests/integration/targets/win_inet_proxy/library/win_phonebook_entry.ps1
@@ -4,7 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.AddType
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.AddType
 
 # This is a very basic skeleton of a possible Windows module for managing RAS connections. It is mostly barebones
 # to enable testing for win_inet_proxy but I've done a bit of extra work in the PInvoke space to possible expand

--- a/tests/integration/targets/win_package/library/win_make_appx.ps1
+++ b/tests/integration/targets/win_package/library/win_make_appx.ps1
@@ -4,8 +4,8 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #AnsibleRequires -CSharpUtil Ansible.Basic
-#Requires -Module Ansible.ModuleUtils.ArgvParser
-#Requires -Module Ansible.ModuleUtils.CommandUtil
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.ArgvParser
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.CommandUtil
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '',
     Justification = 'XML literal values exceed this line')]

--- a/tests/integration/targets/win_stat/library/test_symlink_file.ps1
+++ b/tests/integration/targets/win_stat/library/test_symlink_file.ps1
@@ -1,7 +1,7 @@
 #!powershell
 
-#Requires -Module Ansible.ModuleUtils.Legacy
-#Requires -Module Ansible.ModuleUtils.LinkUtil
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.LinkUtil
 
 $params = Parse-Args $args
 

--- a/tests/integration/targets/win_user_right/library/test_get_right.ps1
+++ b/tests/integration/targets/win_user_right/library/test_get_right.ps1
@@ -1,6 +1,6 @@
 #!powershell
 
-#Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Legacy
 
 # basic script to get the lsit of users in a particular right
 # this is quite complex to put as a simple script so this is


### PR DESCRIPTION
##### SUMMARY
Migrate the module_util requirements to the newer #AnsibleRequires format. This new format makes it easier to debug locally as it won't affect and of the runtime checks PowerShell itself does for modules.

##### ISSUE TYPE
- Feature Pull Request