### PR TITLE
Using fact_path in ansible.windows.setup module

### DIFF
--- a/plugins/modules/setup.yml
+++ b/plugins/modules/setup.yml
@@ -61,4 +61,4 @@ EXAMPLES: |
 
   - name: Gather Windows facts including custom local facts from C:\CustomFacts
     ansible.windows.setup:
-      fact_path: 'C:\\CustomFacts'
+      fact_path: C:\CustomFacts

--- a/plugins/modules/setup.yml
+++ b/plugins/modules/setup.yml
@@ -58,3 +58,7 @@ EXAMPLES: |
   - name: Gather all facts with a custom timeout on Windows host
     ansible.windows.setup:
       gather_timeout: 30
+
+  - name: Gather Windows facts including custom local facts from C:\CustomFacts
+    ansible.windows.setup:
+      fact_path: 'C:\\CustomFacts'


### PR DESCRIPTION
##### SUMMARY  
`ansible.windows.setup` module that demonstrates the use of the `fact_path` parameter which showcases how to retrieve PowerShell or JSON-based facts from `C:\CustomFacts`.

##### ISSUE TYPE  
- Docs Pull Request

##### COMPONENT NAME  
`ansible.windows.setup` module

##### ADDITIONAL INFORMATION  
This update addresses a gap in the documentation by showing how to use `fact_path`, which was previously undocumented in the examples section. This is particularly helpful for users managing their own local facts for automation use cases.

```yaml
- name: Gather Windows facts including custom local facts from C:\CustomFacts
  ansible.windows.setup:
    fact_path: 'C:\\CustomFacts'
```