### PR TITLE
win_package: support `--check`

### DIFF
--- a/changelogs/fragments/win_package-local-file-check.yml
+++ b/changelogs/fragments/win_package-local-file-check.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - win_package - Support check mode with local file path sources

--- a/plugins/modules/win_package.ps1
+++ b/plugins/modules/win_package.ps1
@@ -1361,7 +1361,7 @@ try {
         $getParams.Path = $path
     }
     elseif ($path -and -not $pathType) {
-        if (-not (Test-Path -LiteralPath $path)) {
+        if (-not (Test-Path -LiteralPath $path) -and -not $module.CheckMode) {
             $module.FailJson("the file at the path '$path' cannot be reached")
         }
         $getParams.Path = $path

--- a/tests/integration/targets/win_package/tasks/msi_tests.yml
+++ b/tests/integration/targets/win_package/tasks/msi_tests.yml
@@ -6,6 +6,13 @@
     state: present
     expected_return_code: 0,1603
 
+- name: check mode ignore non-existent files
+  win_package:
+    path: '{{ test_path }}\noexist.msi'
+    state: present
+  register: check_mode_no_exist
+  check_mode: yes
+
 - name: install local msi (check mode)
   win_package:
     path: '{{ test_path }}\good.msi'
@@ -21,6 +28,7 @@
 - name: assert install local msi (check mode)
   assert:
     that:
+    - check_mode_no_exist is changed
     - install_local_msi_check is changed
     - install_local_msi_check.reboot_required == False
     - install_local_msi_actual_check.exists == False


### PR DESCRIPTION
##### SUMMARY
When the file is not downloaded by the module, it fails if the input does not exist. However, it may be populated by a `win_get_url` action which also does nothing with `--check`. Skip the assertion in this case.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_package