### PR TITLE
setup: Update Interface Fact Gathering

### DIFF
--- a/changelogs/fragments/updated_interface_facts.yml
+++ b/changelogs/fragments/updated_interface_facts.yml
@@ -1,6 +1,6 @@
 ---
 major_changes:
-  - ansible.windows.setup - Changed interface discovery command from `[System.Net.NetworkInformation.NetworkInterface]::GetAllNetworkInterfaces()` to `Get-NetAdapter -IncludeHidden`
+  - ansible.windows.setup - Changed interface discovery command to report on disabled interfaces
 minor_changes:
   - ansible.windows.setup - Added `active` attribute to interface facts to determine whether an interface is enabled
   - ansible.windows.setup - Added `device` attribute derived from the CIM_NetworkAdapater `ifName` attribute

--- a/changelogs/fragments/updated_interface_facts.yml
+++ b/changelogs/fragments/updated_interface_facts.yml
@@ -1,0 +1,12 @@
+---
+major_changes:
+  - ansible.windows.setup - Changed interface discovery command from `[System.Net.NetworkInformation.NetworkInterface]::GetAllNetworkInterfaces()` to `Get-NetAdapter -IncludeHidden`
+minor_changes:
+  - ansible.windows.setup - Added `active` attribute to interface facts to determine whether an interface is enabled
+  - ansible.windows.setup - Added `device` attribute derived from the CIM_NetworkAdapater `ifName` attribute
+  - ansible.windows.setup - Added `device_id` attribute derived from the CIM_NetworkAdapater `DeviceID` attribute
+  - ansible.windows.setup - Added `promisc` attribute derived from the CIM_NetworkAdapater `ifName` attribute
+  - ansible.windows.setup - Added `type` attribute derived from the CIM_NetworkAdapater `InterfaceType` attribute
+  - ansible.windows.setup - Added root level facts for each interface, similar to how Unix interface facts are stored (i.e. `ansible_facts.{device}`)
+bufixes:
+  - ansible.windows.setup - Fixed behavior that would not report on interfaces that are disabled or part of a bond/vSwitch

--- a/changelogs/fragments/updated_interface_facts.yml
+++ b/changelogs/fragments/updated_interface_facts.yml
@@ -7,6 +7,5 @@ minor_changes:
   - ansible.windows.setup - Added `device_id` attribute derived from the CIM_NetworkAdapater `DeviceID` attribute
   - ansible.windows.setup - Added `promisc` attribute derived from the CIM_NetworkAdapater `ifName` attribute
   - ansible.windows.setup - Added `type` attribute derived from the CIM_NetworkAdapater `InterfaceType` attribute
-  - ansible.windows.setup - Added root level facts for each interface, similar to how Unix interface facts are stored (i.e. `ansible_facts.{device}`)
-bufixes:
+bugfixes:
   - ansible.windows.setup - Fixed behavior that would not report on interfaces that are disabled or part of a bond/vSwitch

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -753,83 +753,77 @@ $factMeta = @(
             $allRoutes = @(Get-NetRoute -ErrorAction SilentlyContinue)
 
             $formattedNetCfg = @(foreach ($interface in $interfaces) {
-                if ($interface.MacAddress -eq "") {
-                    continue
-                }
+                    if ($interface.MacAddress -eq "") {
+                        continue
+                    }
 
-                $interfaceType = [System.Net.NetworkInformation.NetworkInterfaceType]($interface.InterfaceType)
+                    $interfaceType = [System.Net.NetworkInformation.NetworkInterfaceType]($interface.InterfaceType)
 
-                $addresses = @($allAddresses | Where-Object InterfaceIndex -eq $interface.InterfaceIndex)
+                    $addresses = @($allAddresses | Where-Object InterfaceIndex -eq $interface.InterfaceIndex)
 
-                $ipv4_addresses = $addresses | Where-Object AddressFamily -eq "IPv4" |
-                        Select-Object @{ N = 'address'; E = { $_.IPAddress.ToString() } },
-                                    @{ N = 'prefix';  E = { $_.PrefixLength.ToString() } }
+                    $ipv4_addresses = $addresses | Where-Object AddressFamily -eq "IPv4" |
+                        Select-Object @{ N = 'address'; E = { $_.IPAddress.ToString() } }, @{ N = 'prefix'; E = { $_.PrefixLength.ToString() } }
 
-                $ipv6_addresses = $addresses | Where-Object AddressFamily -eq "IPv6" |
-                        Select-Object @{ N = 'address'; E = { $_.IPAddress.ToString() } },
-                                    @{ N = 'prefix';  E = { $_.PrefixLength.ToString() } }
+                    $ipv6_addresses = $addresses | Where-Object AddressFamily -eq "IPv6" |
+                        Select-Object @{ N = 'address'; E = { $_.IPAddress.ToString() } }, @{ N = 'prefix'; E = { $_.PrefixLength.ToString() } }
 
-                $defaultGateway = $null
+                    $defaultGateway = $null
 
-                $ipv4Default = $allRoutes |
-                    Where-Object {
-                        $_.InterfaceIndex -eq $interface.InterfaceIndex -and
-                        $_.DestinationPrefix -eq '0.0.0.0/0' -and
-                        $_.NextHop -ne '0.0.0.0'
-                    } |
-                    Sort-Object RouteMetric, ifMetric |
-                    Select-Object -First 1
-
-                if ($ipv4Default) {
-                    $defaultGateway = $ipv4Default.NextHop.ToString()
-                }
-                else {
-                    $ipv6Default = $allRoutes |
+                    $ipv4Default = $allRoutes |
                         Where-Object {
                             $_.InterfaceIndex -eq $interface.InterfaceIndex -and
-                            $_.DestinationPrefix -eq '::/0' -and
-                            $_.NextHop -ne '::'
+                            $_.DestinationPrefix -eq '0.0.0.0/0' -and
+                            $_.NextHop -ne '0.0.0.0'
                         } |
                         Sort-Object RouteMetric, ifMetric |
                         Select-Object -First 1
 
-                    if ($ipv6Default) {
-                        $defaultGateway = $ipv6Default.NextHop.ToString()
+                    if ($ipv4Default) {
+                        $defaultGateway = $ipv4Default.NextHop.ToString()
                     }
-                }
+                    else {
+                        $ipv6Default = $allRoutes |
+                            Where-Object {
+                                $_.InterfaceIndex -eq $interface.InterfaceIndex -and
+                                $_.DestinationPrefix -eq '::/0' -and
+                                $_.NextHop -ne '::'
+                            } |
+                            Sort-Object RouteMetric, ifMetric |
+                            Select-Object -First 1
 
-                $dnsClient = $allDnsClients | Where-Object InterfaceIndex -eq $interface.InterfaceIndex | Select-Object -First 1
-                $dnsDomain = if ($dnsClient -and $dnsClient.ConnectionSpecificSuffix) {
-                    $dnsClient.ConnectionSpecificSuffix
-                }
-                else {
-                    $null
-                }
+                        if ($ipv6Default) {
+                            $defaultGateway = $ipv6Default.NextHop.ToString()
+                        }
+                    }
 
-                @{
-                    active = ($interface.Status -eq 'Up')
-                    connection_name = $interface.Name
-                    default_gateway = $defaultGateway
-                    device = $interface.ifName
-                    device_id = $interface.DeviceId.ToString()
-                    dns_domain = $dnsDomain
-                    interface_index = $interface.InterfaceIndex
-                    interface_name = $interface.InterfaceDescription
-                    ipv4 = if ($ipv4_addresses -ne @{}) {$ipv4_addresses} else { $null }
-                    ipv6 = if ($ipv6_addresses -ne @{}) {$ipv6_addresses} else { $null }
-                    macaddress = $interface.MacAddress -replace '-', ':'
-                    mtu = $interface.MtuSize
-                    promisc = $interface.PromiscuousMode
-                    speed = if ($null -ne $interface.Speed) { [int64]($interface.Speed / 1000 / 1000) } else { $null }
-                    type = $interfaceType.ToString()
-                }
-            })
+                    $dnsClient = $allDnsClients | Where-Object InterfaceIndex -eq $interface.InterfaceIndex | Select-Object -First 1
+                    $dnsDomain = if ($dnsClient -and $dnsClient.ConnectionSpecificSuffix) {
+                        $dnsClient.ConnectionSpecificSuffix
+                    }
+                    else {
+                        $null
+                    }
+
+                    @{
+                        active = ($interface.Status -eq 'Up')
+                        connection_name = $interface.Name
+                        default_gateway = $defaultGateway
+                        device = $interface.ifName
+                        device_id = $interface.DeviceId.ToString()
+                        dns_domain = $dnsDomain
+                        interface_index = $interface.InterfaceIndex
+                        interface_name = $interface.InterfaceDescription
+                        ipv4 = if ($ipv4_addresses -ne @{}) { $ipv4_addresses } else { $null }
+                        ipv6 = if ($ipv6_addresses -ne @{}) { $ipv6_addresses } else { $null }
+                        macaddress = $interface.MacAddress -replace '-', ':'
+                        mtu = $interface.MtuSize
+                        promisc = $interface.PromiscuousMode
+                        speed = if ($null -ne $interface.Speed) { [int64]($interface.Speed / 1000 / 1000) } else { $null }
+                        type = $interfaceType.ToString()
+                    }
+                })
 
             $ansibleFacts.ansible_interfaces = $formattedNetCfg
-
-            foreach ($iface in $formattedNetCfg) {
-                $ansibleFacts[$iface.device] = $iface
-            }
         }
     },
     @{

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -747,68 +747,89 @@ $factMeta = @(
     @{
         Subsets = 'interfaces'
         Code = {
-            $interfaces = [System.Net.NetworkInformation.NetworkInterface]::GetAllNetworkInterfaces()
+            $interfaces = Get-NetAdapter -IncludeHidden
+            $allAddresses = @(Get-NetIPAddress -ErrorAction SilentlyContinue)
+            $allDnsClients = @(Get-DnsClient -ErrorAction SilentlyContinue)
+            $allRoutes = @(Get-NetRoute -ErrorAction SilentlyContinue)
 
             $formattedNetCfg = @(foreach ($interface in $interfaces) {
-                    $ipProps = $interface.GetIPProperties()
+                if ($interface.MacAddress -eq "") {
+                    continue
+                }
 
-                    try {
-                        $ipv4 = $ipProps.GetIPv4Properties()
-                    }
-                    catch [System.Net.NetworkInformation.NetworkInformationException] {
-                        $ipv4 = $null
-                    }
-                    try {
-                        $ipv6 = $ipProps.GetIPv6Properties()
-                    }
-                    catch [System.Net.NetworkInformation.NetworkInformationException] {
-                        $ipv6 = $null
-                    }
+                $interfaceType = [System.Net.NetworkInformation.NetworkInterfaceType]($interface.InterfaceType)
 
-                    # Do not repo on either the loopback interface or any interfaces that did not have an IP address.
-                    if (-not ($ipv4 -or $ipv6) -or $interface.NetworkInterfaceType -in @('Loopback', 'Tunnel')) {
-                        continue
-                    }
+                $addresses = @($allAddresses | Where-Object InterfaceIndex -eq $interface.InterfaceIndex)
 
-                    $defaultGateway = if ($ipProps.GatewayAddresses) {
-                        $ipProps.GatewayAddresses[0].Address.IPAddressToString
-                    }
-                    $dnsDomain = $null
-                    if ($ipProps.DnsSuffix) {
-                        $dnsDomain = $ipProps.DnsSuffix
-                    }
-                    $index = if ($ipv4) {
-                        $ipv4.Index
-                    }
-                    elseif ($ipv6) {
-                        $ipv6.Index
-                    }
+                $ipv4_addresses = $addresses | Where-Object AddressFamily -eq "IPv4" |
+                        Select-Object @{ N = 'address'; E = { $_.IPAddress.ToString() } },
+                                    @{ N = 'prefix';  E = { $_.PrefixLength.ToString() } }
 
-                    $ipv4_address = $ipProps.UnicastAddresses | Where-Object {
-                        $_.Address.AddressFamily -eq 2
-                    } | Select-Object @{ N = 'address'; E = { $_.Address.ToString() } }, @{ N = 'prefix'; E = { $_.PrefixLength.ToString() } }
+                $ipv6_addresses = $addresses | Where-Object AddressFamily -eq "IPv6" |
+                        Select-Object @{ N = 'address'; E = { $_.IPAddress.ToString() } },
+                                    @{ N = 'prefix';  E = { $_.PrefixLength.ToString() } }
 
-                    $ipv6_address = $ipProps.UnicastAddresses | Where-Object {
-                        $_.Address.AddressFamily -eq 23
-                    } | Select-Object @{ N = 'address'; E = { $_.Address.ToString() } }, @{ N = 'prefix'; E = { $_.PrefixLength.ToString() } }
+                $defaultGateway = $null
 
-                    $mac = ($interface.GetPhysicalAddress() -replace '(..)', '$1:').ToUpperInvariant().Trim(':')
+                $ipv4Default = $allRoutes |
+                    Where-Object {
+                        $_.InterfaceIndex -eq $interface.InterfaceIndex -and
+                        $_.DestinationPrefix -eq '0.0.0.0/0' -and
+                        $_.NextHop -ne '0.0.0.0'
+                    } |
+                    Sort-Object RouteMetric, ifMetric |
+                    Select-Object -First 1
 
-                    @{
-                        connection_name = $interface.Name
-                        default_gateway = $defaultGateway
-                        dns_domain = $dnsDomain
-                        interface_index = $index
-                        interface_name = $interface.Description
-                        ipv4 = $ipv4_address
-                        ipv6 = $ipv6_address
-                        macaddress = $mac
-                        mtu = $ipv4.Mtu
-                        speed = $interface.Speed / 1000 / 1000
+                if ($ipv4Default) {
+                    $defaultGateway = $ipv4Default.NextHop.ToString()
+                }
+                else {
+                    $ipv6Default = $allRoutes |
+                        Where-Object {
+                            $_.InterfaceIndex -eq $interface.InterfaceIndex -and
+                            $_.DestinationPrefix -eq '::/0' -and
+                            $_.NextHop -ne '::'
+                        } |
+                        Sort-Object RouteMetric, ifMetric |
+                        Select-Object -First 1
+
+                    if ($ipv6Default) {
+                        $defaultGateway = $ipv6Default.NextHop.ToString()
                     }
-                })
+                }
+
+                $dnsClient = $allDnsClients | Where-Object InterfaceIndex -eq $interface.InterfaceIndex | Select-Object -First 1
+                $dnsDomain = if ($dnsClient -and $dnsClient.ConnectionSpecificSuffix) {
+                    $dnsClient.ConnectionSpecificSuffix
+                }
+                else {
+                    $null
+                }
+
+                @{
+                    active = ($interface.Status -eq 'Up')
+                    connection_name = $interface.Name
+                    default_gateway = $defaultGateway
+                    device = $interface.ifName
+                    device_id = $interface.DeviceId.ToString()
+                    dns_domain = $dnsDomain
+                    interface_index = $interface.InterfaceIndex
+                    interface_name = $interface.InterfaceDescription
+                    ipv4 = if ($ipv4_addresses -ne @{}) {$ipv4_addresses} else { $null }
+                    ipv6 = if ($ipv6_addresses -ne @{}) {$ipv6_addresses} else { $null }
+                    macaddress = $interface.MacAddress -replace '-', ':'
+                    mtu = $interface.MtuSize
+                    promisc = $interface.PromiscuousMode
+                    speed = if ($null -ne $interface.Speed) { [int64]($interface.Speed / 1000 / 1000) } else { $null }
+                    type = $interfaceType.ToString()
+                }
+            })
 
             $ansibleFacts.ansible_interfaces = $formattedNetCfg
+
+            foreach ($iface in $formattedNetCfg) {
+                $ansibleFacts[$iface.device] = $iface
+            }
         }
     },
     @{

--- a/tests/integration/targets/win_setup/tasks/main.yml
+++ b/tests/integration/targets/win_setup/tasks/main.yml
@@ -115,9 +115,21 @@
     - setup_result.ansible_facts.gather_subset[2] == 'interfaces'
     - setup_result.ansible_facts.ansible_interfaces is defined
     - setup_result.ansible_facts.ansible_interfaces[0] is defined
-    - setup_result.ansible_facts.ansible_interfaces[0].interface_name is defined
+    - setup_result.ansible_facts.ansible_interfaces[0].active is defined
     - setup_result.ansible_facts.ansible_interfaces[0].connection_name is defined
+    - setup_result.ansible_facts.ansible_interfaces[0].default_gateway is defined
+    - setup_result.ansible_facts.ansible_interfaces[0].device is defined
+    - setup_result.ansible_facts.ansible_interfaces[0].device_id is defined
+    - setup_result.ansible_facts.ansible_interfaces[0].dns_domain is defined
     - setup_result.ansible_facts.ansible_interfaces[0].interface_index is defined
+    - setup_result.ansible_facts.ansible_interfaces[0].interface_name is defined
+    - setup_result.ansible_facts.ansible_interfaces[0].ipv4 is defined
+    - setup_result.ansible_facts.ansible_interfaces[0].ipv6 is defined
+    - setup_result.ansible_facts.ansible_interfaces[0].macaddress is defined
+    - setup_result.ansible_facts.ansible_interfaces[0].mtu is defined
+    - setup_result.ansible_facts.ansible_interfaces[0].promisc is defined
+    - setup_result.ansible_facts.ansible_interfaces[0].speed is defined
+    - setup_result.ansible_facts.ansible_interfaces[0].type is defined
     - setup_result.ansible_facts.keys() | list | union(['ansible_interfaces','gather_subset','module_setup']) | length == 3
 
 - name: test gather_subset "!all,!min,bogus" with list


### PR DESCRIPTION
##### SUMMARY
This pull request changes the underlying fact gathering on interfaces to align more closely to Unix interface facts in [ansible.builtin.setup](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/setup.py).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`setup`

##### ADDITIONAL INFORMATION
The main change in this PR is allowing fact discovery against disabled interfaces, or interfaces that are part of a bond/vSwitch by changing interface discovery from `[System.Net.NetworkInformation.NetworkInterface]::GetAllNetworkInterfaces()` to `Get-NetAdapter -IncludeHidden`.

_**NOTE**: Only interfaces with MAC addresses are reported to avoid bloating with virtual interfaces_

Additionally, more facts are returned for interfaces along with those already returned:
- Added `active` attribute to interface facts to determine whether an interface is enabled
- Added `device` attribute derived from the CIM_NetworkAdapater `ifName` attribute
- Added `device_id` attribute derived from the CIM_NetworkAdapater `DeviceID` attribute
- Added `promisc` attribute derived from the CIM_NetworkAdapater `ifName` attribute
- Added `type` attribute derived from the CIM_NetworkAdapater `InterfaceType` attribute

###### Optional Addition
Root-level facts for interfaces have also been added in this PR to move closer to Unix facts.  
Full alignment will require a major change of the `ansible_facts.interfaces` variable to just be a list of interface names (`CIM_NetworkAdapter.ifName`).

This behavior can be removed from the PR if it's not desirable (L#829 - L#832).

##### OUTPUT COMPARISON
The comparison below executes the whole `Code` block in the `interface` subset, and then outputs it via:

```powershell
foreach ($interface in $formattedNetCfg) {
    $interface | Format-Table
}
```

###### BEFORE
```
Name                           Value                                                                                                                                                                                  
----                           -----                                                                                                                                                                                  
dns_domain                                                                                                                                                                                                            
connection_name                Ethernet 2                                                                                                                                                                             
default_gateway                10.172.123.1                                                                                                                                                                           
mtu                            1500                                                                                                                                                                                   
interface_name                 Red Hat VirtIO Ethernet Adapter #3                                                                                                                                                     
ipv6                           @{address=fe80::220a:171e:f336:c42d%5; prefix=64}                                                                                                                                      
macaddress                     00:00:0A:1C:58:4A                                                                                                                                                                      
speed                          10000                                                                                                                                                                                  
interface_index                5                                                                                                                                                                                      
ipv4                           @{address=10.172.123.13; prefix=25}
```

###### AFTER
```
Name                           Value
----                           -----
ipv6                           @{address=fe80::220a:171e:f336:c42d%5; prefix=64}
device                         ethernet_32774
device_id                      {5247C5F0-9077-4BB6-95C1-478AB59A7045}
connection_name                Ethernet 2
speed                          10000
mtu                            1500
default_gateway                10.172.123.1
interface_name                 Red Hat VirtIO Ethernet Adapter #3
type                           Ethernet
macaddress                     00:00:0A:1C:58:4A
ipv4                           @{address=10.172.123.13; prefix=25}
promisc                        False
dns_domain
interface_index                5
active                         True



Name                           Value
----                           -----
ipv6
device                         ethernet_32773
device_id                      {2E25FE1B-CCD0-4DF6-A0E0-6B1943D396AB}
connection_name                Ethernet
speed                          0
mtu                            0
default_gateway
interface_name                 Red Hat VirtIO Ethernet Adapter #2
type                           Ethernet
macaddress                     00:00:45:1C:58:4A
ipv4
promisc                        False
dns_domain
interface_index                3
active                         False
```

##### TIMING COMPARISONS
These changes increase execution time slightly, but offer much needed improved visibility into available interfaces and their configurations.

The comparisons below execute the whole `Code` block in the `interface` subset within `Measure-Command`:

###### BEFORE
```
Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 36
Ticks             : 363907
TotalDays         : 4.21188657407407E-07
TotalHours        : 1.01085277777778E-05
TotalMinutes      : 0.000606511666666667
TotalSeconds      : 0.0363907
TotalMilliseconds : 36.3907
```

###### AFTER
```
Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 153
Ticks             : 1536000
TotalDays         : 1.77777777777778E-06
TotalHours        : 4.26666666666667E-05
TotalMinutes      : 0.00256
TotalSeconds      : 0.1536
TotalMilliseconds : 153.6
```
