### PR TITLE
Add playbook to allow inbound traffic on Private firewall profile

### DIFF
--- a/plugins/modules/win_firewall.py
+++ b/plugins/modules/win_firewall.py
@@ -68,6 +68,13 @@ EXAMPLES = r'''
     state: enabled
     outbound_action: block
   tags: block_connection
+
+- name: Allow inbound traffic on Private profile
+  ansible.windows.win_firewall:
+    state: enabled
+    profiles:
+      - Private
+    inbound_action: allow  
 '''
 
 RETURN = r'''


### PR DESCRIPTION
##### SUMMARY  
Added a playbook using the `ansible.windows.win_firewall` module to allow inbound traffic on the Private firewall profile.  

##### ISSUE TYPE  
- Docs Pull Request

##### COMPONENT NAME  
`ansible.windows.win_firewall`

##### ADDITIONAL INFORMATION  

```yaml
- name: Allow inbound traffic on Private profile
  ansible.windows.win_firewall:
    state: enabled
    profiles:
      - Private
    inbound_action: allow
