### PR TITLE
Add playbook to render template with trim_blocks enabled for cleaner output

### DIFF
--- a/plugins/modules/win_template.py
+++ b/plugins/modules/win_template.py
@@ -142,6 +142,12 @@ EXAMPLES = r'''
     dest: C:\share\unix\config.conf
     newline_sequence: '\n'
     backup: true
+
+- name: Render template with trimmed newlines
+  ansible.windows.win_template:
+    src: unix/config.conf.j2
+    dest: C:\share\unix\config.conf
+    trim_blocks: true
 '''
 
 RETURN = r'''


### PR DESCRIPTION
##### SUMMARY  
- Added a playbook using the `ansible.windows.win_template` module that demonstrates setting `trim_blocks: true`.  
- This configuration removes unnecessary newlines from Jinja2 block statements, producing cleaner and more compact output files.

##### ISSUE TYPE  
- Docs Pull Request

##### COMPONENT NAME  
`ansible.windows.win_template`

