### PR TITLE
win_shell - Update executable PATH checks

### DIFF
--- a/changelogs/fragments/win_shell-path.yml
+++ b/changelogs/fragments/win_shell-path.yml
@@ -1,0 +1,8 @@
+bugfixes:
+  - >-
+    win_shell - Ensure the default ``executable`` uses the absolute path to ``powershell.exe`` rather than looking it
+    up in the ``PATH`` environment.
+
+minor_changes:
+  - >-
+    win_shell - Support using ``pwsh.exe`` as the executable in a mode similar to how ``powershell.exe`` is run.

--- a/plugins/modules/win_shell.py
+++ b/plugins/modules/win_shell.py
@@ -36,6 +36,10 @@ options:
     description:
       - Change the shell used to execute the command (eg, C(cmd)).
       - The target shell must accept a C(/c) parameter followed by the raw command line to be executed.
+      - This can also be set to a path for V(pwsh.exe) to use PowerShell 7.x in the location specified.
+      - The path used here should be the absolute path to the executable on the target host. If using a path
+        that is not absolute, it will be found in the V(PATH) environment variable which could be suceptible
+        to path hijacking.
     type: path
   stdin:
     description:
@@ -95,7 +99,7 @@ EXAMPLES = r'''
 - name: Run a command under a non-Powershell interpreter (cmd in this case)
   ansible.windows.win_shell: echo %HOMEDIR%
   args:
-    executable: cmd
+    executable: C:\Windows\System32\cmd.exe
   register: homedir_out
 
 - name: Run multi-lined shell commands

--- a/tests/integration/targets/win_shell/tasks/main.yml
+++ b/tests/integration/targets/win_shell/tasks/main.yml
@@ -284,7 +284,7 @@
     - no_profile is changed
     - no_profile.cmd == "[System.Environment]::CommandLine"
     - no_profile.rc == 0
-    - no_profile.stdout is match ('^"powershell.exe" -noninteractive -encodedcommand')
+    - no_profile.stdout is match ('.*powershell.exe" -noninteractive -encodedcommand')
 
 - name: execute powershell with no_profile
   win_shell: '[System.Environment]::CommandLine'
@@ -299,7 +299,7 @@
     - no_profile is changed
     - no_profile.cmd == "[System.Environment]::CommandLine"
     - no_profile.rc == 0
-    - no_profile.stdout is match ('^"powershell.exe" -noprofile -noninteractive -encodedcommand')
+    - no_profile.stdout is match ('.*powershell.exe" -noprofile -noninteractive -encodedcommand')
 
 - name: create symbolic link with space in the path
   win_command: cmd.exe /c mklink /d "C:\ansible test link" C:\Windows\System32\WindowsPowerShell\v1.0
@@ -323,9 +323,30 @@
       - space_exe is changed
       - space_exe.cmd == '[System.Environment]::CommandLine'
       - space_exe.rc == 0
-      - space_exe.stdout|trim == '"C:\\ansible test link\\powershell.exe" /c [System.Environment]::CommandLine'
+      - space_exe.stdout is match ('^"C:\\\\ansible test link\\\\powershell.exe" .*')
   always:
   - name: remove test symbolic link
     win_file:
       path: C:\ansible test link
       state: absent
+
+- name: check if PowerShell 7 is available
+  win_shell: ([bool](Get-Command -Name pwsh.exe -CommandType Application -ErrorAction SilentlyContinue))
+  register: pwsh_check
+
+- name: run PowerShell 7 tests
+  when: pwsh_check.stdout_lines[0] | bool
+  block:
+  - name: run with PowerShell 7 executable
+    win_shell: '$PSVersionTable.PSVersion.Major'
+    args:
+      executable: pwsh.exe
+    register: pwsh_7
+
+  - name: assert PowerShell 7 run
+    assert:
+      that:
+      - pwsh_7 is successful
+      - pwsh_7 is changed
+      - pwsh_7.stdout|trim == '7'
+      - pwsh_7.rc == 0


### PR DESCRIPTION
##### SUMMARY
Ensure that the default executable used is the absolute path to `powershell.exe` to avoid possible PATH hijacking attempts. Also adds support for targeting `pwsh.exe` as an executable using the same logic as PowerShell 5.1.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
win_shell