### PR TITLE
fix: fall back to WMI when SMBIOS Manufacturer is empty

### DIFF
--- a/changelogs/fragments/setup-platform-empty-vendor-fallback.yml
+++ b/changelogs/fragments/setup-platform-empty-vendor-fallback.yml
@@ -1,0 +1,6 @@
+bugfixes:
+  - >-
+    setup - Fix empty ``ansible_system_vendor`` on hosts where the SMBIOS Type 1 Manufacturer
+    string is blank (e.g. some Windows guests after a V2V migration). Falls back to
+    ``Win32_ComputerSystem.Manufacturer`` when SMBIOSInfo returns an empty Manufacturer,
+    matching the existing fallback path for `Win32Exception`.

--- a/changelogs/fragments/setup-platform-empty-vendor-fallback.yml
+++ b/changelogs/fragments/setup-platform-empty-vendor-fallback.yml
@@ -3,4 +3,4 @@ bugfixes:
     setup - Fix empty ``ansible_system_vendor`` on hosts where the SMBIOS Type 1 Manufacturer
     string is blank (e.g. some Windows guests after a V2V migration). Falls back to
     ``Win32_ComputerSystem.Manufacturer`` when SMBIOSInfo returns an empty Manufacturer,
-    matching the existing fallback path for `Win32Exception`.
+    matching the existing fallback path for ``Win32Exception``.

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -871,6 +871,9 @@ $factMeta = @(
         Code = {
             try {
                 $bios = New-Object -TypeName Ansible.Windows.Setup.SMBIOSInfo
+                if ([string]::IsNullOrWhiteSpace($bios.Manufacturer)) {
+                    $bios = Get-CimInstance -ClassName Win32_ComputerSystem -Property Manufacturer
+                }
             }
             catch [System.ComponentModel.Win32Exception] {
                 $bios = Get-CimInstance -ClassName Win32_ComputerSystem -Property Manufacturer


### PR DESCRIPTION
##### SUMMARY
Adds an `IsNullOrWhiteSpace` fallback to `Win32_ComputerSystem.Manufacturer` after the SMBIOSInfo construction in `setup.ps1`'s `platform` subset. Without it, hosts whose SMBIOS table exists but has a blank Type 1 (System Information) Manufacturer string end up with `ansible_system_vendor = ""`. The existing `catch [System.ComponentModel.Win32Exception]` fallback only fires when the raw SMBIOS API call itself fails (e.g. running as non-admin), not when it succeeds with empty fields.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup

##### ADDITIONAL INFORMATION
The same SMBIOSInfo-succeeds-but-empty condition affects the `virtual` subset, which reads both `$bios.Manufacturer` and `$bios.Model` against `manufacturerMap` / `modelMap` to populate `ansible_virtualization_type`. Out of scope for this minimal fix, but worth a separate look — the same `IsNullOrWhiteSpace`-then-fallback pattern would apply, and the lookup tables may need new entries (e.g. `BOCHS_` Manufacturer, `BXPC*` Model glob) to actually classify the host as `kvm` or `openstack` rather than `NA`.

Below output is from an impacted vm, which was migrated/converted from VMware to OpenStack with [virt-v2v](https://libguestfs.org/virt-v2v.1.html)
```
C:\temp>powershell -noprofile
Windows PowerShell
Copyright (C) Microsoft Corporation. All rights reserved.

PS C:\temp> Get-CimInstance win32_operatingsystem | Select Version,Caption

Version    Caption
-------    -------
10.0.17763 Microsoft Windows Server 2019 Datacenter


PS C:\temp> Get-CimInstance -ClassName Win32_ComputerSystemProduct # no output
PS C:\temp> Get-CimInstance -ClassName Win32_ComputerSystem | Select Manufacturer,Model

Manufacturer Model
------------ -----
BOCHS_       BXPC____
```