### PR TITLE
Wrap Win32_Share in try/catch to avoid failure for non-admin

### DIFF
--- a/changelogs/fragments/win_stat-win_find-share-access-denied.yaml
+++ b/changelogs/fragments/win_stat-win_find-share-access-denied.yaml
@@ -1,3 +1,2 @@
 bugfixes:
-  - win_stat - Gracefully handle ``Access denied`` errors when querying ``Win32_Share`` for share information on directories. Non-administrator users will now receive a warning instead of a module failure (https://github.com/ansible-collections/ansible.windows/issues/809).
-  - win_find - Gracefully handle ``Access denied`` errors when querying ``Win32_Share`` for share information on directories. Non-administrator users will now receive a warning instead of a module failure (https://github.com/ansible-collections/ansible.windows/issues/809).
+  - win_stat / win_find - try/catch Access Denied when querying Win32_Share for share info. Non-admin users now get warning instead of failure. Fixes 809.

--- a/changelogs/fragments/win_stat-win_find-share-access-denied.yaml
+++ b/changelogs/fragments/win_stat-win_find-share-access-denied.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - win_stat - Gracefully handle ``Access denied`` errors when querying ``Win32_Share`` for share information on directories. Non-administrator users will now receive a warning instead of a module failure (https://github.com/ansible-collections/ansible.windows/issues/809).
+  - win_find - Gracefully handle ``Access denied`` errors when querying ``Win32_Share`` for share information on directories. Non-administrator users will now receive a warning instead of a module failure (https://github.com/ansible-collections/ansible.windows/issues/809).

--- a/plugins/modules/win_find.ps1
+++ b/plugins/modules/win_find.ps1
@@ -332,10 +332,15 @@ Function Search-Path {
         }
 
         if ($dir_child.Attributes.HasFlag([System.IO.FileAttributes]::Directory)) {
-            $share_info = Get-CimInstance -ClassName Win32_Share -Filter "Path='$($dir_child.FullName -replace "(\\|')", '\$1')'"
-            if ($null -ne $share_info) {
-                $file_info.isshared = $true
-                $file_info.sharename = $share_info.Name
+            try {
+                $share_info = Get-CimInstance -ClassName Win32_Share -Filter "Path='$($dir_child.FullName -replace "(\\|')", '\$1')'"
+                if ($null -ne $share_info) {
+                    $file_info.isshared = $true
+                    $file_info.sharename = $share_info.Name
+                }
+            }
+            catch {
+                $module.Warn("Failed to check share info for '$($dir_child.FullName)': $($_.Exception.Message)")
             }
         }
         else {

--- a/plugins/modules/win_stat.ps1
+++ b/plugins/modules/win_stat.ps1
@@ -139,10 +139,15 @@ If ($null -ne $info) {
     # values that are set according to the type of file
     if ($info.Attributes.HasFlag([System.IO.FileAttributes]::Directory)) {
         $stat.isdir = $true
-        $share_info = Get-CimInstance -ClassName Win32_Share -Filter "Path='$($stat.path -replace "(\\|')", '\$1')'"
-        if ($null -ne $share_info) {
-            $stat.isshared = $true
-            $stat.sharename = $share_info.Name
+        try {
+            $share_info = Get-CimInstance -ClassName Win32_Share -Filter "Path='$($stat.path -replace "(\\|')", '\$1')'"
+            if ($null -ne $share_info) {
+                $stat.isshared = $true
+                $stat.sharename = $share_info.Name
+            }
+        }
+        catch {
+            $module.Warn("Failed to check share info for '$($stat.path)': $($_.Exception.Message)")
         }
 
         if ($get_size) {


### PR DESCRIPTION
##### SUMMARY
`Win32_Share` fails when run as a non-Admin user, which causes `win_stat` and `win_find` to both fail when run as non-Admin. Wrap in try/catch. This is the same approach taken elsewhere eg just before in both.

Fixes #809

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`win_stat` and `win_find`

##### ADDITIONAL INFORMATION
```
fatal: [hostname]: FAILED! => {"changed": false, "msg": "Unhandled exception while executing module: Access denied "}
```
