### PR TITLE
Add support for Defender App Control

### DIFF
--- a/.azure-pipelines/commands/entry-point.sh
+++ b/.azure-pipelines/commands/entry-point.sh
@@ -50,9 +50,7 @@ command -v pip
 pip --version
 pip list --disable-pip-version-check
 if [ "${ansible_version}" == "devel" ]; then
-    # retry pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
-    # FIXME: Undo this when the changes have been merged into Ansible
-    retry pip install "https://github.com/jborean93/ansible/archive/app-control.tar.gz" --disable-pip-version-check
+    retry pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
 else
     retry pip install "https://github.com/ansible/ansible/archive/stable-${ansible_version}.tar.gz" --disable-pip-version-check
 fi

--- a/.azure-pipelines/commands/entry-point.sh
+++ b/.azure-pipelines/commands/entry-point.sh
@@ -50,7 +50,9 @@ command -v pip
 pip --version
 pip list --disable-pip-version-check
 if [ "${ansible_version}" == "devel" ]; then
-    retry pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
+    # retry pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
+    # FIXME: Undo this when the changes have been merged into Ansible
+    retry pip install "https://github.com/jborean93/ansible/archive/app-control.tar.gz" --disable-pip-version-check
 else
     retry pip install "https://github.com/ansible/ansible/archive/stable-${ansible_version}.tar.gz" --disable-pip-version-check
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -394,3 +394,7 @@ changelogs/.plugin-cache.yaml
 
 # ansible-test ignores
 tests/integration/inventory*
+
+# Ansible runtime/build metadata
+meta/powershell_signatures.psd1
+

--- a/changelogs/fragments/wdac.yml
+++ b/changelogs/fragments/wdac.yml
@@ -1,0 +1,9 @@
+minor_changes:
+  - >-
+    win_powershell - Add support for running scripts on a Windows host with an active Windows Application Control
+    policy in place. Scripts that are unsigned will be run in Constrained Language Mode while scripts that are signed
+    and trusted by the remote host's WDAC policy will be run in Full Language Mode.
+  - >-
+    win_shell - Add support for running scripts on a Windows host with an active Windows Application Control policy
+    in place. Scripts will always run in Contrained Language Mode as they are executed in memory, use the
+    ``ansible.windows.win_powershell`` module to run signed scripts in Full Language Mode on a WDAC enabled host.

--- a/changelogs/fragments/win_powershell-path.yml
+++ b/changelogs/fragments/win_powershell-path.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - >-
+    win_powershell - Added the ``path`` and ``remote_src`` options which can be used to specify a local or remote
+    PowerShell script to run.

--- a/plugins/action/win_powershell.py
+++ b/plugins/action/win_powershell.py
@@ -1,0 +1,57 @@
+# Copyright: (c) 2025, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+from ansible.errors import AnsibleActionFail
+from ansible.module_utils.common.validation import check_type_bool
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+
+    def run(
+        self,
+        tmp: str | None = None,
+        task_vars: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        self._supports_async = True
+        self._supports_check_mode = True
+
+        if task_vars is None:
+            task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        del tmp  # tmp no longer has any effect
+
+        module_args = self._task.args
+        path = module_args.get('path', None)
+        remote_src = check_type_bool(module_args.get('remote_src', False))
+        script = module_args.get('script', None)
+
+        if path and not remote_src:
+            if script:
+                raise AnsibleActionFail("parameters are mutually exclusive: path, script")
+
+            # Replace the script argument with the contents of the local script.
+            full_path = self._find_needle('files', path)
+            module_args['script'] = self._loader.get_text_file_contents(full_path)
+            del module_args['path']
+
+        module_result = self._execute_module(
+            module_name='ansible.windows.win_powershell',
+            module_args=module_args,
+            task_vars=task_vars,
+            wrap_async=self._task.async_val,
+        )
+        if (
+            path and not remote_src and
+            'invocation' in module_result and
+            'module_args' in module_result['invocation']
+        ):
+            # Restores the invocation back to the original state.
+            module_result['invocation']['module_args']['script'] = None
+            module_result['invocation']['module_args']['path'] = path
+
+        result.update(module_result)
+        return result

--- a/plugins/modules/win_powershell.py
+++ b/plugins/modules/win_powershell.py
@@ -64,6 +64,23 @@ options:
     - Parameters to pass into the script as key value pairs.
     - The key corresponds to the parameter name and the value is the value for that parameter.
     type: dict
+  path:
+    description:
+    - The path to a PowerShell script to run.
+    - When O(remote_src=False), or unset, this path is searched on the Ansible host.
+    - When O(remote_src=True), or set, this path is searched on the target host.
+    - This option is mutually exclusive with O(script).
+    - Scripts are expected to be saved with UTF-8 encoding, using a different encoding will result in non-ASCII
+      characters being read as invalid characters.
+    type: str
+    version_added: 3.1.0
+  remote_src:
+    description:
+    - When V(false), the O(path) specified will be searched on the Ansible host.
+    - When V(true), the O(path) specified will be searched on the target host.
+    default: false
+    type: bool
+    version_added: 3.1.0
   removes:
     description:
     - A path or path filter pattern; when the referenced path B(does not) exist on the target host, the task will be
@@ -72,8 +89,8 @@ options:
   script:
     description:
     - The PowerShell script to run.
+    - This option is mutually exclusive with O(path).
     type: str
-    required: true
   sensitive_parameters:
     description:
     - Parameters to pass into the script as a SecureString or PSCredential.
@@ -148,6 +165,15 @@ EXAMPLES = r'''
   ansible.windows.win_powershell:
     script: |
       echo "Hello World"
+
+- name: Run script located in the adjacent files directory
+  ansible.windows.win_powershell:
+    path: my-script.ps1
+
+- name: Run script located on the target Windows host
+  ansible.windows.win_powershell:
+    path: C:\temp\my-script.ps1
+    remote_src: true
 
 - name: Run PowerShell script with parameters
   ansible.windows.win_powershell:

--- a/plugins/modules/win_shell.ps1
+++ b/plugins/modules/win_shell.ps1
@@ -75,7 +75,9 @@ If (-not $executable -or $executable -eq "powershell") {
     $exec_application = "powershell.exe"
 
     # force input encoding to preamble-free UTF8 so PS sub-processes (eg, Start-Job) don't blow up
-    $raw_command_line = "[Console]::InputEncoding = New-Object Text.UTF8Encoding `$false; " + $raw_command_line
+    if ([System.Management.Automation.Security.SystemPolicy]::GetSystemLockdownPolicy() -eq 'None') {
+        $raw_command_line = "[Console]::InputEncoding = New-Object Text.UTF8Encoding `$false; " + $raw_command_line
+    }
 
     # Base64 encode the command so we don't have to worry about the various levels of escaping
     $encoded_command = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($raw_command_line))

--- a/tests/integration/targets/app_control/aliases
+++ b/tests/integration/targets/app_control/aliases
@@ -1,0 +1,2 @@
+windows
+shippable/windows/group1

--- a/tests/integration/targets/app_control/files/New-AnsiblePowerShellSignature.ps1
+++ b/tests/integration/targets/app_control/files/New-AnsiblePowerShellSignature.ps1
@@ -1,0 +1,400 @@
+# 0.5.0 fixed BOM-less encoding issues with Unicode
+#Requires -Modules @{ ModuleName = 'OpenAuthenticode'; ModuleVersion = '0.5.0' }
+
+using namespace System.Collections.Generic
+using namespace System.IO
+using namespace System.Management.Automation
+using namespace System.Management.Automation.Language
+using namespace System.Security.Cryptography.X509Certificates
+
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory)]
+    [string]
+    $ScriptPath,
+
+    [Parameter(Mandatory)]
+    [string]
+    $CertPath,
+
+    [Parameter(Mandatory)]
+    [string]
+    $CertPass
+)
+
+$ErrorActionPreference = 'Stop'
+
+Function New-AnsiblePowerShellSignature {
+    <#
+    .SYNOPSIS
+    Creates and signed Ansible content for App Control/WDAC.
+
+    .DESCRIPTION
+    This function will generate the powershell_signatures.psd1 manifest and sign
+    it. The manifest file includes all PowerShell/C# module_utils and
+    PowerShell modules in the collection(s) specified. It will also create the
+    '*.authenticode' signature file for the exec_wrapper.ps1 used inside
+    Ansible itself.
+
+    .PARAMETER Certificate
+    The certificate to use for signing the content.
+
+    .PARAMETER Collection
+    The collection(s) to sign. This is set to ansible.builtin by default but
+    can be overriden to include other collections like ansible.windows.
+
+    .PARAMETER Skip
+    A list of plugins to skip by the fully qualified name. Plugins skipped will
+    not be included in the signed manifest. This means that modules will be run
+    in CLM mode and module_utils will be skipped entirely.
+
+    The values in the list should be the fully qualified name of the plugin as
+    referenced in Ansible. The value can also optionally include the extension
+    of the file if the FQN is ambigious, e.g. collection util that has both a
+    PowerShell and C# util of the same name.
+
+    Here are some examples for the various content types:
+
+        # Ansible Builtin Modules
+        'ansible.builtin.module_name'
+
+        # Ansible Builtin ModuleUtil
+        'Ansible.ModuleUtils.PowerShellUtil'
+        'Ansible.CSharpUtil'
+
+        # Collection Modules
+        'namespace.name.module_name'
+
+        # Collection ModuleUtils
+        'ansible_collections.namespace.name.plugins.module_utils.PowerShellUtil'
+        'ansible_collections.namespace.name.plugins.module_utils.PowerShellUtil.psm1'
+
+        'ansible_collections.namespace.name.plugins.module_utils.CSharpUtil'
+        'ansible_collections.namespace.name.plugins.module_utils.CSharpUtil.cs'
+
+    .PARAMETER Unsupported
+    A list of plugins to be marked as unsupported in the manifest and will
+    error when being run. List -Skip, the values here are the fully qualified
+    name of the plugin as referenced in Ansible.
+
+    .PARAMETER TimeStampServer
+    Optional authenticode timestamp server to use when signing the content.
+
+    .EXAMPLE
+    Signs just the content included in Ansible.
+
+        $cert = [X509Certificate2]::new("wdac-cert.pfx", "password")
+        New-AnsiblePowerShellSignature -Certificate $cert
+
+    .EXAMPLE
+    Signs just the content include in Ansible and the ansible.windows collection
+
+        $cert = [X509Certificate2]::new("wdac-cert.pfx", "password")
+        New-AnsiblePowerShellSignature -Certificate $cert -Collection ansible.builtin, ansible.windows
+
+    .EXAMPLE
+    Signs just the content in the ansible.windows collection
+
+        $cert = [X509Certificate2]::new("wdac-cert.pfx", "password")
+        New-AnsiblePowerShellSignature -Certificate $cert -Collection ansible.windows
+
+    .EXAMPLE
+    Signs content but skips the specified modules and module_utils
+        $skip = @(
+            # Skips the module specified
+            'namespace.name.module'
+
+            # Skips the module_utils specified
+            'ansible_collections.namespace.name.plugins.module_utils.PowerShellUtil'
+            'ansible_collections.namespace.name.plugins.module_utils.CSharpUtil'
+
+            # Skips signing the file specified
+            'ansible_collections.namespace.name.plugins.plugin_utils.powershell.file.ps1'
+        )
+        $cert = [X509Certificate2]::new("wdac-cert.pfx", "password")
+        New-AnsiblePowerShellSignature -Certificate $cert -Collection namespace.name -Skip $skip
+
+    .NOTES
+    This function requires Ansible to be installed and available in the PATH so
+    it can find the Ansible installation and collection paths.
+    #>
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSCustomUseLiteralPath', '',
+        Justification = 'We want to support wildcard matching')]
+    [CmdletBinding()]
+    param (
+        [Parameter(
+            Mandatory
+        )]
+        [X509Certificate2]
+        $Certificate,
+
+        [Parameter(
+            ValueFromPipeline,
+            ValueFromPipelineByPropertyName
+        )]
+        [string[]]
+        $Collection = "ansible.builtin",
+
+        [Parameter(
+            ValueFromPipelineByPropertyName
+        )]
+        [string[]]
+        $Skip = @(),
+
+        [Parameter(
+            ValueFromPipelineByPropertyName
+        )]
+        [string[]]
+        $Unsupported = @(),
+
+        [Parameter()]
+        [string]
+        $TimeStampServer
+    )
+
+    begin {
+        Write-Verbose "Attempting to get ansible-config dump"
+        $configRaw = ansible-config dump --format json --type base 2>&1
+        if ($LASTEXITCODE) {
+            $err = [ErrorRecord]::new(
+                [Exception]::new("Failed to get Ansible configuration, RC: ${LASTEXITCODE} - $configRaw"),
+                'FailedToGetAnsibleConfiguration',
+                [ErrorCategory]::NotSpecified,
+                $null)
+            $PSCmdlet.ThrowTerminatingError($err)
+        }
+
+        $config = $configRaw | ConvertFrom-Json
+        $collectionsPaths = @($config | Where-Object name -EQ 'COLLECTIONS_PATHS' | ForEach-Object value)
+        Write-Verbose "Collections paths to be searched: [$($collectionsPaths -join ":")]"
+
+        $signParams = @{
+            Certificate = $Certificate
+            HashAlgorithm = 'SHA256'
+        }
+        if ($TimeStampServer) {
+            $signParams.TimeStampServer = $TimeStampServer
+        }
+
+        $checked = [HashSet[string]]::new([StringComparer]::OrdinalIgnoreCase)
+
+        Function New-HashEntry {
+            [OutputType([PSObject])]
+            [CmdletBinding()]
+            param (
+                [Parameter(Mandatory, ValueFromPipeline)]
+                [FileInfo]
+                $File,
+
+                [Parameter(Mandatory)]
+                [AllowEmptyString()]
+                [string]
+                $PluginBase,
+
+                [Parameter()]
+                [AllowEmptyCollection()]
+                [string[]]
+                $Unsupported = @(),
+
+                [Parameter()]
+                [AllowEmptyCollection()]
+                [string[]]
+                $Skip = @()
+            )
+
+            process {
+                $nameWithoutExt = [string]::IsNullOrEmpty($PluginBase) ? $File.BaseName : "$PluginBase.$($File.BaseName)"
+                $nameWithExt = "$nameWithoutExt$($File.Extension)"
+
+                $mode = 'Trusted'
+                if ($nameWithoutExt -in $Skip -or $nameWithExt -in $Skip) {
+                    Write-Verbose "Skipping plugin '$nameWithExt' as it is in the supplied skip list"
+                    return
+                }
+                elseif ($nameWithoutExt -in $Unsupported -or $nameWithExt -in $Unsupported) {
+                    Write-Verbose "Marking plugin '$nameWithExt' as unsupported as it is in the unsupported list"
+                    $mode = 'Unsupported'
+                }
+
+                Write-Verbose "Hashing plugin '$nameWithExt'"
+                $hash = Get-FileHash -LiteralPath $File.FullName -Algorithm SHA256
+                [PSCustomObject]@{
+                    Name = $nameWithExt
+                    Hash = $hash.Hash
+                    Mode = $mode
+                }
+            }
+        }
+    }
+
+    process {
+        $newHashParams = @{
+            Skip = $Skip
+            Unsupported = $Unsupported
+        }
+
+        foreach ($c in $Collection) {
+            try {
+                if (-not $checked.Add($c)) {
+                    Write-Verbose "Skipping already processed collection $c"
+                    continue
+                }
+
+                $metaPath = $null
+                $pathsToSign = [List[FileInfo]]::new()
+                $hashedPaths = [List[PSObject]]::new()
+
+                if ($c -eq 'ansible.builtin') {
+                    Write-Verbose "Attempting to get Ansible installation path"
+                    $ansiblePath = python -c "import ansible; print(ansible.__file__)" 2>&1
+                    if ($LASTEXITCODE) {
+                        throw "Failed to find Ansible installation path, RC: ${LASTEXITCODE} - $ansiblePath"
+                    }
+
+                    $ansibleBase = Split-Path -Path $ansiblePath -Parent
+                    $metaPath = [Path]::Combine($ansibleBase, 'config')
+
+                    $execWrapper = Get-Item -LiteralPath ([Path]::Combine($ansibleBase, 'executor', 'powershell', 'exec_wrapper.ps1'))
+                    $pathsToSign.Add($execWrapper)
+
+                    $ansiblePwshContent = [PSObject[]]@(
+                        # These are needed for Ansible and cannot be skipped
+                        Get-ChildItem -Path ([Path]::Combine($ansibleBase, 'executor', 'powershell', '*.ps1')) -Exclude "bootstrap_wrapper.ps1" |
+                            New-HashEntry -PluginBase "ansible.executor.powershell"
+
+                        # Builtin utils are special where the filename is their FQN
+                        Get-ChildItem -Path ([Path]::Combine($ansibleBase, 'module_utils', 'csharp', '*.cs')) |
+                            New-HashEntry -PluginBase "" @newHashParams
+                        Get-ChildItem -Path ([Path]::Combine($ansibleBase, 'module_utils', 'powershell', '*.psm1')) |
+                            New-HashEntry -PluginBase "" @newHashParams
+
+                        Get-ChildItem -Path ([Path]::Combine($ansibleBase, 'modules', '*.ps1')) |
+                            New-HashEntry -PluginBase $c @newHashParams
+                    )
+                    $hashedPaths.AddRange($ansiblePwshContent)
+                }
+                else {
+                    Write-Verbose "Attempting to get collection path for $c"
+                    $namespace, $name, $remaining = $c.ToLowerInvariant() -split '\.'
+                    if (-not $name -or $remaining) {
+                        throw "Invalid collection name '$c', must be in the format 'namespace.name'"
+                    }
+
+                    $foundPath = $null
+                    foreach ($path in $collectionsPaths) {
+                        $collectionPath = [Path]::Combine($path, 'ansible_collections', $namespace, $name)
+
+                        Write-Verbose "Checking if collection $c exists in '$collectionPath'"
+                        if (Test-Path -LiteralPath $collectionPath) {
+                            $foundPath = $collectionPath
+                            break
+                        }
+                    }
+
+                    if (-not $foundPath) {
+                        throw "Failed to find collection path for $c"
+                    }
+
+                    Write-Verbose "Using collection path '$foundPath' for $c"
+
+                    $metaPath = [Path]::Combine($foundPath, 'meta')
+
+                    $collectionPwshContent = [PSObject[]]@(
+                        $utilPath = [Path]::Combine($foundPath, 'plugins', 'module_utils')
+                        if (Test-Path -LiteralPath $utilPath) {
+                            Get-ChildItem -LiteralPath $utilPath | Where-Object Extension -In '.cs', '.psm1' |
+                                New-HashEntry -PluginBase "ansible_collections.$c.plugins.module_utils" @newHashParams
+                        }
+
+                        $modulePath = [Path]::Combine($foundPath, 'plugins', 'modules')
+                        if (Test-Path -LiteralPath $modulePath) {
+                            Get-ChildItem -LiteralPath $modulePath | Where-Object Extension -EQ '.ps1' |
+                                New-HashEntry -PluginBase $c @newHashParams
+                        }
+                    )
+                    $hashedPaths.AddRange($collectionPwshContent)
+                }
+
+                if (-not (Test-Path -LiteralPath $metaPath)) {
+                    Write-Verbose "Creating meta path '$metaPath'"
+                    New-Item -Path $metaPath -ItemType Directory -Force | Out-Null
+                }
+
+                $manifest = @(
+                    '@{'
+                    '    Version = 1'
+                    '    HashList = @('
+                    foreach ($content in $hashedPaths) {
+                        # To avoid encoding problems with Authenticode and non-ASCII
+                        # characters, we escape them as Unicode code points. We also
+                        # escape some ASCII control characters that can cause escaping
+                        # problems like newlines.
+                        $escapedName = [Regex]::Replace(
+                            $content.Name,
+                            '([^\u0020-\u007F])',
+                            { '\u{0:x4}' -f ([uint16][char]$args[0].Value) })
+
+                        $escapedHash = [CodeGeneration]::EscapeSingleQuotedStringContent($content.Hash)
+                        $escapedMode = [CodeGeneration]::EscapeSingleQuotedStringContent($content.Mode)
+                        "        # $escapedName"
+                        "        @{"
+                        "            Hash = '$escapedHash'"
+                        "            Mode = '$escapedMode'"
+                        "        }"
+                    }
+                    '    )'
+                    '}'
+                ) -join "`n"
+                $manifestPath = [Path]::Combine($metaPath, 'powershell_signatures.psd1')
+                Write-Verbose "Creating and signing manifest for $c at '$manifestPath'"
+                Set-Content -LiteralPath $manifestPath -Value $manifest -NoNewline
+                $manifestPath
+
+                Set-OpenAuthenticodeSignature -LiteralPath $manifestPath @signParams
+
+                $pathsToSign | ForEach-Object -Process {
+                    $tempPath = Join-Path $_.DirectoryName "$($_.BaseName)_tmp.ps1"
+                    $_ | Copy-Item -Destination $tempPath -Force
+
+                    try {
+                        Write-Verbose "Signing script '$($_.FullName)'"
+                        Set-OpenAuthenticodeSignature -LiteralPath $tempPath @signParams
+
+                        $signedContent = Get-Content -LiteralPath $tempPath -Raw
+                        $sigIndex = $signedContent.LastIndexOf("`r`n# SIG # Begin signature block`r`n")
+                        if ($sigIndex -eq -1) {
+                            throw "Failed to find signature block in $($_.FullName)"
+                        }
+
+                        # Ignore the first and last \r\n when extracting the signature
+                        $sigIndex += 2
+                        $signature = $signedContent.Substring($sigIndex, $signedContent.Length - $sigIndex - 2)
+                        $sigPath = Join-Path $_.DirectoryName "$($_.Name).authenticode"
+
+                        Write-Verbose "Creating signature file at '$sigPath'"
+                        Set-Content -LiteralPath $sigPath -Value $signature -NoNewline
+                        $sigPath
+                    }
+                    finally {
+                        $tempPath | Remove-Item -Force
+                    }
+                }
+            }
+            catch {
+                $_.ErrorDetails = "Failed to process collection ${c}: $_"
+                $PSCmdlet.WriteError($_)
+                continue
+            }
+        }
+    }
+}
+
+$cert = [X509Certificate2]::new($CertPath, $CertPass)
+
+$sigParams = @{
+    Certificate = $cert
+    Collection = 'ansible.builtin', 'ansible.windows'
+}
+New-AnsiblePowerShellSignature @sigParams
+
+Get-ChildItem -LiteralPath $ScriptPath -Filter *.ps1 | Set-OpenAuthenticodeSignature -Certificate $cert

--- a/tests/integration/targets/app_control/files/test-script.ps1
+++ b/tests/integration/targets/app_control/files/test-script.ps1
@@ -1,0 +1,10 @@
+[CmdletBinding()]
+param (
+    [string]
+    $Value
+)
+
+@{
+    language_mode = $ExecutionContext.SessionState.LanguageMode.ToString()
+    ünicode = $Value
+}

--- a/tests/integration/targets/app_control/handlers/main.yml
+++ b/tests/integration/targets/app_control/handlers/main.yml
@@ -1,0 +1,40 @@
+- name: remove local tmp
+  file:
+    path: '{{ local_tmp.path }}'
+    state: absent
+  delegate_to: localhost
+
+- name: remove OpenAuthenticode module
+  shell: Uninstall-PSResource -Name OpenAuthenticode -Version 0.6.1
+  args:
+    executable: pwsh
+  delegate_to: localhost
+
+- name: remove WDAC certificates
+  win_powershell:
+    parameters:
+      CAThumbprint: '{{ cert_info.output[0].ca_thumbprint }}'
+      CertThumbprint: '{{ cert_info.output[0].thumbprint }}'
+    script: |
+      [CmdletBinding()]
+      param (
+          [Parameter(Mandatory)]
+          [string]
+          $CAThumbprint,
+
+          [Parameter(Mandatory)]
+          [string]
+          $CertThumbprint
+      )
+
+      $ErrorActionPreference = 'Stop'
+
+      Remove-Item -LiteralPath "Cert:\LocalMachine\Root\$CAThumbprint" -Force
+      Remove-Item -LiteralPath "Cert:\LocalMachine\TrustedPublisher\$CertThumbprint" -Force
+
+- name: remove signed content
+  file:
+    path: '{{ item }}'
+    state: absent
+  delegate_to: localhost
+  loop: '{{ sign_result.stdout_lines }}'

--- a/tests/integration/targets/app_control/meta/main.yml
+++ b/tests/integration/targets/app_control/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- setup_remote_tmp_dir

--- a/tests/integration/targets/app_control/tasks/main.yml
+++ b/tests/integration/targets/app_control/tasks/main.yml
@@ -1,0 +1,42 @@
+- name: get OS version
+  win_powershell:
+    script: (Get-Item -LiteralPath $env:SystemRoot\System32\kernel32.dll).VersionInfo.ProductVersion.ToString()
+  changed_when: False
+  register: os_version
+
+- name: check if pwsh is installed locally
+  shell: command -V pwsh
+  delegate_to: localhost
+  failed_when: False
+  changed_when: False
+  register: pwsh_stat
+
+- name: run tests if pwsh is present and running on Server 2019 or later
+  when:
+  - pwsh_stat.rc == 0
+  - os_version.output[0] is version('10.0.17763', '>=')
+  block:
+  - name: setup App Control
+    import_tasks: setup.yml
+
+  - name: run App Control tests
+    import_tasks: test.yml
+
+  always:
+  - name: disable policy through CiTool if present
+    win_command: CiTool.exe --remove-policy {{ policy_info.output[0].policy_id }}
+    when:
+    - policy_info is defined
+    - policy_info.output[0].policy_id is truthy
+
+  - name: remove App Control policy
+    win_file:
+      path: '{{ policy_info.output[0].path }}'
+      state: absent
+    register: policy_removal
+    when:
+    - policy_info is defined
+
+  - name: reboot after removing policy file
+    win_reboot:
+    when: policy_removal is changed

--- a/tests/integration/targets/app_control/tasks/setup.yml
+++ b/tests/integration/targets/app_control/tasks/setup.yml
@@ -1,0 +1,194 @@
+- name: create local temp directory
+  tempfile:
+    state: directory
+  register: local_tmp
+  notify: remove local tmp
+  delegate_to: localhost
+
+- name: install OpenAuthenticode
+  shell: |
+    if (-not (Get-Module -Name OpenAuthenticode -ListAvailable | Where-Object Version -ge '0.5.0')) {
+        $url = 'https://ansible-ci-files.s3.us-east-1.amazonaws.com/test/integration/targets/win_app_control/openauthenticode.0.6.1.nupkg'
+        Invoke-WebRequest -Uri $url -OutFile '{{ local_tmp.path }}/openauthenticode.0.6.1.nupkg'
+
+        Register-PSResourceRepository -Name AnsibleTemp -Trusted -Uri '{{ local_tmp.path }}'
+        try {
+            Install-PSResource -Name OpenAuthenticode -Repository AnsibleTemp
+        } finally {
+            Unregister-PSResourceRepository -Name AnsibleTemp
+        }
+
+        $true
+    } else {
+        $false
+    }
+  args:
+    executable: pwsh
+  register: open_auth_install
+  changed_when: open_auth_install.stdout | bool
+  notify: remove OpenAuthenticode module
+  delegate_to: localhost
+
+- name: generate cert password
+  set_fact:
+    cert_pw: "{{ 'password123!' + lookup('password', '/dev/null chars=ascii_letters,digits length=8') }}"
+
+- name: setup WDAC certificates
+  win_powershell:
+    parameters:
+      TempPath: '{{ remote_tmp_dir }}'
+    sensitive_parameters:
+    - name: CertPass
+      value: '{{ cert_pw }}'
+    script: |
+      [CmdletBinding()]
+      param (
+          [Parameter(Mandatory)]
+          [string]
+          $TempPath,
+
+          [Parameter(Mandatory)]
+          [SecureString]
+          $CertPass
+      )
+
+      $ErrorActionPreference = 'Stop'
+
+      $testPrefix = 'Ansible-WDAC'
+      $enhancedKeyUsage = [Security.Cryptography.OidCollection]::new()
+      $null = $enhancedKeyUsage.Add('1.3.6.1.5.5.7.3.3')  # Code Signing
+      $caParams = @{
+          Extension = @(
+              [Security.Cryptography.X509Certificates.X509BasicConstraintsExtension]::new($true, $false, 0, $true),
+              [Security.Cryptography.X509Certificates.X509KeyUsageExtension]::new('KeyCertSign', $false),
+              [Security.Cryptography.X509Certificates.X509EnhancedKeyUsageExtension ]::new($enhancedKeyUsage, $false)
+          )
+          CertStoreLocation = 'Cert:\CurrentUser\My'
+          NotAfter = (Get-Date).AddDays(1)
+          Type = 'Custom'
+      }
+      $ca = New-SelfSignedCertificate @caParams -Subject "CN=$testPrefix-Root"
+
+      $certParams = @{
+          CertStoreLocation = 'Cert:\CurrentUser\My'
+          KeyUsage = 'DigitalSignature'
+          TextExtension = @("2.5.29.37={text}1.3.6.1.5.5.7.3.3", "2.5.29.19={text}")
+          Type = 'Custom'
+      }
+      $cert = New-SelfSignedCertificate @certParams -Subject "CN=$testPrefix-Signed" -Signer $ca
+      $null = $cert | Export-PfxCertificate -Password $CertPass -FilePath "$TempPath\signing.pfx"
+      $cert.Export('Cert') | Set-Content -LiteralPath "$TempPath\signing.cer" -Encoding Byte
+
+      $caWithoutKey = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($ca.Export('Cert'))
+      $certWithoutKey = [System.Security.Cryptography.X509Certificates.X509Certificate2]::new($cert.Export('Cert'))
+
+      Remove-Item -LiteralPath "Cert:\CurrentUser\My\$($ca.Thumbprint)" -DeleteKey -Force
+      Remove-Item -LiteralPath "Cert:\CurrentUser\My\$($cert.Thumbprint)" -DeleteKey -Force
+
+      $root = Get-Item Cert:\LocalMachine\Root
+      $root.Open('ReadWrite')
+      $root.Add($caWithoutKey)
+      $root.Dispose()
+
+      $trustedPublisher = Get-Item Cert:\LocalMachine\TrustedPublisher
+      $trustedPublisher.Open('ReadWrite')
+      $trustedPublisher.Add($certWithoutKey)
+      $trustedPublisher.Dispose()
+
+      @{
+          ca_thumbprint = $caWithoutKey.Thumbprint
+          thumbprint = $certWithoutKey.Thumbprint
+      }
+  register: cert_info
+  notify: remove WDAC certificates
+  become: true
+  become_method: runas
+  vars:
+    ansible_become_user: '{{ ansible_user }}'
+    ansible_become_pass: '{{ ansible_password | default(ansible_test_connection_password) }}'
+
+- name: fetch signing certificates
+  fetch:
+    src: '{{ remote_tmp_dir }}\signing.pfx'
+    dest: '{{ local_tmp.path }}/signing.pfx'
+    flat: yes
+
+- name: create script to sign
+  copy:
+    src: test-script.ps1
+    dest: '{{ local_tmp.path }}/signed-script.ps1'
+  delegate_to: localhost
+
+- name: sign Ansible content
+  script: >-
+    New-AnsiblePowerShellSignature.ps1
+    -ScriptPath {{ local_tmp.path | quote }}
+    -CertPath {{ local_tmp.path ~ "/signing.pfx" | quote }}
+    -CertPass {{ cert_pw | quote }}
+  args:
+    executable: pwsh
+  environment:
+    NO_COLOR: '1'
+  delegate_to: localhost
+  register: sign_result
+  notify: remove signed content
+
+- name: enable App Control
+  win_powershell:
+    parameters:
+      TempPath: '{{ remote_tmp_dir }}'
+    script: |
+      [CmdletBinding()]
+      param (
+          [Parameter(Mandatory)]
+          [string]
+          $TempPath
+      )
+
+      $ErrorActionPreference = 'Stop'
+      
+      $policyPath = Join-Path $TempPath policy.xml
+      $certPath = Join-Path $TempPath signing.cer
+      $policyName = 'Ansible_AppControl_Test'
+
+      Copy-Item "$env:windir\schemas\CodeIntegrity\ExamplePolicies\DefaultWindows_Enforced.xml" $policyPath
+      Set-CIPolicyIdInfo -FilePath $policyPath -PolicyName $policyName -PolicyId (New-Guid)
+      Set-CIPolicyVersion -FilePath $policyPath -Version "1.0.0.0"
+
+      Add-SignerRule -FilePath $policyPath -CertificatePath $certPath -User
+      Set-RuleOption -FilePath $policyPath -Option 0          # Enabled:UMCI
+      Set-RuleOption -FilePath $policyPath -Option 3 -Delete  # Enabled:Audit Mode
+      Set-RuleOption -FilePath $policyPath -Option 11 -Delete # Disabled:Script Enforcement
+      Set-RuleOption -FilePath $policyPath -Option 19         # Enabled:Dynamic Code Security
+
+      $policyBinPath = "$env:windir\System32\CodeIntegrity\SiPolicy.p7b"
+      $null = ConvertFrom-CIPolicy -XmlFilePath $policyPath -BinaryFilePath $policyBinPath
+
+      $ciTool = Get-Command -Name CiTool.exe -ErrorAction SilentlyContinue
+      $policyId = $null
+      if ($ciTool) {
+          $setInfo = & $ciTool --update-policy $policyBinPath *>&1
+          if ($LASTEXITCODE) {
+              throw "citool.exe --update-policy failed ${LASTEXITCODE}: $setInfo"
+          }
+
+          $policyId = & $ciTool --list-policies --json |
+              ConvertFrom-Json |
+              Select-Object -ExpandProperty Policies |
+              Where-Object FriendlyName -eq $policyName |
+              Select-Object -ExpandProperty PolicyID
+      }
+      else {
+          $rc = Invoke-CimMethod -Namespace root\Microsoft\Windows\CI -ClassName PS_UpdateAndCompareCIPolicy -MethodName Update -Arguments @{
+              FilePath = $policyBinPath
+          }
+          if ($rc.ReturnValue) {
+              throw "PS_UpdateAndCompareCIPolicy Update failed $($rc.ReturnValue)"
+          }
+      }
+
+      @{
+          policy_id = $policyId
+          path = $policyBinPath
+      }
+  register: policy_info

--- a/tests/integration/targets/app_control/tasks/test.yml
+++ b/tests/integration/targets/app_control/tasks/test.yml
@@ -1,0 +1,93 @@
+- name: test async task
+  win_ping:
+  async: 60
+  poll: 2
+  register: async_result
+
+- name: test win_reboot
+  win_reboot:
+
+- name: copy across test script
+  win_copy:
+    src: '{{ item.src }}'
+    dest: '{{ remote_tmp_dir }}/{{ item.dest }}'
+  loop:
+  - src: '{{ local_tmp.path }}/signed-script.ps1'
+    dest: signed-script.ps1
+  - src: test-script.ps1
+    dest: test-script.ps1
+
+- name: run win_powershell signed script through local path
+  win_powershell:
+    path: '{{ local_tmp.path ~ "/signed-script.ps1" }}'
+    parameters:
+      Value: café
+  register: pwsh_result_local_path
+
+- name: run win_powershell signed script through remote path
+  win_powershell:
+    path: '{{ remote_tmp_dir ~ "/signed-script.ps1" }}'
+    remote_src: true
+    parameters:
+      Value: café
+  register: pwsh_result_remote_path
+
+- name: run win_powershell signed script through string content
+  win_powershell:
+    script: '{{ lookup("file", local_tmp.path ~ "/signed-script.ps1", rstrip=False) }}'
+    parameters:
+      Value: café
+  register: pwsh_result_script
+
+- name: assert win_powershell signed script
+  assert:
+    that:
+    - pwsh_result_local_path.output[0].language_mode == 'FullLanguage'
+    - pwsh_result_local_path.output[0].ünicode == 'café'
+    - pwsh_result_remote_path.output[0].language_mode == 'FullLanguage'
+    - pwsh_result_remote_path.output[0].ünicode == 'café'
+    - pwsh_result_script.output[0].language_mode == 'FullLanguage'
+    - pwsh_result_script.output[0].ünicode == 'café'
+
+- name: run win_powershell unsigned script through local path
+  win_powershell:
+    path: test-script.ps1
+    parameters:
+      Value: café
+  register: pwsh_result_local_path
+
+- name: run win_powershell unsigned script through remote path
+  win_powershell:
+    path: '{{ remote_tmp_dir ~ "/test-script.ps1" }}'
+    remote_src: true
+    parameters:
+      Value: café
+  register: pwsh_result_remote_path
+
+- name: run win_powershell unsigned script through string content
+  win_powershell:
+    script: '{{ lookup("file", "test-script.ps1", rstrip=False) }}'
+    parameters:
+      Value: café
+  register: pwsh_result_script
+
+- name: assert win_powershell unsigned script
+  assert:
+    that:
+    - pwsh_result_local_path.output[0].language_mode == 'ConstrainedLanguage'
+    - pwsh_result_local_path.output[0].ünicode == 'café'
+    - pwsh_result_remote_path.output[0].language_mode == 'ConstrainedLanguage'
+    - pwsh_result_remote_path.output[0].ünicode == 'café'
+    - pwsh_result_script.output[0].language_mode == 'ConstrainedLanguage'
+    - pwsh_result_script.output[0].ünicode == 'café'
+
+- name: run win_shell script
+  win_shell: $ExecutionContext.SessionState.LanguageMode.ToString()
+  register: win_shell_result
+
+- name: assert win_shell script
+  assert:
+    that:
+    - win_shell_result.rc == 0
+    - win_shell_result.stdout | trim == 'ConstrainedLanguage'
+    - win_shell_result.stderr == ''

--- a/tests/integration/targets/win_powershell/files/test-script.ps1
+++ b/tests/integration/targets/win_powershell/files/test-script.ps1
@@ -1,0 +1,11 @@
+[CmdletBinding()]
+param (
+    [Parameter(Mandatory)]
+    [string]
+    $Name
+)
+
+@{
+    Name = $Name
+    Unicode = 'ü'
+}

--- a/tests/integration/targets/win_powershell/tasks/failure.yml
+++ b/tests/integration/targets/win_powershell/tasks/failure.yml
@@ -49,3 +49,64 @@
   register: fail_ss_value_and_password
   failed_when: >-
     fail_ss_value_and_password.msg != 'parameters are mutually exclusive: value, password found in sensitive_parameters'
+
+- name: expect failure when both script and path is set
+  win_powershell:
+    script: '"test"'
+    path: abc.ps1
+  ignore_errors: true
+  register: fail_both_script_and_path
+
+- name: assert expect failure when both script and path is set
+  assert:
+    that:
+    - fail_both_script_and_path is failed
+    - >-
+      fail_both_script_and_path.msg == 'parameters are mutually exclusive: path, script'
+
+- name: expect failure when both script and path is set with remote_src
+  win_powershell:
+    script: '"test"'
+    path: abc.ps1
+    remote_src: true
+  register: fail_both_script_and_path_remote
+  failed_when: >-
+    fail_both_script_and_path_remote.msg != 'parameters are mutually exclusive: path, script'
+
+- name: expect failure with a missing local script path
+  win_powershell:
+    path: missing.ps1
+  ignore_errors: true
+  register: fail_missing_local
+
+- name: assert expect failure with a missing local script path
+  assert:
+    that:
+    - fail_missing_local is failed
+    - >-
+      fail_missing_local.msg is search("Could not find or access 'missing\.ps1'")
+
+- name: expect failure with a missing remote script path
+  win_powershell:
+    path: missing.ps1
+    remote_src: true
+  register: fail_missing_remote
+  failed_when: >-
+    fail_missing_remote.msg is not search("Could not find or access 'missing\.ps1' on Windows host")
+
+- name: expected failure with script with invalid syntax
+  win_powershell:
+    script: '[- abc'
+  register: invalid_syntax_script
+  failed_when:
+  - invalid_syntax_script.error | count != 1
+  - invalid_syntax_script.error[0]['category_info']['category'] != 'ParserError'
+
+- name: expect failure with script path with invalid syntax
+  win_powershell:
+    path: '{{ remote_tmp_dir }}\syntax-error.ps1'
+    remote_src: true
+  register: invalid_syntax_path
+  failed_when:
+  - invalid_syntax_path.error | count != 1
+  - invalid_syntax_path.error[0]['category_info']['category'] != 'ParserError'

--- a/tests/integration/targets/win_powershell/tasks/main.yml
+++ b/tests/integration/targets/win_powershell/tasks/main.yml
@@ -25,6 +25,17 @@
   register: dt_values
   changed_when: False
 
+- name: copy across test file
+  win_copy:
+    src: test-script.ps1
+    dest: '{{ remote_tmp_dir }}/test-script.ps1'
+
+- name: create script with syntax errors
+  win_copy:
+    content: |
+      [- abc
+    dest: '{{ remote_tmp_dir }}/syntax-error.ps1'
+
 - name: run failure tests
   import_tasks: failure.yml
 

--- a/tests/integration/targets/win_powershell/tasks/tests.yml
+++ b/tests/integration/targets/win_powershell/tasks/tests.yml
@@ -1018,3 +1018,34 @@
     - wmi_object.output[0]['Name'] == 'WinRM'
     - wmi_object.output[0]['__RELPATH'] == 'Win32_Service.Name="WinRM"'
   when: pwsh_executable is not defined
+
+- name: execute script from local path
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    path: test-script.ps1
+    parameters:
+      Name: café
+  register: script_from_local_path
+
+- name: assert execute script from local path
+  assert:
+    that:
+    - script_from_local_path is changed
+    - script_from_local_path.output[0]['Name'] == 'café'
+    - script_from_local_path.output[0]['Unicode'] == 'ü'
+
+- name: execute script from remote path
+  win_powershell:
+    executable: '{{ pwsh_executable | default(omit) }}'
+    path: '{{ remote_tmp_dir }}\test-script.ps1'
+    remote_src: true
+    parameters:
+      Name: café
+  register: script_from_remote_path
+
+- name: assert execute script from local path
+  assert:
+    that:
+    - script_from_remote_path is changed
+    - script_from_remote_path.output[0]['Name'] == 'café'
+    - script_from_remote_path.output[0]['Unicode'] == 'ü'


### PR DESCRIPTION
##### SUMMARY
Adds support for running modules like win_powershell in Windows Defender Application Control (WDAC). WDAC support requires Ansible 2.19 and the changes to the exec runner introduced there to run the modules in that environment.

##### ISSUE TYPE
- Feature Pull Request