### PR TITLE
win_find - fix depth/recursion logic

### DIFF
--- a/changelogs/fragments/win_find-depth.yml
+++ b/changelogs/fragments/win_find-depth.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    win_find - Fix depth and recursion logic that resulted in directories being skipped or depth being ignored -
+    https://github.com/ansible-collections/ansible.windows/issues/839

--- a/plugins/modules/win_find.ps1
+++ b/plugins/modules/win_find.ps1
@@ -252,7 +252,7 @@ Function Search-Path {
         if ($dir_child.Attributes.HasFlag([System.IO.FileAttributes]::Directory) -and $Recurse -and $Depth -ne 1) {
             if ($Follow -or -not $dir_child.Attributes.HasFlag([System.IO.FileAttributes]::ReparsePoint)) {
                 $PSBoundParameters.Remove('Path') > $null
-                $PSBoundParameters['Depth'] = ($PSBoundParameters['Depth']) - 1
+                $PSBoundParameters['Depth'] = $Depth - 1
                 Search-Path -Path $dir_child.FullName @PSBoundParameters
             }
         }

--- a/tests/integration/targets/win_find/defaults/main.yml
+++ b/tests/integration/targets/win_find/defaults/main.yml
@@ -1,2 +1,3 @@
-win_find_dir: '{{ remote_tmp_dir }}\win_find .ÅÑŚÌβŁÈ [$!@^&test(;)]'
+win_base_dir: '{{ remote_tmp_dir }}\win_find .ÅÑŚÌβŁÈ [$!@^&test(;)]'
+win_find_dir: '{{ win_base_dir }}\testing'
 test_win_find_username: testuser

--- a/tests/integration/targets/win_find/tasks/main.yml
+++ b/tests/integration/targets/win_find/tasks/main.yml
@@ -8,6 +8,24 @@
 # all in bulk than with with_items to save each round trip over WinRM
 - name: set test files and folders
   win_shell: |
+    $base_tmp_dir = '{{ win_base_dir }}'
+    @(
+        "nested-depth\folder_1\sub_folder_1",
+        "nested-depth\folder_2\sub_folder_2"
+        "nested-depth\folder_3\sub_folder_3\deep_sub_folder_3"
+    ) | ForEach-Object {
+        New-Item -Path "$base_tmp_dir\$_" -ItemType Directory -Force
+    }
+
+    @(
+        "nested-depth\folder_1\sub_folder_1\file_1.txt",
+        "nested-depth\folder_2\sub_folder_2\file_2.txt"
+        "nested-depth\folder_3\sub_folder_3\file_3.txt"
+        "nested-depth\folder_3\sub_folder_3\deep_sub_folder_3\deep_file_3.txt"
+    ) | ForEach-Object {
+        New-Item -Path "$base_tmp_dir\$_" -ItemType File -Value ""
+    }
+
     $directories = @(
         "nested",
         "single",
@@ -117,5 +135,5 @@
 
   - name: remove testing folder
     win_file:
-      path: '{{win_find_dir}}'
+      path: '{{win_base_dir}}'
       state: absent

--- a/tests/integration/targets/win_find/tasks/tests.yml
+++ b/tests/integration/targets/win_find/tasks/tests.yml
@@ -968,3 +968,27 @@
     - not any_result is changed
     - any_result.examined == 4
     - any_result.matched == 3
+
+# Verifies the depth logic does not impact multiple sibling directories.
+# This test ensures two things:
+# 1. All sibling folders at the same depth are searched correctly (bug would cause
+#    folder_2 to be skipped (Depth = 1) due to depth value mutation)
+# 2. Files beyond depth 3 are correctly excluded (deep_file_3.txt should NOT be found)
+# https://github.com/ansible-collections/ansible.windows/issues/839
+- name: find files with recurse and custom depth
+  win_find:
+    paths: '{{ win_base_dir }}\nested-depth'
+    recurse: true
+    depth: 3
+  register: actual
+
+- name: assert find files with recurse and custom depth
+  assert:
+    that:
+    - not actual is changed
+    - actual.examined == 10
+    - actual.matched == 3
+    - actual.files | length == 3
+    - actual.files[0].path == win_base_dir + '\\nested-depth\\folder_1\\sub_folder_1\\file_1.txt'
+    - actual.files[1].path == win_base_dir + '\\nested-depth\\folder_2\\sub_folder_2\\file_2.txt'
+    - actual.files[2].path == win_base_dir + '\\nested-depth\\folder_3\\sub_folder_3\\file_3.txt'


### PR DESCRIPTION
##### SUMMARY
Fixes the logic for `win_find` `depth/recurse` to ensure the depth value is respected. The original issue was that the depth value was mutated for each folder in a directory causing it to either go below 1 which meant no depth was set or set to 1 ignoring a directory that should not have been ignored.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/839

##### ISSUE TYPE
- Bugfix Pull Request