### PR TITLE
Usage for gather_timeout to customize fact gathering duration

### DIFF
--- a/plugins/modules/setup.yml
+++ b/plugins/modules/setup.yml
@@ -54,3 +54,7 @@ DOCUMENTATION:
 EXAMPLES: |
   - name: run the setup facts
     ansible.windows.setup:
+
+   - name: Gather all facts with a custom timeout on Windows host
+     ansible.windows.setup:
+       gather_timeout: 30 


### PR DESCRIPTION
##### SUMMARY

- Added a task using the `gather_timeout `parameter to demonstrate how users can customize the timeout for individual fact-gathering operations in the `ansible.windows.setup` module. 
- This helps avoid failures in environments with slower responses or limited compute resources.

##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME
  ansible.windows.setup
