### PR TITLE
Stop using deprecated text utils

### DIFF
--- a/changelogs/fragments/test-utils.yml
+++ b/changelogs/fragments/test-utils.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - >-
+    Stop using the deprecated text module_utils in Ansible that will be removed in Ansible ``2.24``.

--- a/plugins/action/win_copy.py
+++ b/plugins/action/win_copy.py
@@ -18,7 +18,7 @@ import zipfile
 
 from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleFileNotFound
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action import ActionBase
 from ansible.utils.hashing import checksum

--- a/plugins/action/win_template.py
+++ b/plugins/action/win_template.py
@@ -21,7 +21,7 @@ from jinja2.defaults import (
 from ansible import constants as C
 from ansible.config.manager import ensure_type
 from ansible.errors import AnsibleError, AnsibleFileNotFound, AnsibleAction, AnsibleActionFail
-from ansible.module_utils._text import to_bytes, to_text, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_text, to_native
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action import ActionBase
 


### PR DESCRIPTION
##### SUMMARY
Change the imports for the text utils to use the public import API. The deprecated `_text` import is deprecated and will be removed in Ansible 2.24.

##### ISSUE TYPE
- Bugfix Pull Request