### PR TITLE
win_package: Fail uninstall when no product id is provided

### DIFF
--- a/changelogs/fragments/win_package.yml
+++ b/changelogs/fragments/win_package.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - win_package - fail to remove package when no product id is provided with path as an URL (https://github.com/ansible-collections/ansible.windows/issues/667).

--- a/plugins/modules/win_package.ps1
+++ b/plugins/modules/win_package.ps1
@@ -1350,7 +1350,7 @@ try {
         CreatesService = $createsService
     }
 
-    # If the packge is a remote file, productId is set and state is set to present
+    # If the package is a remote file, productId is set and state is set to present
     # then check if the package is installed and avoid downloading the package to a temp file.
     if ($pathType -and $productId -and ($state -eq 'present')) {
         $packageStatus = Get-InstalledStatus @getParams
@@ -1410,6 +1410,9 @@ try {
         }
         $setParams += $packageStatus.ExtraInfo
         &$providerInfo."$($packageStatus.Provider)".Set @setParams
+    }
+    if ($state -eq 'absent' -and $null -eq $productId -and $pathType -eq 'url') {
+        $Module.FailJson("Unable to find Product ID from the URL path. Please specify product_id when using state=absent")
     }
     $module.Result.changed = $changed
 }

--- a/plugins/modules/win_package.py
+++ b/plugins/modules/win_package.py
@@ -112,8 +112,8 @@ options:
       idempotency checks, otherwise the file will only be downloaded if the
       package has not been installed based on the C(product_id) checks.
     - If C(state=present) then this value MUST be set.
-    - If C(state=absent) then this value does not need to be set if
-      C(product_id) is.
+    - If C(state=absent) and C(product_id) is set then this value is not required.
+    - Module can not derive product id if C(state=absent) and path is a URL.
     type: str
   product_id:
     description:
@@ -128,7 +128,7 @@ options:
       package found under the C(Get-AppxPackage) cmdlet.
     - For registry (exe) packages, this is the registry key name under the
       registry paths specified in I(provider).
-    - This value is ignored if C(path) is set to a local accesible file path
+    - This value is ignored if C(path) is set to a local accessible file path
       and the package is not an C(exe).
     - This SHOULD be set when the package is an C(exe), or the path is a url
       or a network share and credential delegation is not being used. The
@@ -172,7 +172,7 @@ options:
     - The module uses I(product_id) to determine whether the package is
       installed or not.
     - For all providers but C(auto), the I(path) can be used for idempotency
-      checks if it is locally accesible filesystem path.
+      checks if it is locally accessible filesystem path.
     type: str
     choices: [ absent, present ]
     default: present

--- a/tests/integration/targets/win_package/tasks/failure_tests.yml
+++ b/tests/integration/targets/win_package/tasks/failure_tests.yml
@@ -5,7 +5,7 @@
     path: '{{ test_path }}\bad.msi'
     state: present
   register: fail_bad_rc
-  failed_when: "'unexpected rc from' not in fail_bad_rc.msg and fail_bad_rc.rc != 1603" 
+  failed_when: "'unexpected rc from' not in fail_bad_rc.msg and fail_bad_rc.rc != 1603"
 
 - name: fail when not using an int for a return code
   win_package:
@@ -41,6 +41,13 @@
     state: present
   register: fail_invalid_url_path
   failed_when: "\"The remote name could not be resolved: 'fakeurl'\" not in fail_invalid_url_path.msg"
+
+- name: fail uninstall when no product id is specified and path is URL
+  win_package:
+    path: https://www.python.org/ftp/python/3.11.0/python-3.11.0-amd64.exe
+    state: absent
+  register: fail_uninstall_url_path
+  failed_when: "\"Unable to find Product ID from the URL path.\" not in fail_uninstall_url_path.msg"
 
 - name: fail to check version without creates_path
   win_package:


### PR DESCRIPTION
##### SUMMARY

* When path is specified as an URL with state as absent,
  it is difficult to derive product id, which is required for
  uninstalling the package.
  Gracefully fail and let user know about this requirement.

Fixes: #667

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request


