### PR TITLE
feat: add computername parameter and fix scope filtering for leases/reservations

### DIFF
--- a/changelogs/fragments/win_dhcp_lease.yml
+++ b/changelogs/fragments/win_dhcp_lease.yml
@@ -1,5 +1,5 @@
 bugfixes:
-  - >-    
+  - >-
     win_dhcp_lease - Fix scope filtering when searching for existing leases or reservations:
     ensure the query is limited to the specified scope. This prevents ambiguity
     when the same MAC address exists in multiple scopes (e.g. a device with

--- a/changelogs/fragments/win_dhcp_lease.yml
+++ b/changelogs/fragments/win_dhcp_lease.yml
@@ -1,0 +1,9 @@
+bugfixes:
+  - >-    
+    win_dhcp_lease - Fix scope filtering when searching for existing leases or reservations:
+    ensure the query is limited to the specified scope. This prevents ambiguity
+    when the same MAC address exists in multiple scopes (e.g. a device with
+    reservations in different scopes).
+
+minor_changes:
+  - win_dhcp_lease - add support for computername parameter.

--- a/plugins/modules/win_dhcp_lease.ps1
+++ b/plugins/modules/win_dhcp_lease.ps1
@@ -18,6 +18,7 @@ $spec = @{
         reservation_name = @{ type = "str"; }
         description = @{ type = "str"; }
         state = @{ type = "str"; choices = "absent", "present"; default = "present" }
+		computer_name = @{ type = "str" }
     }
     required_if = @(
         @("state", "present", @("mac", "ip"), $true),
@@ -39,6 +40,11 @@ $dns_regtype = $module.Params.dns_regtype
 $reservation_name = $module.Params.reservation_name
 $description = $module.Params.description
 $state = $module.Params.state
+$dhcp_computer_name = $module.Params.computer_name
+$extra_args = @{}
+if ($null -ne $dhcp_computer_name) {
+    $extra_args.ComputerName = $dhcp_computer_name
+}
 
 Function Convert-MacAddress {
     Param(
@@ -129,13 +135,13 @@ if ($mac) {
         $module.FailJson("The MAC Address is not properly formatted")
     }
     else {
-        $current_lease = Get-DhcpServerv4Scope | Get-DhcpServerv4Lease | Where-Object ClientId -eq $mac
+        $current_lease = Get-DhcpServerv4Scope @extra_args | Get-DhcpServerv4Lease @extra_args | Where-Object ClientId -eq $mac
     }
 }
 
 # Find existing lease by IP address
 if ($ip -and (-not $current_lease)) {
-    $current_lease = Get-DhcpServerv4Scope | Get-DhcpServerv4Lease | Where-Object IPAddress -eq $ip
+    $current_lease = Get-DhcpServerv4Scope @extra_args | Get-DhcpServerv4Lease @extra_args | Where-Object IPAddress -eq $ip
 }
 
 # Did we find a lease/reservation
@@ -168,7 +174,7 @@ if ($state -eq "absent") {
         if ($current_lease_reservation -eq $true) {
             # Try to remove reservation
             Try {
-                $current_lease | Remove-DhcpServerv4Reservation -WhatIf:$check_mode
+                $current_lease | Remove-DhcpServerv4Reservation -WhatIf:$check_mode @extra_args
                 $state_absent_removed = $true
             }
             Catch {
@@ -179,7 +185,7 @@ if ($state -eq "absent") {
         else {
             # Try to remove lease
             Try {
-                $current_lease | Remove-DhcpServerv4Lease -WhatIf:$check_mode
+                $current_lease | Remove-DhcpServerv4Lease -WhatIf:$check_mode @extra_args
                 $state_absent_removed = $true
             }
             Catch {
@@ -236,17 +242,17 @@ if ($state -eq "present") {
                 }
 
                 # Desired type is reservation
-                $current_lease | Add-DhcpServerv4Reservation -WhatIf:$check_mode
+                $current_lease | Add-DhcpServerv4Reservation @params -WhatIf:$check_mode @extra_args
 
                 if (-not $check_mode) {
-                    $current_reservation = Get-DhcpServerv4Lease -ClientId $params.ClientId -ScopeId $current_lease.ScopeId
+                    $current_reservation = Get-DhcpServerv4Lease -ClientId $params.ClientId -ScopeId $current_lease.ScopeId @extra_args
                 }
 
                 # Update the reservation with new values
-                $current_reservation | Set-DhcpServerv4Reservation @params -WhatIf:$check_mode
+                $current_reservation | Set-DhcpServerv4Reservation @params -WhatIf:$check_mode @extra_args
 
                 if (-not $check_mode) {
-                    $updated_reservation = Get-DhcpServerv4Lease -ClientId $params.ClientId -ScopeId $current_reservation.ScopeId
+                    $updated_reservation = Get-DhcpServerv4Lease -ClientId $params.ClientId -ScopeId $current_reservation.ScopeId @extra_args
                 }
 
                 if (-not $check_mode) {
@@ -271,7 +277,8 @@ if ($state -eq "present") {
         if ($type -eq "lease") {
             Try {
                 # Desired type is a lease, remove the reservation
-                $current_lease | Remove-DhcpServerv4Reservation -WhatIf:$check_mode
+                $current_lease | Remove-DhcpServerv4Reservation -WhatIf:$check_mode @extra_args
+
                 # Build a new lease object with remnants of the reservation
                 $lease_params = @{
                     ClientId = $original_lease.ClientId
@@ -283,7 +290,7 @@ if ($state -eq "present") {
 
                 # Create new lease
                 Try {
-                    Add-DhcpServerv4Lease @lease_params -WhatIf:$check_mode
+                    Add-DhcpServerv4Lease @lease_params -WhatIf:$check_mode @extra_args
                 }
                 Catch {
                     $module.FailJson("Unable to convert the reservation to a lease: $_", $_)
@@ -292,7 +299,7 @@ if ($state -eq "present") {
                 # Get the lease we just created
                 if (-not $check_mode) {
                     Try {
-                        $new_lease = Get-DhcpServerv4Lease -ClientId $lease_params.ClientId -ScopeId $lease_params.ScopeId
+                        $new_lease = Get-DhcpServerv4Lease -ClientId $lease_params.ClientId -ScopeId $lease_params.ScopeId @extra_args
                     }
                     Catch {
                         $module.FailJson("Unable to retreive the newly created lease: $_", $_)
@@ -345,10 +352,10 @@ if ($state -eq "present") {
             }
 
             # Update the reservation with new values
-            $current_lease | Set-DhcpServerv4Reservation @params -WhatIf:$check_mode
+            $current_lease | Set-DhcpServerv4Reservation @params -WhatIf:$check_mode @extra_args
 
             if (-not $check_mode) {
-                $reservation = Get-DhcpServerv4Lease -ClientId $current_lease.ClientId -ScopeId $current_lease.ScopeId
+                $reservation = Get-DhcpServerv4Lease -ClientId $current_lease.ClientId -ScopeId $current_lease.ScopeId @extra_args
                 $module.Result.changed = Compare-DhcpLease -Original $original_lease -Updated $reservation
                 $module.Result.lease = Convert-ReturnValue -Object $reservation
             }
@@ -396,11 +403,11 @@ if ($state -eq "present") {
                 }
                 $params.AddressState = 'Active'
                 # Create lease based on parameters
-                Add-DhcpServerv4Lease @params -WhatIf:$check_mode
+                Add-DhcpServerv4Lease @lease_params -WhatIf:$check_mode @extra_args
 
                 # Retreive the lease
                 if (-not $check_mode) {
-                    $new_lease = Get-DhcpServerv4Lease -ClientId $mac -ScopeId $scope_id
+                    $new_lease = Get-DhcpServerv4Lease -ClientId $mac -ScopeId $scope_id @extra_args
                     $module.Result.lease = Convert-ReturnValue -Object $new_lease
                 }
 
@@ -440,11 +447,11 @@ if ($state -eq "present") {
                 Try {
                     if ($check_mode) {
                         # In check mode, a lease won't exist for conversion, make one manually
-                        Add-DhcpServerv4Reservation -ScopeId $scope_id -ClientId $mac -IPAddress $ip -WhatIf:$check_mode
+                        Add-DhcpServerv4Reservation -ScopeId $scope_id -ClientId $mac -IPAddress $ip -WhatIf:$check_mode @extra_args
                     }
                     else {
                         # Convert to Reservation
-                        Add-DhcpServerv4Reservation @params -WhatIf:$check_mode
+                        Add-DhcpServerv4Reservation @params -WhatIf:$check_mode @extra_args
                     }
                 }
                 Catch {
@@ -454,7 +461,7 @@ if ($state -eq "present") {
 
                 if (-not $check_mode) {
                     # Get DHCP reservation object
-                    $new_lease = Get-DhcpServerv4Reservation -ClientId $mac -ScopeId $scope_id
+                    $new_lease = Get-DhcpServerv4Reservation -ClientId $mac -ScopeId $scope_id @extra_args
                     $module.Result.lease = Convert-ReturnValue -Object $new_lease
                 }
 

--- a/plugins/modules/win_dhcp_lease.ps1
+++ b/plugins/modules/win_dhcp_lease.ps1
@@ -18,7 +18,7 @@ $spec = @{
         reservation_name = @{ type = "str"; }
         description = @{ type = "str"; }
         state = @{ type = "str"; choices = "absent", "present"; default = "present" }
-		computer_name = @{ type = "str" }
+        computer_name = @{ type = "str" }
     }
     required_if = @(
         @("state", "present", @("mac", "ip"), $true),
@@ -46,7 +46,7 @@ if ($null -ne $dhcp_computer_name) {
     $extra_args.ComputerName = $dhcp_computer_name
 }
 
-# filter to the scope if it was provided 
+# filter to the scope if it was provided
 #Ensure we get the desired lease if mac address is present more than once in all the scopes
 $scope_filter = @{ }
 if ($scope_id) {

--- a/plugins/modules/win_dhcp_lease.ps1
+++ b/plugins/modules/win_dhcp_lease.ps1
@@ -410,7 +410,7 @@ if ($state -eq "present") {
                 }
                 $params.AddressState = 'Active'
                 # Create lease based on parameters
-                Add-DhcpServerv4Lease @lease_params -WhatIf:$check_mode @extra_args
+                Add-DhcpServerv4Lease @params -WhatIf:$check_mode @extra_args
 
                 # Retreive the lease
                 if (-not $check_mode) {

--- a/plugins/modules/win_dhcp_lease.ps1
+++ b/plugins/modules/win_dhcp_lease.ps1
@@ -46,6 +46,13 @@ if ($null -ne $dhcp_computer_name) {
     $extra_args.ComputerName = $dhcp_computer_name
 }
 
+# filter to the scope if it was provided 
+#Ensure we get the desired lease if mac address is present more than once in all the scopes
+$scope_filter = @{ }
+if ($scope_id) {
+    $scope_filter.ScopeId = $scope_id
+}
+
 Function Convert-MacAddress {
     Param(
         [string]$mac
@@ -135,13 +142,13 @@ if ($mac) {
         $module.FailJson("The MAC Address is not properly formatted")
     }
     else {
-        $current_lease = Get-DhcpServerv4Scope @extra_args | Get-DhcpServerv4Lease @extra_args | Where-Object ClientId -eq $mac
+        $current_lease = Get-DhcpServerv4Scope @scope_filter @extra_args | Get-DhcpServerv4Lease @extra_args | Where-Object ClientId -eq $mac
     }
 }
 
 # Find existing lease by IP address
 if ($ip -and (-not $current_lease)) {
-    $current_lease = Get-DhcpServerv4Scope @extra_args | Get-DhcpServerv4Lease @extra_args | Where-Object IPAddress -eq $ip
+    $current_lease = Get-DhcpServerv4Scope @scope_filter @extra_args | Get-DhcpServerv4Lease @extra_args | Where-Object IPAddress -eq $ip
 }
 
 # Did we find a lease/reservation

--- a/plugins/modules/win_dhcp_lease.py
+++ b/plugins/modules/win_dhcp_lease.py
@@ -87,6 +87,14 @@ options:
       - Specifies the description for reservation being created.
       - Only applicable to l(type=reservation).
     type: str
+  computer_name:
+    description:
+      - Specifies a DHCP server.
+      - You can specify an IP address or any value that resolves to an IP
+        address, such as a fully qualified domain name (FQDN), host name, or
+        NETBIOS name.
+    type: str
+
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/win_dhcp_lease.py
+++ b/plugins/modules/win_dhcp_lease.py
@@ -94,6 +94,7 @@ options:
         address, such as a fully qualified domain name (FQDN), host name, or
         NETBIOS name.
     type: str
+    version_added: 3.6.0
 
 '''
 


### PR DESCRIPTION
##### SUMMARY
Add support for the `computername` parameter and fix scope filtering
when searching for existing DHCP leases or reservations.

Previously, lookups were not restricted to the specified scope, which
could lead to incorrect matches when the same MAC address exists in
multiple scopes (e.g. a device with multiple reservations).

This change ensures:
- support of `computername` as an input parameter
- lookup operations are restricted to the given scope for accuracy

Fixes: https://github.com/ansible-collections/ansible.windows/issues/835

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request


##### COMPONENT NAME
win_dhcp_lease

##### ADDITIONAL INFORMATION

###### Problem reproduction
1. Create multiple DHCP scopes
2. Add the same MAC address in more than one scope (e.g. reservations)
3. Run the module without strict scope filtering
4. Observe that the returned lease/reservation may not belong to the expected scope

###### Behavior before
- Lookup could return an object from a different scope
- Ambiguous results when MAC exists in multiple scopes

###### Behavior after
- Lookup is strictly limited to the specified scope
- No ambiguity even if MAC address exists in multiple scopes