### PR TITLE
Add playbook to set retention_days for Windows event log

### DIFF
--- a/plugins/modules/win_eventlog.py
+++ b/plugins/modules/win_eventlog.py
@@ -113,6 +113,12 @@ EXAMPLES = r'''
   ansible.windows.win_eventlog:
     name: MyNewLog
     state: absent
+
+- name: Set retention policy for MyNewLog to 15 days
+  ansible.windows.win_eventlog:
+    name: MyNewLog
+    retention_days: 15
+    state: present
 '''
 
 RETURN = r'''


### PR DESCRIPTION
##### SUMMARY  
Added a playbook that demonstrates how to set the `retention_days` parameter using the `ansible.windows.win_eventlog` module.  

##### ISSUE TYPE  
- Docs Pull Request

##### COMPONENT NAME  
`ansible.windows.win_eventlog`

