### PR TITLE
Raise minimum Ansible version to 2.16

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -71,6 +71,20 @@ stages:
               test: sanity
             - name: Units
               test: units
+  - stage: Ansible_2_19
+    displayName: Ansible 2.19
+    dependsOn:
+      - Dependencies
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: '{0}'
+          testFormat: '2.19/{0}'
+          targets:
+            - name: Sanity
+              test: sanity
+            - name: Units
+              test: units
   - stage: Ansible_2_18
     displayName: Ansible 2.18
     dependsOn:
@@ -110,20 +124,6 @@ stages:
         parameters:
           nameFormat: '{0}'
           testFormat: '2.16/{0}'
-          targets:
-            - name: Sanity
-              test: sanity
-            - name: Units
-              test: units
-  - stage: Ansible_2_15
-    displayName: Ansible 2.15
-    dependsOn:
-      - Dependencies
-    jobs:
-      - template: templates/matrix.yml
-        parameters:
-          nameFormat: '{0}'
-          testFormat: '2.15/{0}'
           targets:
             - name: Sanity
               test: sanity
@@ -229,10 +229,10 @@ stages:
     condition: succeededOrFailed()
     dependsOn:
       - Ansible_devel
+      - Ansible_2_19
       - Ansible_2_18
       - Ansible_2_17
       - Ansible_2_16
-      - Ansible_2_15
       - Windows_1
       - Windows_2
       - Windows_3

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For more information about communication, see the [Ansible communication guide](
 
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.15**.
+This collection has been tested against following Ansible versions: **>=2.16**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.

--- a/changelogs/fragments/ansible-ver.yml
+++ b/changelogs/fragments/ansible-ver.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Set minimum supported Ansible version to 2.16 to align with the versions still supported by Ansible.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,4 +1,4 @@
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.16.0"
 plugin_routing:
   modules:
     win_domain_controller:


### PR DESCRIPTION
##### SUMMARY
Raises the minimum Ansible version supported to 2.16 to align with the currently supported versions.

##### ISSUE TYPE
- Feature Pull Request