### PR TITLE
Add support for creating temporary file with custom prefix

### DIFF
--- a/plugins/modules/win_tempfile.py
+++ b/plugins/modules/win_tempfile.py
@@ -46,6 +46,11 @@ EXAMPLES = r"""
     state: directory
     suffix: build
 
+- name: Create temporary file with custom prefix
+  ansible.windows.win_tempfile:
+    state: file
+    prefix: customlog_
+
 - name: Create temporary file
   ansible.windows.win_tempfile:
     state: file


### PR DESCRIPTION
##### SUMMARY
- Uses the ansible.windows.win_tempfile module to create a temporary file with a custom prefix. 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible.windows.win_tempfile:


##### ADDITIONAL INFORMATION
This task allows users to specify the prefix parameter to prepend a custom string to the generated temporary file. This can be useful for log aggregation, debugging, or identifying files related to specific processes.

```yaml
- name: Create temporary file with custom prefix
  ansible.windows.win_tempfile:
    state: file
    prefix: customlog_
```

```
Before: Default temp file name begins with "ansible."
After: Temp file name begins with "customlog_"
```

