### PR TITLE
win_updates - Improve reboot handling

### DIFF
--- a/changelogs/fragments/update-reboot-fixes.yml
+++ b/changelogs/fragments/update-reboot-fixes.yml
@@ -1,0 +1,10 @@
+bugfixes:
+  - >-
+    win_updates - Add additional post reboot check to ensure that Windows is still not performing more update work
+    after a reboot is complete.
+  - >-
+    win_updates - Handle update task that errors with ``ERROR_SHUTDOWN_IN_PROGRESS`` when ``reboot=True`` is set. If
+    this error is received and the task has ``reboot=True`` then the module will wait for the reboot to be complete
+    before trying again like how other errors are handled.
+  - >-
+    win_updates - Fix issue display warnings after data tagging changes made in Ansible 2.19.

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -33,6 +33,36 @@ from ..plugin_utils._reboot import reboot_host
 
 display = Display()
 
+# An additional test command for rebooting to wait until the host is ready for
+# the next update round. Some reports have indicated CBS could still be
+# installing updates even when the AutoLogonCheck reg key is created. By also
+# waiting for this to be 0 or 1 we should be more certain the host is ready and
+# CBS is still not doing post reboot work. In testing I've found the values can
+# be (MS may add future values as this isn't publicly documented):
+#   None - The key doesn't exist which we treat as 0
+#   0 - No work is being done
+#   1 - An update is pending a reboot but not doing work
+#   2 - CBS is actively working on something and we should wait
+_CBS_SERVICING_TEST_CMD = r"""
+try {
+    $propParams = @{
+        LiteralPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\Interface'
+        Name = 'ServicingInProgress'
+        ErrorAction = 'Stop'
+    }
+    $val = Get-ItemPropertyValue @propParams
+    if ($val -in @(0, 1)) {
+        exit 0
+    }
+    else {
+        exit $val
+    }
+}
+catch {
+    exit 0
+}
+"""
+
 
 def _get_hresult_error(hresult):  # type: (int) -> str
     """Converts a WUA HRESULT to a human readable error message.
@@ -796,12 +826,27 @@ class ActionModule(ActionBase):
                 has_rebooted_on_failure = False
 
             if reboot_required and reboot:
-                display.v("Rebooting host after installing updates", host=task_vars.get('inventory_hostname', None))
+                inventory_hostname = task_vars.get('inventory_hostname', None)
+                if update_result.reboot_in_progress_last_boot_time:
+                    msg = f"[{inventory_hostname}] Host indicated reboot is in progress, waiting for it to come " \
+                        "back online before trying again. This is a best effort attempt to recover from a reboot " \
+                        "that was triggered outside of Ansible's control. If the host is shutting down instead of " \
+                        "rebooting the task will time out."
+                    display.warning(msg)
+                else:
+                    display.v("Rebooting host after installing updates", host=inventory_hostname)
+
                 if self._task.check_mode:
                     reboot_res = {'failed': False}
 
                 else:
-                    reboot_res = reboot_host(self._task.action, self._connection, reboot_timeout=reboot_timeout)
+                    reboot_res = reboot_host(
+                        self._task.action,
+                        self._connection,
+                        reboot_timeout=reboot_timeout,
+                        last_boot_time=update_result.reboot_in_progress_last_boot_time,
+                        additional_test_commands=[_CBS_SERVICING_TEST_CMD],
+                    )
 
                 result['rebooted'] = True
 
@@ -936,7 +981,11 @@ class ActionModule(ActionBase):
             raise _ReturnResultException(msg, exception=result.get('exception', None), **extra_result)
 
         for w in result.get('warnings', []):
-            display.warning(w)
+            # warnings from this plugin can be injected by _execute_module on
+            # a subsequent run so we want to ensure only module warnings that
+            # were strings are written to the display here.
+            if isinstance(w, str):
+                display.warning(w)
 
         return result
 
@@ -978,6 +1027,7 @@ class UpdateResult:
         self.install_results = {}
         self.changed = False
         self.reboot_required = False
+        self.reboot_in_progress_last_boot_time = None
         self.failed = False
         self.msg = None
         self.exception = None
@@ -1072,3 +1122,10 @@ class UpdateResult:
             self.exception = result['exception'].get('exception', None)
             if 'hresult' in result['exception']:
                 self.hresult = result['exception']['hresult'] & 0xFFFFFFFF
+
+            # Special marker when WUA returned an error indicating a shutdown
+            # is in progress. When reboot=True we use this to proceed directly
+            # to waiting for the reboot to complete before trying again.
+            last_boot_time = result['exception'].pop('_is_rebooting_last_boot_time', None)
+            if last_boot_time is not None:
+                self.reboot_in_progress_last_boot_time = str(last_boot_time)

--- a/plugins/modules/win_updates.ps1
+++ b/plugins/modules/win_updates.ps1
@@ -1697,10 +1697,31 @@ namespace Ansible.Windows.WinUpdates
             # COMExceptions don't contain any info in the error message, we make sure we return the HResult for the
             # action plugin to properly decode
             $exitResult.exception.hresult = $_.Exception.HResult
+
+            if ($_.Exception.HResult -eq 0x8007045B) {
+                # ERROR_SHUTDOWN_IN_PROGRESS. We return the last boot time so
+                # the action plugin does not need to do it itself and risk the
+                # connection being lost.
+                $exitResult.exception._is_rebooting_last_boot_time = [string]$lastBootUpTime
+            }
         }
 
         if ($api) {
-            $api.WriteLog("Exception encountered:`r`n$($_ | Out-String)`r`nExiting...")
+            $expMsg = @(
+                "ErrorRecord:"
+                "Message: $_"
+                "FullyQualifiedErrorId: $($_.FullyQualifiedErrorId)"
+                "CategoryInfo: $($_.CategoryInfo)"
+                "TargetObject: $($_.TargetObject)"
+                "ScriptStackTrace:`r`n$($_.ScriptStackTrace)"
+                ""
+                "Exception:"
+                "Type: $($_.Exception.GetType().FullName)"
+                foreach ($prop in $_.Exception.PSObject.Properties) {
+                    "$($prop.Name): $($prop.Value)"
+                }
+            ) -join "`r`n"
+            $api.WriteLog("Exception encountered:`r`n$expMsg`r`nExiting...")
         }
         $OutputCollection.Add(@{
                 task = 'exit'
@@ -1717,6 +1738,11 @@ namespace Ansible.Windows.WinUpdates
         action = $null  # Current action, used for exception information if set
         exception = $null  # Exception info in case of a failure @{message, exception, hresult}
     }
+
+    # We query this first to make sure that if a reboot is in progress during a
+    # failure we don't waste time trying to get this value and can return
+    # quickly.
+    $lastBootUpTime = (Get-CimInstance -ClassName Win32_OperatingSystem -Property LastBootUpTime).LastBootUpTime.ToFileTime()
 
     $api = New-Object -TypeName Ansible.Windows.WinUpdates.API -ArgumentList @(
         $OutputCollection,

--- a/plugins/plugin_utils/_reboot.py
+++ b/plugins/plugin_utils/_reboot.py
@@ -77,6 +77,8 @@ def reboot_host(
     pre_reboot_delay: int = 2,
     reboot_timeout: int = 600,
     test_command: t.Optional[str] = None,
+    last_boot_time: t.Optional[str] = None,
+    additional_test_commands: t.Optional[t.List[str]] = None,
 ) -> t.Dict[str, t.Any]:
     """Reboot a Windows Host.
 
@@ -118,6 +120,16 @@ def reboot_host(
             determines the machine is ready for management. When not defined
             the default command should wait until the reboot is complete and
             all pre-login configuration has completed.
+        last_boot_time: The last boot time of the system. If set then the host
+            has indicated it is already rebooting and we should wait for it to
+            come back online. The value should be the same result as
+            _DEFAULT_BOOT_TIME_COMMAND.
+        additional_test_commands: A list of additional commands to run after
+            the test_command to further validate the host is ready.
+            These will be run sequentially and any non-zero return codes will
+            be repeated until they return 0 or the reboot_timeout is reached.
+            This is designed to allow the default test cmd to be used alongside
+            additional caller defined commands.
 
     Returns:
         (Dict[str, Any]): The return result as a dictionary. Use the 'failed'
@@ -132,34 +144,44 @@ def reboot_host(
     }
     host_context = {"do_close_on_reset": True}
 
-    # Get current boot time. A lot of tasks that require a reboot leave the WSMan stack in a bad place. Will try to
-    # get the initial boot time 3 times before giving up.
-    try:
-        previous_boot_time = _do_until_success_or_retry_limit(
-            task_action,
-            connection,
-            host_context,
-            "pre-reboot boot time check",
-            3,
-            _get_system_boot_time,
-            task_action,
-            connection,
-            boot_time_command,
-        )
+    if last_boot_time:
+        # If an explicit last_boot_time was set we consider the host as already
+        # in the reboot cycle and skip trying to retrieve the last boot time
+        # and sending the reboot command.
+        perform_reboot = False
+        previous_boot_time = last_boot_time
 
-    except Exception as e:
-        # Report a the failure based on the last exception received.
-        if isinstance(e, _ReturnResultException):
-            result.update(e.result)
+    else:
+        # Get current boot time. A lot of tasks that require a reboot leave
+        # the WSMan stack in a bad place. Will try to get the initial boot
+        # time 3 times before giving up.
+        perform_reboot = True
+        try:
+            previous_boot_time = _do_until_success_or_retry_limit(
+                task_action,
+                connection,
+                host_context,
+                "pre-reboot boot time check",
+                3,
+                _get_system_boot_time,
+                task_action,
+                connection,
+                boot_time_command,
+            )
 
-        if isinstance(e, AnsibleConnectionFailure):
-            result["unreachable"] = True
-        else:
-            result["failed"] = True
+        except Exception as e:
+            # Report a the failure based on the last exception received.
+            if isinstance(e, _ReturnResultException):
+                result.update(e.result)
 
-        result["msg"] = str(e)
-        result["exception"] = traceback.format_exc()
-        return result
+            if isinstance(e, AnsibleConnectionFailure):
+                result["unreachable"] = True
+            else:
+                result["failed"] = True
+
+            result["msg"] = str(e)
+            result["exception"] = traceback.format_exc()
+            return result
 
     # Get the original connection_timeout option var so it can be reset after
     original_connection_timeout: t.Optional[float] = None
@@ -219,7 +241,8 @@ ConvertTo-Json -Compress -InputObject @{
 
     start = None
     try:
-        _perform_reboot(task_action, connection, reboot_command)
+        if perform_reboot:
+            _perform_reboot(task_action, connection, reboot_command)
 
         start = datetime.datetime.utcnow()
         result["changed"] = True
@@ -272,6 +295,21 @@ ConvertTo-Json -Compress -InputObject @{
             expected=expected_test_result,
         )
 
+        if additional_test_commands:
+            for cmd in additional_test_commands:
+                display.vv(f"{task_action} running additional post reboot test command")
+                _do_until_success_or_timeout(
+                    task_action,
+                    connection,
+                    host_context,
+                    "additional post-reboot test command",
+                    reboot_timeout,
+                    _run_test_command,
+                    task_action,
+                    connection,
+                    cmd,
+                )
+
         display.vv(f"{task_action}: system successfully rebooted")
 
     except Exception as e:
@@ -308,6 +346,7 @@ def _check_boot_time(
     current_boot_time = _get_system_boot_time(
         task_action, connection, boot_time_command
     )
+    display.vvvv(f"{task_action}: comparing current boot time {current_boot_time!r} to previous {previous_boot_time!r}")
     if current_boot_time == previous_boot_time:
         raise _TestCommandFailure("boot time has not changed")
 


### PR DESCRIPTION
##### SUMMARY
Adds more logic and error handling when it comes to reboots with this module. In addition to the normal registry key the reboot action checks we now also check that the CBS/TiWorker is not currently performing any work. This should ensure that the next update round will not begin after a reboot until CBS has indicated it is done with any post reboot work.

Adds better handling when the Windows Update API returns `ERROR_SHUTDOWN_IN_PROGRESS`. This error has been reported when the CBS worker or some other component on Windows has initiated a reboot while our module is running. If the caller of the module has set `reboot=True` we will treat this error as a reboot cycle and try again when the host comes back online. This check is not perfect as the host could have been set to shutdown rather than reboot but we cannot know this and rely on the timeout to pick that up eventually.

Adds some more logging around exceptions to help pick up more information about these failures in the future.

##### ISSUE TYPE
- Bugfix Pull Request