### PR TITLE
win_package: checksum verify the package before installation

### DIFF
--- a/changelogs/fragments/win_package-checksum.yml
+++ b/changelogs/fragments/win_package-checksum.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - win_get_url - Added ``checksum`` and ``checksum_algorithm`` to verify the
+    package before installation. Also returns ``checksum`` if
+    ``checksum_algorithm`` is provided -
+    https://github.com/ansible-collections/ansible.windows/issues/596

--- a/plugins/modules/win_package.py
+++ b/plugins/modules/win_package.py
@@ -39,6 +39,26 @@ options:
       or uninstalling a package.
     - This is only used for the C(msi), C(msp), and C(registry) providers.
     type: path
+  checksum:
+    description:
+      - If a I(checksum) is passed to this parameter, the digest of the
+        package will be calculated before executing it to verify that the
+        path or downloaded file has the expected contents.
+    type: str
+    version_added: 2.8.0
+  checksum_algorithm:
+    description:
+      - Specifies the hashing algorithm used when calculating the checksum of
+        the path provided.
+    type: str
+    choices:
+      - md5
+      - sha1
+      - sha256
+      - sha384
+      - sha512
+    default: sha1
+    version_added: 2.8.0
   creates_path:
     description:
     - Will check the existence of the path specified and use the result to
@@ -340,6 +360,12 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
+checksum:
+  description: <algorithm> checksum of the package
+  returned: checksum_algorithm is set, package exists, and not check mode
+  type: str
+  version_added: 2.8.0
+  sample: 6E642BB8DD5C2E027BF21DD923337CBB4214F827
 log:
   description: The contents of the MSI or MSP log.
   returned: installation/uninstallation failure for MSI or MSP packages

--- a/tests/integration/targets/win_package/tasks/failure_tests.yml
+++ b/tests/integration/targets/win_package/tasks/failure_tests.yml
@@ -58,3 +58,11 @@
     creates_version: 1
   register: fail_creates_version_not_a_file
   failed_when: "'creates_path must be a file not a directory when creates_version is set' not in fail_creates_version_not_a_file.msg"
+
+- name: bad checksum local msi (check mode)
+  win_package:
+    path: '{{ test_path }}\good.msi'
+    checksum: 'deadbeef'
+    state: present
+  register: fail_bad_checksum
+  failed_when: "\"good.msi did not match 'deadbeef', it was '28A630152517E3ED9306729491871264D45D062C'\" not in fail_bad_checksum.msg"

--- a/tests/integration/targets/win_package/tasks/msi_tests.yml
+++ b/tests/integration/targets/win_package/tasks/msi_tests.yml
@@ -28,6 +28,8 @@
 - name: install local msi with log
   win_package:
     path: '{{ test_path }}\good.msi'
+    checksum: '6736380C8C81D6BF1CC9BB6F59A6FC4713AD276EEFF434FC6B35E443CAFBAE55'
+    checksum_algorithm: sha256
     state: present
     log_path: '{{ test_path }}\msi.log'
   register: install_local_msi
@@ -40,6 +42,7 @@
 - name: assert install local msi
   assert:
     that:
+    - install_local_msi.checksum == '6736380C8C81D6BF1CC9BB6F59A6FC4713AD276EEFF434FC6B35E443CAFBAE55'
     - install_local_msi is changed
     - install_local_msi.reboot_required == False
     - install_local_msi.rc == 0


### PR DESCRIPTION
##### SUMMARY
Note that this is only performed when installation is performed as file download does not occur in check mode, so URL sources cannot be verified in check mode anyways.

Fixes: #596

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`win_package`