### PR TITLE
win_copy: fix symlink information

### DIFF
--- a/changelogs/fragments/copy_fix.yml
+++ b/changelogs/fragments/copy_fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+   - win_copy - report correct information about symlinks in action plugin.

--- a/plugins/action/win_copy.py
+++ b/plugins/action/win_copy.py
@@ -198,7 +198,7 @@ def _walk_dirs(topdir, loader, decrypt=True, base_path=None, local_follow=False,
         offset += 1
 
     if os.path.islink(topdir) and not local_follow:
-        r_files['symlinks'] = {"src": os.readlink(topdir), "dest": os.path.basename(topdir)}
+        r_files['symlinks'].append({"src": os.readlink(topdir), "dest": os.path.basename(topdir)})
         return r_files
 
     dir_stats = os.stat(topdir)

--- a/tests/unit/plugins/action/test_win_copy.py
+++ b/tests/unit/plugins/action/test_win_copy.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible_collections.ansible.windows.plugins.action import win_copy
+
+
+def test_walk_dirs_with_symlink(mocker):
+    mocker.patch("os.path.islink", return_value=True)
+    mocker.patch("os.readlink", return_value="/path/to/real/file.txt")
+    mocker.patch("os.path.basename", return_value="file.txt")
+
+    ret = win_copy._walk_dirs("/path/to/symlink", loader=None, local_follow=False)
+    expected = {
+        "directories": [],
+        "files": [],
+        "symlinks": [
+            {
+                "dest": "file.txt",
+                "src": "/path/to/real/file.txt",
+            }
+        ],
+    }
+    assert ret == expected


### PR DESCRIPTION
##### SUMMARY

* symlinks should return list of dict containing src and dest

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
plugins/action/win_copy.py
tests/unit/plugins/action/test_win_copy.py


