### PR TITLE
win_product_facts: return license facts in string

### DIFF
--- a/changelogs/fragments/win_product_facts.yml
+++ b/changelogs/fragments/win_product_facts.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+    - win_products_facts - return string for all the license related facts (https://github.com/ansible-collections/community.windows/issues/661).

--- a/plugins/modules/win_product_facts.ps1
+++ b/plugins/modules/win_product_facts.ps1
@@ -79,7 +79,7 @@ if (-not $product_key) {
 
 # Retrieve license information
 $license_info = Get-CimInstance SoftwareLicensingProduct | Where-Object {
-    $product_key -match $_.PartialProductKey -and $_.Name -match "Windows"
+    $_.PartialProductKey -and $_.Name -match "Windows"
 }
 $winlicense_status = switch ($license_info.LicenseStatus) {
     0 { "Unlicensed" }

--- a/tests/integration/targets/win_product_facts/tasks/main.yml
+++ b/tests/integration/targets/win_product_facts/tasks/main.yml
@@ -9,3 +9,8 @@
     that:
     - ansible_os_product_id is defined
     - ansible_os_product_key is defined
+    - ansible_os_license_channel is string
+    - ansible_os_license_edition is string
+    - ansible_os_license_status is string
+    - ansible_os_product_id is string
+    - ansible_os_product_key is string


### PR DESCRIPTION
##### SUMMARY

* Added tests

Fixes: https://github.com/ansible-collections/community.windows/issues/661

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/win_product_facts.yml
plugins/modules/win_product_facts.ps1
tests/integration/targets/win_product_facts/tasks/main.yml


