### PR TITLE
win_reboot - remove PATH lookup

### DIFF
--- a/changelogs/fragments/win_reboot-path.yml
+++ b/changelogs/fragments/win_reboot-path.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    win_reboot - Use full path to ``shutdown.exe`` to avoid relying on ``PATH`` lookups to find -
+    https://github.com/ansible-collections/ansible.windows/issues/826

--- a/plugins/plugin_utils/_reboot.py
+++ b/plugins/plugin_utils/_reboot.py
@@ -176,14 +176,14 @@ def reboot_host(
     # This command may be wrapped in other shells or command making it hard to detect what shutdown.exe actually
     # returned. We use this hackery to return a json that contains the stdout/stderr/rc as a structured object for our
     # code to parse and detect if something went wrong.
-    reboot_command = """$ErrorActionPreference = 'Continue'
+    reboot_command = r"""$ErrorActionPreference = 'Continue'
 
 if ($%s) {
     Remove-Item -LiteralPath '%s' -Force -ErrorAction SilentlyContinue
 }
 
 $stdout = $null
-$stderr = . { shutdown.exe /r /t %s /c %s | Set-Variable stdout } 2>&1 | ForEach-Object ToString
+$stderr = . { C:\Windows\System32\shutdown.exe /r /t %s /c %s | Set-Variable stdout } 2>&1 | ForEach-Object ToString
 
 ConvertTo-Json -Compress -InputObject @{
     stdout = (@($stdout) -join "`n")
@@ -518,7 +518,7 @@ def _perform_reboot(
 
         # Try to abort (this may fail if it was already aborted)
         rc, stdout, stderr = _execute_command(
-            task_action, connection, "shutdown.exe /a"
+            task_action, connection, r"C:\Windows\System32\shutdown.exe /a"
         )
         display.vvvv(
             f"{task_action}: result from trying to abort existing shutdown - rc: {rc}, stdout: {stdout}, stderr: {stderr}"


### PR DESCRIPTION
##### SUMMARY
Remove the reliance on finding `shutdown.exe` in the `PATH` environment variable by using the full path to the exe. This also ensures that no custom `shutdown.exe` can hijack our call to `shutdown.exe`.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/826

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_reboot