### PR TITLE
fix: win_service with --check flag

### DIFF
--- a/changelogs/fragments/win_service_check_flag.yml
+++ b/changelogs/fragments/win_service_check_flag.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - win_service - Fix crash with --check flag.
+  - win_service - Fix crash when attempting to create a service with the ``--check`` flag.

--- a/changelogs/fragments/win_service_check_flag.yml
+++ b/changelogs/fragments/win_service_check_flag.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - win_service - Crash with --check flag.

--- a/changelogs/fragments/win_service_check_flag.yml
+++ b/changelogs/fragments/win_service_check_flag.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - win_service - Crash with --check flag.
+  - win_service - Fix crash with --check flag.

--- a/changelogs/fragments/win_template_preserve_ansible_managed.yml
+++ b/changelogs/fragments/win_template_preserve_ansible_managed.yml
@@ -1,2 +1,5 @@
 minor_changes:
   - win_template - Preserve user-supplied value for ``ansible_managed`` when set on Ansible Core 2.19+.
+
+bug_fixes:
+  - win_server - Fix crash with --check flag.

--- a/changelogs/fragments/win_template_preserve_ansible_managed.yml
+++ b/changelogs/fragments/win_template_preserve_ansible_managed.yml
@@ -1,5 +1,2 @@
 minor_changes:
   - win_template - Preserve user-supplied value for ``ansible_managed`` when set on Ansible Core 2.19+.
-
-bug_fixes:
-  - win_server - Fix crash with --check flag.

--- a/plugins/modules/win_service.ps1
+++ b/plugins/modules/win_service.ps1
@@ -1031,7 +1031,7 @@ else {
 
         # The ServiceStartName for these types of services aren't the account it runs on so running this will fail
         # to convert it to an account. While this could be configured in the future for now we just ignore the values.
-        if ( -not (
+        if ($service -and -not (
                 $service.ServiceType.HasFlag([Ansible.Windows.SCManager.ServiceType]::KernelDriver) -or
                 $service.ServiceType.HasFlag([Ansible.Windows.SCManager.ServiceType]::FileSystemDriver)
             )) {

--- a/tests/integration/targets/win_service/tasks/tests.yml
+++ b/tests/integration/targets/win_service/tasks/tests.yml
@@ -689,6 +689,21 @@
     name: "{{test_win_service_name}}"
     path: "{{test_win_service_path}}"
 
+- name: create service with check mode
+  win_service:
+    name: TestServiceParent2
+    display_name: Test Service Parent 2
+    path: "{{test_win_service_path}}"
+  check_mode: true
+
+- name: check that creating a service with check mode does not change anything
+  win_powershell:
+    script: Get-Service -Name $args[0] -ErrorAction Ignore
+    parameters:
+      Name: TestServiceParent2
+  register: create_service_check
+  failed_when: create_service_check.output != []
+
 - name: create new second dependency parent service
   win_service:
     name: TestServiceParent2


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

The `win_service` module will crash if you run it with the --check flag.
This pull request fixes the issue.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
win_service

##### ADDITIONAL INFORMATION
n/a