### PR TITLE
setup - remove dep on shared function

### DIFF
--- a/changelogs/fragments/setup-json.yml
+++ b/changelogs/fragments/setup-json.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - setup - Remove dependency on shared function loaded by Ansible

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: ansible
 name: windows
-version: 2.7.0
+version: 2.8.0
 readme: README.md
 authors:
   - Jordan Borean @jborean93


### PR DESCRIPTION
##### SUMMARY
Remove the dep on ConvertFrom-AnsibleJson so that we can start to deprecate that function in Ansible exec wrapper. This is the only instance where it is used outside of the exec wrapper and it can easily be replaced by the custom PSCustomObject enumerator. Luckily this code path is not used by any of our supported connection plugins. It may be used by other connection types that cannot pipeline or through local debugging.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
setup