### PR TITLE
win_environment - Add env_values return value

### DIFF
--- a/changelogs/fragments/win_environment-return.yml
+++ b/changelogs/fragments/win_environment-return.yml
@@ -1,0 +1,5 @@
+minor_changes:
+  - >-
+    win_environment - Add the return value ``env_values`` which is a copy of the existing ``values`` return value. The
+    documentation for ``values`` has been removed to discourage use of that version due to the inability to use
+    ``values`` with dot notation in a Jinja2 template due to the conflict with the Python ``values`` attribute.

--- a/plugins/modules/win_environment.ps1
+++ b/plugins/modules/win_environment.ps1
@@ -52,7 +52,7 @@ function Set-EnvironmentVariableState {
         $State
     )
 
-    Process {
+    process {
         if (-not $State) {
             $State = if (-not $Value) {
                 'absent'
@@ -89,7 +89,7 @@ function Set-EnvironmentVariableState {
     }
 }
 
-Function Register-EnvironmentChange {
+function Register-EnvironmentChange {
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -151,7 +151,11 @@ namespace Ansible.Windows.WinEnvironment
         5000)
 }
 
+# We use both values and env_values. We need to deprecate 'values' due to a new
+# linting rule that tries to stop us using something that doesn't work with dot
+# notation.
 $module.Result.values = @{}
+$module.Result.env_values = @{}
 
 $level = $module.Params.level
 $state = $module.Params.state
@@ -191,6 +195,7 @@ foreach ($kv in $envvars.GetEnumerator()) {
     }
 
     $module.Result.values.$name = $status
+    $module.Result.env_values.$name = $status
     $module.Result.changed = $module.Result.changed -or $status.changed
 
     $module.Result.before_value = $status.before

--- a/plugins/modules/win_environment.py
+++ b/plugins/modules/win_environment.py
@@ -109,10 +109,11 @@ value:
   returned: always
   type: str
   sample: C:\Program Files\jdk1.8
-values:
-  description: "dictionary of before and after values; each key is a variable name, each value is
-  another dict with C(before), C(after), and C(changed) keys"
+env_values:
+  description:
+  - Dictionary of before and after values; each key is a variable name, each value is another dict with C(before), C(after), and C(changed) keys
+  - This is also returned under the C(values) key for backward compatibility, but that usage is deprecated.
   returned: always
   type: dict
-  version_added: '1.3.0'
+  version_added: '3.3.0'
 '''

--- a/tests/integration/targets/win_environment/tasks/main.yml
+++ b/tests/integration/targets/win_environment/tasks/main.yml
@@ -52,6 +52,7 @@
   assert:
     that:
     - create_machine_check is changed
+    - create_machine_check.env_values is defined
     - create_machine_check_actual.stdout == ""
 
 - name: create test environment value for machine
@@ -71,6 +72,7 @@
     that:
     - create_machine is changed
     - create_machine.before_value == None
+    - create_machine.env_values is defined
     - create_machine_actual.stdout | trim == test_machine_environment_value
 
 - name: create test environment value for machine again
@@ -90,6 +92,7 @@
     that:
     - create_machine_again is not changed
     - create_machine_again.before_value == test_machine_environment_value
+    - create_machine_again.env_values is defined
     - create_machine_actual_again.stdout | trim == test_machine_environment_value
 
 - name: change test environment value for machine check
@@ -110,6 +113,7 @@
     that:
     - change_machine_check is changed
     - change_machine_check.before_value == test_machine_environment_value
+    - change_machine_check.env_values is defined
     - change_machine_actual_check.stdout | trim == test_machine_environment_value
 
 - name: change test environment value for machine
@@ -129,6 +133,7 @@
     that:
     - change_machine is changed
     - change_machine.before_value == test_machine_environment_value
+    - change_machine.env_values is defined
     - change_machine_actual.stdout | trim == test_new_machine_environment_value
 
 - name: change test environment value for machine again
@@ -148,6 +153,7 @@
     that:
     - change_machine_again is not changed
     - change_machine_again.before_value == test_new_machine_environment_value
+    - change_machine_again.env_values is defined
     - change_machine_actual_again.stdout | trim == test_new_machine_environment_value
 
 - name: create test environment value for user check


### PR DESCRIPTION
##### SUMMARY
Adds the `env_values` return value which is a copy of the existing `values` return value. The `values` return value is being discouraged due to the name conflict with the builtin Python `values` attribute on a dict making it harder to use in a Jinja2 template.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_environment