### PR TITLE
preserve user-provided value for ansible_managed for 2.19+

### DIFF
--- a/changelogs/fragments/win_template_preserve_ansible_managed.yml
+++ b/changelogs/fragments/win_template_preserve_ansible_managed.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - win_template - Preserve user-supplied value for ``ansible_managed`` when set on Ansible Core 2.19+.

--- a/tests/integration/targets/win_template/tasks/main.yml
+++ b/tests/integration/targets/win_template/tasks/main.yml
@@ -251,3 +251,43 @@
     that:
     - template_windows_1252 is changed
     - template_windows_1252_actual.content | b64decode(encoding='windows-1252') == expected_content + "\r\n"
+
+- name: verify ansible_managed default
+  win_template:
+    src: with_managed.j2
+    dest: '{{ remote_tmp_dir }}/with_managed_default.templated'
+  register: template_result_managed_default
+
+- set_fact:
+    expected_managed_default: "{{ lookup('template', 'with_managed.j2') }}"
+
+- name: run with overridden ansible_managed (no-op < 2.19)
+  vars:
+    ansible_managed: overridden
+  block:
+  - name: verify ansible_managed override
+    win_template:
+      src: with_managed.j2
+      dest: '{{ remote_tmp_dir }}/with_managed_override.templated'
+    register: template_result_managed_override
+
+  - set_fact:
+      expected_managed_override: "{{ lookup('template', 'with_managed.j2') }}"
+
+- name: fetch templated ansible_managed values
+  slurp:
+    src: '{{ item }}'
+  loop:
+    - '{{ template_result_managed_default.dest }}'
+    - '{{ template_result_managed_override.dest }}'
+  register: slurp_res
+
+- set_fact:
+    actual_managed_default: '{{ slurp_res.results[0].content | b64decode }}'
+    actual_managed_override: '{{ slurp_res.results[1].content | b64decode }}'
+
+- name: assert expected ansible_managed values
+  assert:
+    that:
+    - actual_managed_default is contains expected_managed_default
+    - actual_managed_override is contains expected_managed_override

--- a/tests/integration/targets/win_template/templates/with_managed.j2
+++ b/tests/integration/targets/win_template/templates/with_managed.j2
@@ -1,0 +1,1 @@
+{{ ansible_managed }}  # NB: no line ending on this template to avoid line-ending issues


### PR DESCRIPTION
##### SUMMARY
The not-really-public core utility function `generate_ansible_template_vars` previously always masked user-supplied values for `ansible_managed`. Core 2.19 deprecates the multiple bespoke (and largely undocumented/untested) template grammars that grew for `ansible_managed` in favor of standard Jinja templating, with a static default for `ansible_managed` only supplied in the absence of a user-supplied value.

This change (and associated tests) uses the new behavior that was added to the core `template` action and lookup if available, while preserving existing behavior on < core 2.19.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
