### PR TITLE
win_powershell - Fix WMI output object conversion

### DIFF
--- a/changelogs/fragments/powershell-wmi-result.yml
+++ b/changelogs/fragments/powershell-wmi-result.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >-
+    win_powershell - Handle failure on output conversion when the output object uses a custom adapter set that fails to
+    enumerate the method members. This is seen when using the output from ``Get-WmiObject`` -
+    https://github.com/ansible-collections/ansible.windows/issues/767

--- a/plugins/modules/win_powershell.ps1
+++ b/plugins/modules/win_powershell.ps1
@@ -365,7 +365,10 @@ Function Convert-OutputObject {
         }
         # Have a defensive check to see if GetType() exists as a method on the object.
         # https://github.com/ansible-collections/ansible.windows/issues/708
-        elseif ('GetType' -in $InputObject.PSObject.Methods.Name -and $InputObject.GetType().IsValueType) {
+        # We use ForEach-Object to defensively get the Methods as it fails on a WMI
+        # based object
+        # https://github.com/ansible-collections/ansible.windows/issues/767
+        elseif ('GetType' -in ($InputObject.PSObject | ForEach-Object Methods | ForEach-Object Name) -and $InputObject.GetType().IsValueType) {
             # We want to display just this value and not any properties it has (if any).
             $InputObject.PSObject.BaseObject
         }

--- a/tests/integration/targets/win_powershell/tasks/tests.yml
+++ b/tests/integration/targets/win_powershell/tasks/tests.yml
@@ -1003,3 +1003,18 @@
     that:
     - result_depth is changed
     - result_depth.result.One.Two.Three.Four == 'abc'
+
+- name: get WMI object
+  win_powershell:
+    script: |
+      Get-WmiObject -Class Win32_Service -Filter 'Name="WinRM"'
+  register: wmi_object
+  when: pwsh_executable is not defined
+
+- name: assert get WMI object
+  assert:
+    that:
+    - wmi_object.output | length == 1
+    - wmi_object.output[0]['Name'] == 'WinRM'
+    - wmi_object.output[0]['__RELPATH'] == 'Win32_Service.Name="WinRM"'
+  when: pwsh_executable is not defined


### PR DESCRIPTION
##### SUMMARY
Fixes the conversion of WMI output objects as they use a custom type accelerator that fails to enumerate members through the `PSObject` members.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/767

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_powershell