### PR TITLE
win_powershell - Fix async support

### DIFF
--- a/changelogs/fragments/win_powershell-async-output.yml
+++ b/changelogs/fragments/win_powershell-async-output.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    win_powershell - Fix up async support for Ansible 2.19 when running ``win_powershell`` -
+    https://github.com/ansible-collections/ansible.windows/issues/828


### PR DESCRIPTION
##### SUMMARY
Fix async support in Ansible 2.19 by ensuring the `win_powershell` module does not emit more than just the module result json.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/828

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_powershell