### PR TITLE
Add .gitleaksignore for test fixture false positive

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+188788b22121f08f4d273dd27e0d86eb45439f11:tests/integration/targets/win_credential_info/tasks/tests.yml:generic-api-key:62


### PR DESCRIPTION
The GenericPass456 value in win_credential_info integration tests is a hardcoded test fixture, not a real credential.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
