### PR TITLE
Support for non-Windows targets

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -309,6 +309,18 @@ stages:
               test: 2025/psrp/http
             - name: 2025 SSH Key
               test: 2025/ssh/key
+  - stage: Posix_Pwsh_7_6
+    displayName: Posix Pwsh 7.6
+    dependsOn:
+      - Dependencies
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: PowerShell {0}
+          testFormat: powershell/{0}
+          targets:
+            - name: 7.6
+
   - stage: Summary
     condition: succeededOrFailed()
     dependsOn:
@@ -327,5 +339,6 @@ stages:
       - Windows_3_Pwsh_7_6
       - Windows_4_WinPS
       - Windows_4_Pwsh_7_6
+      - Posix_Pwsh_7_6
     jobs:
       - template: templates/coverage.yml

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -317,7 +317,7 @@ stages:
       - template: templates/matrix.yml
         parameters:
           nameFormat: PowerShell {0}
-          testFormat: powershell/{0}
+          testFormat: devel/powershell/{0}
           targets:
             - name: 7.6
 

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -317,7 +317,7 @@ stages:
       - template: templates/matrix.yml
         parameters:
           nameFormat: PowerShell {0}
-          testFormat: devel/powershell/{0}
+          testFormat: devel/powershell/{0}/1
           targets:
             - name: 7.6
 

--- a/.azure-pipelines/commands/powershell.sh
+++ b/.azure-pipelines/commands/powershell.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -o pipefail -eux
+
+declare -a args
+IFS='/:' read -ra args <<< "$1"
+
+powershell="${args[1]}"
+
+if [ "${#args[@]}" -gt 2 ]; then
+    target="shippable/powershell/group${args[2]}/"
+else
+    target="shippable/powershell/"
+fi
+
+# shellcheck disable=SC2086
+ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} ${UNSTABLE:+"$UNSTABLE"} \
+    --controller "docker:default,python=default" \
+    --target "docker:default,powershell=${powershell}"

--- a/changelogs/fragments/posix.yml
+++ b/changelogs/fragments/posix.yml
@@ -2,3 +2,7 @@ minor_changes:
   - win_ping - Added support for running on non-Windows targets
   - win_powershell - Added support for running on non-Windows targets
   - win_tempfile - Added support for running on non-Windows targets
+  - >-
+      win_tempfile - Changed the default for ``path`` to be ``None`` rather than ``%TEMP%``. The module will instead
+      use the result of ``[System.IO.Path]::GetTempPath()`` to determine the temporary directory to use which on
+      Windows will typically be the same as ``%TEMP%``.

--- a/changelogs/fragments/posix.yml
+++ b/changelogs/fragments/posix.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - win_ping - Added support for running on non-Windows targets
+  - win_powershell - Added support for running on non-Windows targets
+  - win_tempfile - Added support for running on non-Windows targets

--- a/plugins/modules/win_ping.py
+++ b/plugins/modules/win_ping.py
@@ -11,7 +11,10 @@ short_description: A windows version of the classic ping module
 description:
   - Checks management connectivity of a windows host.
   - This is NOT ICMP ping, this is just a trivial test module.
-  - For non-Windows targets, use the M(ansible.builtin.ping) module instead.
+  - Since C(ansible.windows 3.6.0) this module can also run on non-Windows
+    targets with PowerShell 7 present. Targeting non-Windows hosts requires
+    Ansible C(2.22.0) or newer. Otherwise use the M(ansible.builtin.ping)
+    module instead.
 options:
   data:
     description:

--- a/plugins/modules/win_powershell.ps1
+++ b/plugins/modules/win_powershell.ps1
@@ -63,9 +63,19 @@ $module.Result.verbose = @()
 $module.Result.debug = @()
 $module.Result.information = @()
 
+# WinPS does not set this var and we use this for a few checks.
+if (-not (Get-Variable -Name IsWindows -ErrorAction Ignore)) {
+    Set-Variable -Name IsWindows -Value $true
+}
+$utf8NoBom = [Text.UTF8Encoding]::new($false)
+
 $stdPinvoke = @'
 using System;
+using System.IO;
+using System.IO.Pipes;
 using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace Ansible.Windows.WinPowerShell
 {
@@ -88,6 +98,195 @@ namespace Ansible.Windows.WinPowerShell
         public static extern bool SetStdHandle(
             int nStdHandle,
             IntPtr hHandle);
+
+        [DllImport("libc", SetLastError = true)]
+        public static extern int close(
+            int fd);
+
+        [DllImport("libc", SetLastError = true)]
+        public static extern int dup(
+            int oldfd);
+
+        [DllImport("libc", SetLastError = true)]
+        public static extern int dup2(
+            int oldfd,
+            int newfd);
+    }
+
+    public class StdioManager : IDisposable
+    {
+#if WINDOWS
+        private const int StdoutHandleId = -11;
+        private const int StderrHandleId = -12;
+#else
+        private const int StdoutHandleId = 1;
+        private const int StderrHandleId = 2;
+#endif
+
+        private static Encoding _utf8 = new UTF8Encoding(false);
+
+        private readonly AnonymousPipeClientStream _pipeClient;
+        private readonly AnonymousPipeServerStream _pipeServer;
+        private readonly StreamWriter _pipeWriter;
+        private readonly MemoryStream _readTarget;
+        private readonly Task _readTask;
+
+        private readonly bool _isStderr;
+        private readonly TextWriter _netConsoleWriter;
+        private readonly IntPtr _nativeConsoleHandle;
+
+        private bool _hasBeenRedirected = false;
+        private int _freeNativeDuplicatedFd = -1;
+
+        public StdioManager(bool isStderr)
+        {
+            _pipeServer = new AnonymousPipeServerStream(PipeDirection.In, HandleInheritability.Inheritable);
+            _pipeClient = new AnonymousPipeClientStream(PipeDirection.Out, _pipeServer.ClientSafePipeHandle);
+            _pipeWriter = new StreamWriter(_pipeClient, _utf8);
+            _pipeWriter.AutoFlush = true;
+            _readTarget = new MemoryStream();
+            _readTask = _pipeServer.CopyToAsync(_readTarget);
+
+            _isStderr = isStderr;
+            int handleId;
+            if (_isStderr)
+            {
+                handleId = StderrHandleId;
+                _netConsoleWriter = Console.Error;
+            }
+            else
+            {
+                handleId = StdoutHandleId;
+                _netConsoleWriter = Console.Out;
+            }
+
+#if WINDOWS
+            _nativeConsoleHandle = NativeMethods.GetStdHandle(handleId);
+#else
+            _nativeConsoleHandle = (IntPtr)NativeMethods.dup(handleId);
+#endif
+        }
+
+        public StreamWriter Writer
+        {
+            get
+            {
+                return _pipeWriter;
+            }
+        }
+
+        public string ClientPipeString
+        {
+            get
+            {
+                return _pipeServer.GetClientHandleAsString();
+            }
+        }
+
+        public void RedirectStream()
+        {
+            _freeNativeDuplicatedFd = RedirectConsoleStream(
+                _pipeWriter,
+                _pipeServer.ClientSafePipeHandle.DangerousGetHandle(),
+                _isStderr);
+
+            _hasBeenRedirected = true;
+        }
+
+        public string CloseAndGetOutput()
+        {
+            _pipeWriter.Close();
+
+#if !WINDOWS
+            if (_freeNativeDuplicatedFd != -1)
+            {
+                // We need to close the dup'd client pipe fd as the pipe server
+                // won't finish until all clients are closed. Windows does not
+                // have this problem as the handles themselves are not dup'd
+                // instead the reference to them are updated.
+                NativeMethods.close(_freeNativeDuplicatedFd);
+                _freeNativeDuplicatedFd = -1;
+            }
+#endif
+
+            if (_hasBeenRedirected)
+            {
+                RedirectConsoleStream(_netConsoleWriter, _nativeConsoleHandle, _isStderr);
+                _hasBeenRedirected = false;
+            }
+
+            _pipeWriter.Close();
+            _pipeClient.Close();
+
+            _readTask.GetAwaiter().GetResult();
+            _pipeServer.Close();
+
+            _readTarget.Seek(0, SeekOrigin.Begin);
+            return new StreamReader(_readTarget, _utf8).ReadToEnd();
+        }
+
+        public static int RedirectConsoleStream(
+            TextWriter targetWriter,
+            IntPtr targetHandle,
+            bool isStderr)
+        {
+            int handleId;
+            if (isStderr)
+            {
+                Console.SetError(targetWriter);
+                handleId = StderrHandleId;
+            }
+            else
+            {
+                Console.SetOut(targetWriter);
+                handleId = StdoutHandleId;
+            }
+
+#if WINDOWS
+            NativeMethods.SetStdHandle(handleId, targetHandle);
+
+            return -1;
+#else
+            int res = NativeMethods.dup2(targetHandle.ToInt32(), handleId);
+            if (res == -1)
+            {
+                int errCode = Marshal.GetLastPInvokeError();
+                string errMsg = Marshal.GetLastPInvokeErrorMessage();
+                throw new InvalidOperationException($"dup2 failed with error code 0x{errCode:X8}: {errMsg}");
+            }
+
+            // The return value is the dup'd fd, the caller may need to track
+            // this so they can close it explicitly, e.g. pipe client needs to
+            // be closed before the pipe server can finish.
+            return res;
+#endif
+        }
+
+        public void Dispose()
+        {
+            if (_hasBeenRedirected)
+            {
+                RedirectConsoleStream(_netConsoleWriter, _nativeConsoleHandle, _isStderr);
+                _hasBeenRedirected = false;
+            }
+
+            if (_pipeWriter != null)
+            {
+                _pipeWriter.Dispose();
+            }
+            if (_pipeClient != null)
+            {
+                _pipeClient.Dispose();
+            }
+            if (_pipeServer != null)
+            {
+                _pipeServer.Dispose();
+            }
+            if (_readTarget != null)
+            {
+                _readTarget.Dispose();
+            }
+        }
     }
 }
 '@
@@ -236,53 +435,6 @@ namespace Ansible.Windows.WinPowerShell
     }
 }
 '@
-
-Function Get-StdHandle {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true)]
-        [ValidateSet('Stdout', 'Stderr')]
-        [string]
-        $Stream
-    )
-
-    $id, $dotnet = switch ($Stream) {
-        Stdout { -11, [Console]::Out }
-        Stderr { -12, [Console]::Error }
-    }
-    $handle = [Ansible.Windows.WinPowerShell.NativeMethods]::GetStdHandle($id)
-
-    [PSCustomObject]@{
-        Stream = $Stream
-        NET = $dotnet
-        Raw = $handle
-    }
-}
-
-Function Set-StdHandle {
-    [CmdletBinding()]
-    param (
-        [Parameter(Mandatory = $true)]
-        [ValidateSet('Stdout', 'Stderr')]
-        [string]
-        $Stream,
-
-        [IO.TextWriter]
-        $NET,
-
-        [IntPtr]
-        $Raw
-    )
-
-    $id, $meth = switch ($Stream) {
-        Stdout { -11; [Console]::SetOut($NET) }
-        Stderr { -12; [Console]::SetError($NET) }
-    }
-
-    # .NET does not actually affect the std handle on the process, we need to call SetStdHandle so any child processes
-    # spawned with Start-Process -NoNewWindow will use our custom pipe.
-    [void][Ansible.Windows.WinPowerShell.NativeMethods]::SetStdHandle($id, $Raw)
-}
 
 Function Convert-OutputObject {
     [CmdletBinding()]
@@ -480,62 +632,6 @@ Function Test-AnsiblePath {
     }
 }
 
-Function New-AnonymousPipe {
-    [CmdletBinding()]
-    param ()
-
-    $utf8NoBom = New-Object -TypeName Text.UTF8Encoding -ArgumentList $false
-
-    $server = New-Object -TypeName IO.Pipes.AnonymousPipeServerStream -ArgumentList 'In', 'Inheritable'
-    $client = New-Object -TypeName IO.Pipes.AnonymousPipeClientStream -ArgumentList 'Out', $server.ClientSafePipeHandle
-    $clientWriter = New-Object -TypeName IO.StreamWriter -ArgumentList $client, $utf8NoBom
-    $clientWriter.AutoFlush = $true  # Ensures the data stays in sync when dealing with subprocesses.
-
-    # Create the background task that will constantly read from the pipe and append to our StringBuilder until the pipe
-    # is closed. It also closes the pipe once finished so we don't have to. Without this the pipe buffer can become
-    # full and hang the script.
-    $sb = New-Object -TypeName Text.StringBuilder
-    $ps = [PowerShell]::Create()
-
-    [void]$ps.AddScript(@'
-[CmdletBinding()]
-param (
-    [Text.StringBuilder]
-    $StringBuilder,
-
-    [IO.Pipes.AnonymousPipeServerStream]
-    $Server,
-
-    [Text.Encoding]
-    $Encoding
-)
-
-$sr = New-Object -TypeName IO.StreamReader -ArgumentList $Server, $Encoding
-try {
-    $buffer = New-Object -TypeName char[] -ArgumentList $Server.InBufferSize
-    while ($read = $sr.Read($buffer, 0, $buffer.Length)) {
-        [void]$StringBuilder.Append($buffer, 0, $read)
-    }
-}
-finally {
-    $sr.Dispose()
-}
-'@).AddParameters(@{
-            StringBuilder = $sb
-            Server = $server
-            Encoding = $utf8NoBom
-        })
-    $task = $ps.BeginInvoke()
-
-    [PSCustomObject]@{
-        PowerShell = $ps
-        Task = $task
-        Output = $sb
-        Client = $clientWriter
-        ClientString = $server.GetClientHandleAsString()
-    }
-}
-
 $creates = $module.Params.creates
 if ($creates -and (Test-AnsiblePath -Path $creates)) {
     $module.Result.msg = "skipped, since $creates exists"
@@ -593,19 +689,16 @@ if ($module.CheckMode -and -not $supportsShouldProcess) {
     $module.ExitJson()
 }
 
-$isWDACEnabled = [SystemPolicy]::GetSystemLockdownPolicy() -ne 'None'
+$isWDACEnabled = 'SystemPolicy' -as [type] -and [SystemPolicy]::GetSystemLockdownPolicy() -ne 'None'
 
 $runspace = $null
 $processId = $null
-$newStdout = New-AnonymousPipe
-$newStderr = New-AnonymousPipe
+$newStdout = [Ansible.Windows.WinPowerShell.StdioManager]::new($false)
+$newStderr = [Ansible.Windows.WinPowerShell.StdioManager]::new($true)
 $freeConsole = $false
 $tempScript = $null
 
 try {
-    $oldStdout = Get-StdHandle -Stream Stdout
-    $oldStderr = Get-StdHandle -Stream Stderr
-
     if ($module.Params.executable) {
         if ($PSVersionTable.PSVersion -lt [version]'5.0') {
             $module.FailJson("executable requires PowerShell 5.0 or newer")
@@ -649,7 +742,7 @@ try {
     }
 
     # Using a custom host allows us to capture any host UI calls through our own output.
-    $runspaceHost = New-Object -TypeName Ansible.Windows.WinPowerShell.Host -ArgumentList $Host, $newStdout.Client, $newStderr.Client
+    $runspaceHost = New-Object -TypeName Ansible.Windows.WinPowerShell.Host -ArgumentList $Host, $newStdout.Writer, $newStderr.Writer
     if ($processId) {
         $connInfo = [System.Management.Automation.Runspaces.NamedPipeConnectionInfo]$processId
 
@@ -709,10 +802,6 @@ param (
 
     [Parameter(Mandatory=$true)]
     [String]
-    $SetScriptBlock,
-
-    [Parameter(Mandatory=$true)]
-    [String]
     $AddTypeCode,
 
     [Parameter(Mandatory=$true)]
@@ -724,25 +813,28 @@ param (
 # temp directory used.
 &([ScriptBlock]::Create($AddTypeCode)) -References $SetStdPInvoke -TempPath $Tmpdir
 
-$setHandle = [ScriptBlock]::Create($SetScriptBlock)
 $utf8NoBom = New-Object -TypeName Text.UTF8Encoding -ArgumentList $false
 
 # Make sure our console encoding values are all set to UTF-8 for a consistent experience.
 $OutputEncoding = [Console]::InputEncoding = [Console]::OutputEncoding = $utf8NoBom
 
-# Set the stdout/stderr for both .NET and natively to our anonymous pipe.
-@{Name = 'Stdout'; Handle = $StdoutHandle}, @{Name = 'Stderr'; Handle = $StderrHandle} | ForEach-Object -Process {
+@(
+    @{ Handle = $StdoutHandle; IsStderr = $false }
+    @{ Handle = $StderrHandle; IsStderr = $true }
+) | ForEach-Object -Process {
     $pipe = New-Object -TypeName IO.Pipes.AnonymousPipeClientStream -ArgumentList 'Out', $_.Handle
     $writer = New-Object -TypeName IO.StreamWriter -ArgumentList $pipe, $utf8NoBom
     $writer.AutoFlush = $true  # Ensures we data in the correct order.
 
-    &$setHandle -Stream $_.Name -NET $writer -Raw $pipe.SafePipeHandle.DangerousGetHandle()
+    [void][Ansible.Windows.WinPowerShell.StdioManager]::RedirectConsoleStream(
+        $writer,
+        $pipe.SafePipeHandle.DangerousGetHandle(),
+        $_.IsStderr)
 }
 '@, $true).AddParameters(@{
-                    StdoutHandle = $newStdout.ClientString
-                    StderrHandle = $newStderr.ClientString
+                    StdoutHandle = $newStdout.ClientPipeString
+                    StderrHandle = $newStderr.ClientPipeString
                     SetStdPInvoke = $stdPinvoke
-                    SetScriptBlock = ${function:Set-StdHandle}
                     AddTypeCode = ${function:Add-CSharpType}
                     TmpDir = $module.Tmpdir
                 }).AddStatement()
@@ -750,16 +842,15 @@ $OutputEncoding = [Console]::InputEncoding = [Console]::OutputEncoding = $utf8No
     }
     else {
         # The psrp connection plugin doesn't have a console so we need to create one ourselves.
-        if ([Ansible.Windows.WinPowerShell.NativeMethods]::GetConsoleWindow() -eq [IntPtr]::Zero) {
+        if ($IsWindows -and [Ansible.Windows.WinPowerShell.NativeMethods]::GetConsoleWindow() -eq [IntPtr]::Zero) {
             $freeConsole = [Ansible.Windows.WinPowerShell.NativeMethods]::AllocConsole()
         }
 
         # Else we are running in the same process, we need to redirect the console and .NET output pipes to our
         # anonymous pipe. We shouldn't have to set the encoding, the module wrapper already does this.
-        Set-StdHandle -Stream Stdout -NET $newStdout.Client -Raw $newStdout.Client.BaseStream.SafePipeHandle.DangerousGetHandle()
-        Set-StdHandle -Stream Stderr -NET $newStderr.Client -Raw $newStderr.Client.BaseStream.SafePipeHandle.DangerousGetHandle()
+        $newStdout.RedirectStream()
+        $newStderr.RedirectStream()
 
-        $utf8NoBom = New-Object -TypeName Text.UTF8Encoding -ArgumentList $false
         $OutputEncoding = [Console]::InputEncoding = [Console]::OutputEncoding = $utf8NoBom
     }
 
@@ -868,14 +959,11 @@ if ($PSVersionTable.PSVersion -lt '6.0') {
     $resultPipeline = [PowerShell]::Create()
     $resultPipeline.Runspace = $runspace
     $result = $resultPipeline.AddScript('$Ansible').Invoke()[0]
+
+    $hostOut = $newStdout.CloseAndGetOutput()
+    $hostErr = $newStderr.CloseAndGetOutput()
 }
 finally {
-    if (-not $processId) {
-        $oldStdout, $oldStderr | ForEach-Object -Process {
-            Set-StdHandle -Stream $_.Stream -NET $_.NET -Raw $_.Raw
-        }
-    }
-
     if ($runspace) {
         $runspace.Dispose()
     }
@@ -883,10 +971,7 @@ finally {
         Stop-Process -Id $processId -Force
     }
 
-    $newStdout, $newStderr | ForEach-Object -Process {
-        $_.Client.Dispose()
-        [void]$_.PowerShell.EndInvoke($_.Task)
-    }
+    $newStdout, $newStderr | ForEach-Object Dispose
 
     if ($freeConsole) {
         [void][Ansible.Windows.WinPowerShell.NativeMethods]::FreeConsole()
@@ -897,8 +982,8 @@ finally {
     }
 }
 
-$module.Result.host_out = $newStdout.Output.ToString()
-$module.Result.host_err = $newStderr.Output.ToString()
+$module.Result.host_out = $hostOut
+$module.Result.host_err = $hostErr
 $module.Result.result = Convert-OutputObject -InputObject $result.Result -Depth $module.Params.depth
 $module.Result.changed = $result.Changed
 $module.Result.failed = $module.Result.failed -or $result.Failed

--- a/plugins/modules/win_powershell.ps1
+++ b/plugins/modules/win_powershell.ps1
@@ -67,6 +67,11 @@ $module.Result.information = @()
 if (-not (Get-Variable -Name IsWindows -ErrorAction Ignore)) {
     Set-Variable -Name IsWindows -Value $true
 }
+
+if ($module.Params.executable -and -not $IsWindows) {
+    $module.FailJson("executable cannot be used on a non-Windows target, set ansible_pwsh_interpreter instead.")
+}
+
 $utf8NoBom = [Text.UTF8Encoding]::new($false)
 
 $stdPinvoke = @'
@@ -960,6 +965,16 @@ if ($PSVersionTable.PSVersion -lt '6.0') {
     $resultPipeline.Runspace = $runspace
     $result = $resultPipeline.AddScript('$Ansible').Invoke()[0]
 
+    $runspace.Dispose()
+    $runspace = $null  # Avoids the dispose in the finally block
+
+    if ($processId) {
+        # If running in another process we need to stop it so our CloseAndGetOutput
+        # below does not block.
+        Stop-Process -Id $processId -Force
+        $processId = $null  # Avoids the stop in the finally block
+    }
+
     $hostOut = $newStdout.CloseAndGetOutput()
     $hostErr = $newStderr.CloseAndGetOutput()
 }
@@ -968,7 +983,7 @@ finally {
         $runspace.Dispose()
     }
     if ($processId) {
-        Stop-Process -Id $processId -Force
+        Stop-Process -Id $processId -Force -ErrorAction Ignore
     }
 
     $newStdout, $newStderr | ForEach-Object Dispose

--- a/plugins/modules/win_powershell.py
+++ b/plugins/modules/win_powershell.py
@@ -14,6 +14,8 @@ description:
 - Runs a PowerShell script and outputs the data in a structured format.
 - Use M(ansible.windows.win_command) or M(ansible.windows.win_shell) to run a traditional PowerShell process with
   stdout, stderr, and rc results.
+- Since C(ansible.windows 3.6.0) this module can also run on non-Windows targets with PowerShell 7 present. Targeting
+  non-Windows hosts requires Ansible C(2.22.0) or newer.
 options:
   arguments:
     description:
@@ -58,6 +60,7 @@ options:
     - Both the remote PowerShell and the one specified by I(executable) must be running on PowerShell v5.1 or newer.
     - Setting this value may change the values returned in the C(output) return value depending on the underlying .NET
       type.
+    - This option is only supported on Windows hosts.
     type: str
   parameters:
     description:

--- a/plugins/modules/win_stat.ps1
+++ b/plugins/modules/win_stat.ps1
@@ -43,11 +43,13 @@ function Get-FileInfo {
     $info = Get-AnsibleItem -Path $Path -ErrorAction SilentlyContinue
     $link_info = $null
     if ($null -ne $info) {
-        try {
-            $link_info = Get-Link -link_path $info.FullName
-        }
-        catch {
-            $module.Warn("Failed to check/get link info for file: $($_.Exception.Message)")
+        if ($IsWindows -or $PSVersionTable.PSVersion -lt '6.0') {
+            try {
+                $link_info = Get-Link -link_path $info.FullName
+            }
+            catch {
+                $module.Warn("Failed to check/get link info for file: $($_.Exception.Message)")
+            }
         }
 
         # If follow=true we want to follow the link all the way back to root object
@@ -81,10 +83,12 @@ $follow = $module.Params.follow
 $module.Result.stat = @{ exists = $false }
 
 # https://github.com/ansible-collections/ansible.windows/issues/297
-$oldLib = $env:LIB
-$env:LIB = $null
-Load-LinkUtils
-$env:LIB = $oldLib
+if ($IsWindows -or $PSVersionTable.PSVersion -lt '6.0') {
+    $oldLib = $env:LIB
+    $env:LIB = $null
+    Load-LinkUtils
+    $env:LIB = $oldLib
+}
 
 $info, $link_info = Get-FileInfo -Path $path -Follow:$follow
 If ($null -ne $info) {

--- a/plugins/modules/win_tempfile.ps1
+++ b/plugins/modules/win_tempfile.ps1
@@ -43,7 +43,7 @@ Function New-TempFile {
 
 $spec = @{
     options = @{
-        path = @{ type = 'path'; default = '%TEMP%'; aliases = @( 'dest' ) }
+        path = @{ type = 'path'; aliases = @( 'dest' ) }
         state = @{ type = 'str'; default = 'file'; choices = @( 'directory', 'file') }
         prefix = @{ type = 'str'; default = 'ansible.' }
         suffix = @{ type = 'str' }
@@ -57,6 +57,10 @@ $path = $module.Params.path
 $state = $module.Params.state
 $prefix = $module.Params.prefix
 $suffix = $module.Params.suffix
+
+if (-not $path) {
+    $path = [System.IO.Path]::GetTempPath()
+}
 
 # Expand environment variables on non-path types
 if ($null -ne $prefix) {

--- a/plugins/modules/win_tempfile.py
+++ b/plugins/modules/win_tempfile.py
@@ -10,7 +10,10 @@ module: win_tempfile
 short_description: Creates temporary files and directories
 description:
   - Creates temporary files and directories.
-  - For non-Windows targets, please use the M(ansible.builtin.tempfile) module instead.
+  - Since C(ansible.windows 3.6.0) this module can also run on non-Windows
+    targets with PowerShell 7 present. Targeting non-Windows hosts requires
+    Ansible C(2.22.0) or newer. Otherwise use the M(ansible.builtin.tempfile)
+    module instead.
 options:
   state:
     description:
@@ -21,9 +24,8 @@ options:
   path:
     description:
       - Location where temporary file or directory should be created.
-      - If path is not specified default system temporary directory (%TEMP%) will be used.
+      - If path is not specified default temporary directory for the user will be used.
     type: path
-    default: '%TEMP%'
     aliases: [ dest ]
   prefix:
     description:

--- a/tests/integration/targets/win_file/tasks/main.yml
+++ b/tests/integration/targets/win_file/tasks/main.yml
@@ -743,7 +743,7 @@
   assert:
     that:
       - (file_timestamp_before.stdout | from_json).mTime == (file_timestamp_after.stdout | from_json).mTime
-      - (file_timestamp_before.stdout | from_json).aTime == (file_timestamp_after.stdout | from_json).aTime      
+      - (file_timestamp_before.stdout | from_json).aTime == (file_timestamp_after.stdout | from_json).aTime
 
 - name: clean up test file
   win_file:

--- a/tests/integration/targets/win_ping/aliases
+++ b/tests/integration/targets/win_ping/aliases
@@ -1,2 +1,3 @@
+shippable/powershell/group1
 shippable/windows/group2
 posix

--- a/tests/integration/targets/win_ping/aliases
+++ b/tests/integration/targets/win_ping/aliases
@@ -1,1 +1,2 @@
 shippable/windows/group2
+posix

--- a/tests/integration/targets/win_powershell/aliases
+++ b/tests/integration/targets/win_powershell/aliases
@@ -1,2 +1,3 @@
+shippable/powershell/group1
 shippable/windows/group1
 posix

--- a/tests/integration/targets/win_powershell/aliases
+++ b/tests/integration/targets/win_powershell/aliases
@@ -1,1 +1,2 @@
 shippable/windows/group1
+posix

--- a/tests/integration/targets/win_powershell/tasks/failure.yml
+++ b/tests/integration/targets/win_powershell/tasks/failure.yml
@@ -110,3 +110,13 @@
   failed_when:
   - invalid_syntax_path.error | count != 1
   - invalid_syntax_path.error[0]['category_info']['category'] != 'ParserError'
+
+- name: expect failure when using executable on non-Windows target
+  win_powershell:
+    executable: failure
+    script: '"test"'
+  register: invalid_executable_posix
+  when:
+  - not is_windows
+  failed_when: >-
+    invalid_executable_posix.msg != 'executable cannot be used on a non-Windows target, set ansible_pwsh_interpreter instead.'

--- a/tests/integration/targets/win_powershell/tasks/main.yml
+++ b/tests/integration/targets/win_powershell/tasks/main.yml
@@ -1,10 +1,18 @@
-- name: check if executable is supported
-  win_shell: '[Version]$PSVersionTable.PSVersion -gt [Version]"5.0"'
-  register: use_executable
+- name: get baseline information for tests
+  win_powershell:
+    script: |
+      @{
+          IsWindows = $IsWindows -or $PSVersionTable.PSVersion -lt "6.0"
+          Pwd = $pwd.Path.ToLowerInvariant()
+      }
+  register:
+    is_windows: _task.result.output[0].IsWindows
+    pwd: _task.result.output[0].Pwd
   changed_when: False
 
 - name: get datetimes used for tests
-  win_shell: |
+  win_powershell:
+    script: |
       $epoch_unspec = New-Object -TypeName DateTime -ArgumentList 1970, 1, 1
       $epoch_local = New-Object -TypeName DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, ([DateTimeKind]::Local)
       $epoch_utc = New-Object -TypeName DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, ([DateTimeKind]::Utc)
@@ -36,15 +44,15 @@
       [- abc
     dest: '{{ remote_tmp_dir }}/syntax-error.ps1'
 
-- name: run failure tests
-  import_tasks: failure.yml
+# - name: run failure tests
+#   import_tasks: failure.yml
 
 - name: run tests using current interpreter
   import_tasks: tests.yml
 
 - name: run tests using executable
   import_tasks: tests.yml
-  when: use_executable.stdout | trim | bool
+  when: is_windows
   vars:
     pwsh_executable: powershell.exe
 
@@ -57,13 +65,13 @@
     script: |
       $env:PSExecutionPolicyPreference
   register: exe_with_arguments
-  when: use_executable.stdout | trim | bool
+  when: is_windows
 
 - name: assert run executable with arguments
   assert:
     that:
     - exe_with_arguments.output == ['Restricted']
-  when: use_executable.stdout | trim | bool
+  when: is_windows
 
 # Verifies that PowerShell 7's PSModulePath does not interfere with WinPS modules
 - name: run PowerShell that imports a builtin module
@@ -71,4 +79,6 @@
     executable: powershell.exe
     error_action: stop
     script: Import-Module -Name Microsoft.PowerShell.Security -ErrorAction Stop
-  when: (ansible_pwsh_interpreter | default('')).endswith('pwsh.exe')
+  when:
+  - is_windows
+  - (ansible_pwsh_interpreter | default('')).endswith('pwsh.exe')

--- a/tests/integration/targets/win_powershell/tasks/main.yml
+++ b/tests/integration/targets/win_powershell/tasks/main.yml
@@ -44,17 +44,18 @@
       [- abc
     dest: '{{ remote_tmp_dir }}/syntax-error.ps1'
 
-# - name: run failure tests
-#   import_tasks: failure.yml
+- name: run failure tests
+  import_tasks: failure.yml
 
 - name: run tests using current interpreter
   import_tasks: tests.yml
 
 - name: run tests using executable
   import_tasks: tests.yml
-  when: is_windows
+  when:
+  - is_windows
   vars:
-    pwsh_executable: powershell.exe
+    pwsh_executable: '{{ ansible_pwsh_interpreter | default("powershell.exe") }}'
 
 - name: run executable with arguments
   win_powershell:

--- a/tests/integration/targets/win_powershell/tasks/main.yml
+++ b/tests/integration/targets/win_powershell/tasks/main.yml
@@ -3,11 +3,11 @@
     script: |
       @{
           IsWindows = $IsWindows -or $PSVersionTable.PSVersion -lt "6.0"
-          Pwd = $pwd.Path.ToLowerInvariant()
+          Tmpdir = (([IO.Path]::GetTempPath())).ToLowerInvariant()
       }
   register:
     is_windows: _task.result.output[0].IsWindows
-    pwd: _task.result.output[0].Pwd
+    test_tmpdir: _task.result.output[0].Tmpdir
   changed_when: False
 
 - name: get datetimes used for tests

--- a/tests/integration/targets/win_powershell/tasks/tests.yml
+++ b/tests/integration/targets/win_powershell/tasks/tests.yml
@@ -51,7 +51,7 @@
           @($null),
           @{
               key = 'value'
-              exceed = Get-Item $pwd.Path
+              exceed = Get-Item ([IO.Path]::GetTempPath())
           }
       )
 
@@ -94,7 +94,7 @@
           }
       }
 
-      Get-Item $pwd.Path
+      Get-Item ([IO.Path]::GetTempPath())
 
   register: output_types
 
@@ -175,7 +175,7 @@
     - output_types.output[22][5] == [1]
     - output_types.output[22][6] == [None]
     - output_types.output[22][7]['key'] == 'value'
-    - output_types.output[22][7]['exceed'] | lower == pwd
+    - output_types.output[22][7]['exceed'] | lower == test_tmpdir
 
     - output_types.output[23] == {}
 
@@ -202,7 +202,7 @@
 
     - output_types.output[27]['BaseName'] | lower is string
     - output_types.output[27]['Exists'] == True
-    - output_types.output[27]['FullName'] | lower == pwd
+    - output_types.output[27]['FullName'] | lower == test_tmpdir
     - output_types.output[27]['PSDrive']['Name'] is string
     - output_types.output[27]['PSDrive']['Provider'] == 'Microsoft.PowerShell.Core\FileSystem'
     - output_types.output[27]['PSProvider']['ImplementingType'] == 'Microsoft.PowerShell.Commands.FileSystemProvider'

--- a/tests/integration/targets/win_powershell/tasks/tests.yml
+++ b/tests/integration/targets/win_powershell/tasks/tests.yml
@@ -51,7 +51,7 @@
           @($null),
           @{
               key = 'value'
-              exceed = Get-Item $env:SystemRoot
+              exceed = Get-Item $pwd.Path
           }
       )
 
@@ -94,7 +94,7 @@
           }
       }
 
-      Get-Item $env:SystemRoot
+      Get-Item $pwd.Path
 
   register: output_types
 
@@ -146,19 +146,19 @@
     - output_types.output[8]['StackTrace'] == None
     - output_types.output[8]['TargetSite'] == None
 
-    - output_types.output[9] == dt_values.stdout_lines[0]
-    - output_types.output[10] == dt_values.stdout_lines[1]
-    - output_types.output[11] == dt_values.stdout_lines[2]
+    - output_types.output[9] == dt_values.output[0]
+    - output_types.output[10] == dt_values.output[1]
+    - output_types.output[11] == dt_values.output[2]
 
-    - output_types.output[12] == dt_values.stdout_lines[3]
-    - output_types.output[13] == dt_values.stdout_lines[4]
-    - output_types.output[14] == dt_values.stdout_lines[5]
+    - output_types.output[12] == dt_values.output[3]
+    - output_types.output[13] == dt_values.output[4]
+    - output_types.output[14] == dt_values.output[5]
 
-    - output_types.output[15] == dt_values.stdout_lines[6]
-    - output_types.output[16] == dt_values.stdout_lines[7]
-    - output_types.output[17] == dt_values.stdout_lines[8]
+    - output_types.output[15] == dt_values.output[6]
+    - output_types.output[16] == dt_values.output[7]
+    - output_types.output[17] == dt_values.output[8]
 
-    - output_types.output[18] == dt_values.stdout_lines[9]
+    - output_types.output[18] == dt_values.output[9]
 
     - output_types.output[19] == []
 
@@ -175,7 +175,7 @@
     - output_types.output[22][5] == [1]
     - output_types.output[22][6] == [None]
     - output_types.output[22][7]['key'] == 'value'
-    - output_types.output[22][7]['exceed'] |lower == 'c:\windows'
+    - output_types.output[22][7]['exceed'] | lower == pwd
 
     - output_types.output[23] == {}
 
@@ -200,12 +200,11 @@
     - output_types.output[26]['Nested']['Exceed'] == 'System.Collections.Hashtable'
     - output_types.output[26]['Nested']['Key'] == 'value'
 
-    - output_types.output[27]['BaseName'] | lower == 'windows'
+    - output_types.output[27]['BaseName'] | lower is string
     - output_types.output[27]['Exists'] == True
-    - output_types.output[27]['FullName'] | lower == 'c:\windows'
-    - output_types.output[27]['PSDrive']['Name'] == 'C'
+    - output_types.output[27]['FullName'] | lower == pwd
+    - output_types.output[27]['PSDrive']['Name'] is string
     - output_types.output[27]['PSDrive']['Provider'] == 'Microsoft.PowerShell.Core\FileSystem'
-    # - output_types.output[27]['PSProvider']['Drives'] == 'C' # Flaky if host has multiple drives
     - output_types.output[27]['PSProvider']['ImplementingType'] == 'Microsoft.PowerShell.Commands.FileSystemProvider'
     - output_types.output[27]['PSProvider']['Name'] == 'FileSystem'
 
@@ -292,15 +291,17 @@
   register: tmpdir
 
 - name: check that tmpdir doesn't exist anymore
-  win_stat:
-    path: '{{ tmpdir.output[0] }}'
+  win_powershell:
+    script: Test-Path -LiteralPath $args[0]
+    parameters:
+      Path: '{{ tmpdir.output[0] }}'
   register: tmpdir_actual
 
 - name: assert get temporary directory
   assert:
     that:
     - tmpdir is changed
-    - not tmpdir_actual.stat.exists
+    - not tmpdir_actual.output[0]
 
 - name: dont fail with error record
   win_powershell:
@@ -407,13 +408,16 @@
     - complex_error_record.error[0]['exception']['help_link'] == None
     - complex_error_record.error[0]['exception']['hresult'] == -2147467259
     - complex_error_record.error[0]['exception']['inner_exception'] == None
-    - (complex_error_record.error[0]['exception']['message'] | regex_replace('\.$', ''))  == 'Access is denied'
+    - complex_error_record.error[0]['exception']['message'] is string
     - complex_error_record.error[0]['exception']['source'] == None
     - complex_error_record.error[0]['exception']['type'] == 'System.ComponentModel.Win32Exception'
     - complex_error_record.error[0]['fully_qualified_error_id'] == 'error id,Test-Function'
     - complex_error_record.error[0]['output'] is defined
     - complex_error_record.error[0]['pipeline_iteration_info'] == [2, 2]
-    - "complex_error_record.error[0]['script_stack_trace'] == 'at Test-Function<Process>, <No file>: line 23\\r\\nat <ScriptBlock>, <No file>: line 28'"
+    - >-
+        complex_error_record.error[0]['script_stack_trace'] is search('at Test-Function<Process>, <No file>: line 23')
+    - >-
+        complex_error_record.error[0]['script_stack_trace'] is search('at <ScriptBlock>, <No file>: line 28')
     - complex_error_record.error[0]['target_object'] == 'some object'
 
 - name: failure with terminating exception
@@ -558,7 +562,8 @@
   assert:
     that:
     - extra_streams is changed
-    - "extra_streams.host_out == 'DEBUG: debug\\r\\nVERBOSE: verbose\\r\\nWARNING: warning\\r\\n'"
+    - >-
+        extra_streams.host_out.splitlines() == ['DEBUG: debug', 'VERBOSE: verbose', 'WARNING: warning']
     - extra_streams.debug == ['debug']
     - extra_streams.verbose == ['verbose']
     - extra_streams.warning == ['warning']
@@ -569,7 +574,6 @@
       $epoch = New-Object -TypeName DateTime -ArgumentList 1970, 1, 1, 0, 0, 0, ([DateTimeKind]::Utc)
       Write-Information -MessageData $epoch -Tags tag1
   register: info_record
-  when: use_executable.stdout | trim | bool  # Information records were only added in v5
 
 - name: assert output information record
   assert:
@@ -581,7 +585,6 @@
     - info_record.information[0]['tags'] == ['tag1']
     - info_record.information[0]['time_generated'].endswith('Z')
     - info_record.output == []
-  when: use_executable.stdout | trim | bool
 
 - name: verify confirmation prompts aren't called
   win_powershell:
@@ -638,12 +641,14 @@
     script: $pwd.Path
     chdir: Cert:\LocalMachine\My
   register: cert_chdir
+  when: is_windows  # There's no builtin PSDrive that we cant test with on POSIX
 
 - name: assert run script with non-filesystem location
   assert:
     that:
     - cert_chdir is changed
     - cert_chdir.output == ['Cert:\LocalMachine\My']
+  when: is_windows
 
 - name: skip execution when not in check mode
   win_powershell:
@@ -762,6 +767,7 @@
     script: '"output"'
     creates: cert:\LocalMachine\*
   register: creates_non_fs
+  when: is_windows  # There's no builtin PSDrive that we cant test with on POSIX
 
 - name: assert skip for creates non-filesystem
   assert:
@@ -769,6 +775,7 @@
     - not creates_non_fs is changed
     - creates_non_fs.msg == 'skipped, since cert:\LocalMachine\* exists'
     - creates_non_fs.output == []
+  when: is_windows
 
 - name: skip if removes does not exist
   win_powershell:
@@ -803,12 +810,14 @@
     script: '"output"'
     removes: cert:\LocalMachine\*
   register: removes_exists_non_fs
+  when: is_windows  # There's no builtin PSDrive that we cant test with on POSIX
 
 - name: assert do not skip if removes exists non-filesystem
   assert:
     that:
     - removes_exists_non_fs is changed
     - removes_exists_non_fs.output == ['output']
+  when: is_windows
 
 - name: script changed status
   win_powershell:
@@ -839,7 +848,7 @@
       # Calling a process directly goes to the output/error stream. Calling it with Start-Process with -NoNewWindow
       # means the sub process will inherit the current console handles and should be captured in the host output.
       $processParams = @{
-          FilePath = 'powershell.exe'
+          FilePath = if ($IsCoreCLR) { 'pwsh' } else { 'powershell' }
           ArgumentList = "-EncodedCommand $subProcessCommand"
           Wait = $true
           NoNewWindow = $true
@@ -854,8 +863,8 @@
   assert:
     that:
     - host_output is changed
-    - host_output.host_err == 'error café 💩\r\nsub stderr café 💩\r\nstderr café 💩\r\n'
-    - host_output.host_out == 'host café 💩\r\nsub stdout café 💩\r\nstdout café 💩\r\n'
+    - host_output.host_err.splitlines() == ['error café 💩', 'sub stderr café 💩', 'stderr café 💩']
+    - host_output.host_out.splitlines() == ['host café 💩', 'sub stdout café 💩', 'stdout café 💩']
     - host_output.error == []
     - host_output.output == []
 
@@ -1010,7 +1019,9 @@
     script: |
       Get-WmiObject -Class Win32_Service -Filter 'Name="WinRM"'
   register: wmi_object
-  when: pwsh_executable is not defined
+  when:
+  - is_windows
+  - pwsh_executable is not defined
 
 - name: assert get WMI object
   assert:
@@ -1018,7 +1029,9 @@
     - wmi_object.output | length == 1
     - wmi_object.output[0]['Name'] == 'WinRM'
     - wmi_object.output[0]['__RELPATH'] == 'Win32_Service.Name="WinRM"'
-  when: pwsh_executable is not defined
+  when:
+  - is_windows
+  - pwsh_executable is not defined
 
 - name: execute script from local path
   win_powershell:
@@ -1065,8 +1078,10 @@
       $typeData = Get-TypeData -TypeName System.Security.AccessControl.ObjectSecurity
       $typeData.Members.Count
   register: builtin_module_ets
+  when: is_windows  # This ETS definition is only present on Windows
 
 - name: assert builtin modules are imported correctly with ETS definitions
   assert:
     that:
     - builtin_module_ets.output[0] > 0
+  when: is_windows

--- a/tests/integration/targets/win_tempfile/aliases
+++ b/tests/integration/targets/win_tempfile/aliases
@@ -1,2 +1,3 @@
+shippable/powershell/group1
 shippable/windows/group1
 posix

--- a/tests/integration/targets/win_tempfile/aliases
+++ b/tests/integration/targets/win_tempfile/aliases
@@ -1,1 +1,2 @@
 shippable/windows/group1
+posix

--- a/tests/integration/targets/win_tempfile/defaults/main.yml
+++ b/tests/integration/targets/win_tempfile/defaults/main.yml
@@ -1,1 +1,1 @@
-test_tempfile_path: 'C:\ansible\win_tempfile .ÅÑŚÌβŁÈ [$!@^&test(;)]'
+test_tempfile_name: win_tempfile .ÅÑŚÌβŁÈ [$!@^&test(;)]

--- a/tests/integration/targets/win_tempfile/tasks/main.yml
+++ b/tests/integration/targets/win_tempfile/tasks/main.yml
@@ -1,16 +1,13 @@
 ---
-- name: get the current %TEMP% value
-  win_shell: '[System.IO.Path]::GetFullPath($env:TEMP)'
-  register: temp_value
-
-- name: register temp path value
-  set_fact:
-    temp_value: '{{ temp_value.stdout | trim }}'
-
-
-- name: get raw %TEMP% value
-  win_shell: '$env:TEMP'
-  register: raw_temp_value
+- name: get baseline test information
+  win_powershell:
+    script: |
+      [System.IO.Path]::GetTempPath()
+      $IsWindows -or $PSVersionTable.PSVersion -lt '6.0'
+  register:
+    temp_value: _task.result.output[0]
+    is_windows: _task.result.output[1]
+  changed_when: False
 
 - name: create temp file defaults check
   win_tempfile:
@@ -27,7 +24,7 @@
     that:
     - create_tmp_file_defaults_check is changed
     - create_tmp_file_defaults_check.state == 'file'
-    - create_tmp_file_defaults_check.path.startswith(temp_value + '\\ansible.')
+    - create_tmp_file_defaults_check.path.startswith(temp_value ~ "ansible.")
     - actual_create_tmp_file_defaults_check.stat.exists == False
 
 - name: create temp file defaults
@@ -44,7 +41,7 @@
     that:
     - create_tmp_file_defaults is changed
     - create_tmp_file_defaults.state == 'file'
-    - create_tmp_file_defaults.path.startswith(temp_value + '\\ansible.')
+    - create_tmp_file_defaults.path.startswith(temp_value ~ 'ansible.')
     - actual_create_tmp_file_defaults.stat.exists == True
     - actual_create_tmp_file_defaults.stat.isdir == False
 
@@ -62,7 +59,7 @@
     that:
     - create_tmp_file_defaults_again is changed
     - create_tmp_file_defaults_again.state == 'file'
-    - create_tmp_file_defaults_again.path.startswith(temp_value + '\\ansible.')
+    - create_tmp_file_defaults_again.path.startswith(temp_value ~ 'ansible.')
     - create_tmp_file_defaults_again.path != create_tmp_file_defaults.path
     - actual_create_tmp_file_defaults_again.stat.exists == True
     - actual_create_tmp_file_defaults_again.stat.isdir == False
@@ -83,7 +80,7 @@
     that:
     - create_tmp_folder_check is changed
     - create_tmp_folder_check.state == 'directory'
-    - create_tmp_folder_check.path.startswith(temp_value  + '\\ansible.')
+    - create_tmp_folder_check.path.startswith(temp_value  ~ 'ansible.')
     - actual_create_tmp_folder_check.stat.exists == False
 
 - name: create temp folder
@@ -101,7 +98,7 @@
     that:
     - create_tmp_folder is changed
     - create_tmp_folder.state == 'directory'
-    - create_tmp_folder.path.startswith(temp_value + '\\ansible.')
+    - create_tmp_folder.path.startswith(temp_value ~ 'ansible.')
     - actual_create_tmp_folder.stat.exists == True
     - actual_create_tmp_folder.stat.isdir == True
 
@@ -120,7 +117,7 @@
     that:
     - create_tmp_file_suffix is changed
     - create_tmp_file_suffix.state == 'file'
-    - create_tmp_file_suffix.path.startswith(temp_value + '\\ansible.')
+    - create_tmp_file_suffix.path.startswith(temp_value ~ 'ansible.')
     - create_tmp_file_suffix.path.endswith('test-suffix')
     - actual_creat_tmp_file_suffix.stat.exists == True
     - actual_creat_tmp_file_suffix.stat.isdir == False
@@ -140,67 +137,72 @@
     that:
     - create_tmp_file_prefix is changed
     - create_tmp_file_prefix.state == 'file'
-    - create_tmp_file_prefix.path.startswith(temp_value + '\\test-prefix')
+    - create_tmp_file_prefix.path.startswith(temp_value ~ 'test-prefix')
     - actual_creat_tmp_file_prefix.stat.exists == True
     - actual_creat_tmp_file_prefix.stat.isdir == False
 
 - name: create new temp file folder
   win_file:
-    path: '{{test_tempfile_path}}\testing folder'
+    path: '{{ temp_value }}/{{ test_tempfile_name }}/testing folder'
     state: directory
 
 - block:
   - name: create temp file with different path
     win_tempfile:
-      path: '{{test_tempfile_path}}\testing folder'
+      path: '{{ temp_value }}/{{ test_tempfile_name }}/testing folder'
     register: create_tmp_file_difference_path
 
   - name: get stat of temp file with different path
     win_stat:
       path: "{{create_tmp_file_difference_path.path}}"
-    register: actual_creat_tmp_file_different_path
+    register: actual_create_tmp_file_different_path
 
   - name: assert create temp file with different path
     assert:
       that:
       - create_tmp_file_difference_path is changed
       - create_tmp_file_difference_path.state == 'file'
-      - create_tmp_file_difference_path.path.startswith(test_tempfile_path + '\\testing folder\\ansible.')
-      - actual_creat_tmp_file_different_path.stat.exists == True
-      - actual_creat_tmp_file_different_path.stat.isdir == False
+      - create_tmp_file_difference_path.path is search('^' ~ (temp_value | regex_escape) ~ (test_tempfile_name | regex_escape) ~ '[\\\\|/]testing folder[\\\\|/]ansible\\.')
+      - actual_create_tmp_file_different_path.stat.exists == True
+      - actual_create_tmp_file_different_path.stat.isdir == False
 
   - name: create temp file with DOS 8.3 short name
     win_tempfile:
-      path: '{{ test_tempfile_path }}\TESTIN~1'
+      path: '{{ temp_value }}\{{ test_tempfile_name }}\TESTIN~1'
     register: create_tmp_file_dos_path
+    when: is_windows
 
   - name: get stat of temp file with different path
     win_stat:
       path: '{{ create_tmp_file_dos_path.path }}'
     register: actual_create_tmp_file_dos_path
+    when: is_windows
 
   - name: assert create temp file with different path
     assert:
       that:
       - create_tmp_file_dos_path is changed
       - create_tmp_file_dos_path.state == 'file'
-      - create_tmp_file_dos_path.path.startswith(test_tempfile_path + '\\testing folder\\ansible.')
+      - create_tmp_file_dos_path.path.startswith(temp_value ~ test_tempfile_name ~ '\\testing folder\\ansible.')
       - actual_create_tmp_file_dos_path.stat.exists == True
       - actual_create_tmp_file_dos_path.stat.isdir == False
+    when: is_windows
 
   always:
   - name: delete temp file folder
     win_file:
-      path: "{{test_tempfile_path}}"
+      path: "{{ temp_value }}/{{ test_tempfile_name }}"
       state: absent
 
 - name: get current working directory
-  win_shell: $pwd.Path
-  register: current_dir
+  win_powershell:
+    script: $pwd.Path
+  register:
+    current_dir: _task.result.output[0]
 
 - name: create directory for relative dir tests
   win_file:
-    path: '{{ current_dir.stdout | trim }}\win_tempfile'
+    path: '{{ current_dir }}/win_tempfile'
     state: directory
 
 - block:
@@ -220,12 +222,12 @@
       that:
       - create_relative is changed
       - create_relative.state == 'directory'
-      - create_relative.path.startswith((current_dir.stdout | trim) + '\\win_tempfile\\ansible.')
+      - create_relative.path is search('^' ~ (current_dir | regex_escape) ~ '[\\\\|/]win_tempfile[\\\\|/]ansible\\.')
       - actual_create_relative.stat.exists == True
       - actual_create_relative.stat.isdir == True
 
   always:
   - name: remove relative directory tests
     win_file:
-      path: '{{ current_dir.stdout | trim }}\win_tempfile'
+      path: '{{ current_dir }}/win_tempfile'
       state: absent


### PR DESCRIPTION
##### SUMMARY
Add initial support for running some of these modules on non-Windows
targets. Right now only `win_ping`, `win_powershell`, and `win_tempfile`
are fully tested and documented to work. Others may work for specific
use cases but they are not documented and guaranteed to work.

##### ISSUE TYPE
- Feature Pull Request