### PR TITLE
Add diff support to win_copy and win_template

### DIFF
--- a/changelogs/fragments/diff-support-to-copy.yml
+++ b/changelogs/fragments/diff-support-to-copy.yml
@@ -1,4 +1,6 @@
-bugfixes:
-- >-
-  win_copy - Add diff support to win_copy and win_template -
-  https://github.com/ansible-collections/ansible.windows/issues/16
+minor_changes:
+  - >-
+    win_copy - Add diff support to win_copy and win_template when copying
+    single files only. Copying multiple files will still not produce any diff
+    output -
+    https://github.com/ansible-collections/ansible.windows/issues/16

--- a/changelogs/fragments/diff-support-to-copy.yml
+++ b/changelogs/fragments/diff-support-to-copy.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- >-
+  win_copy - Add diff support to win_copy and win_template -
+  https://github.com/ansible-collections/ansible.windows/issues/16

--- a/plugins/action/win_copy.py
+++ b/plugins/action/win_copy.py
@@ -506,6 +506,7 @@ class ActionModule(ActionBase):
             # we only need to copy 1 file, don't mess around with zips
             file_src = query_return['files'][0]['src']
             file_dest = query_return['files'][0]['dest']
+            basename = original_basename or file_dest
             if self._task.diff:
                 result['diff'] = self._get_diff_data(dest, source_full, task_vars, content is None)
             result.update(self._copy_single_file(file_src, dest, basename, file_dest,

--- a/plugins/action/win_copy.py
+++ b/plugins/action/win_copy.py
@@ -507,10 +507,21 @@ class ActionModule(ActionBase):
             file_src = query_return['files'][0]['src']
             file_dest = query_return['files'][0]['dest']
             basename = original_basename or file_dest
+            file_diff = None
             if self._task.diff:
-                result['diff'] = self._get_diff_data(dest, source_full, task_vars, content is None)
+                file_diff = self._get_diff_data(
+                    dest,
+                    source_full,
+                    task_vars,
+                    content=content is not None,
+                )
+
             result.update(self._copy_single_file(file_src, dest, basename, file_dest,
                                                  task_vars, self._connection._shell.tmpdir, backup))
+
+            if file_diff is not None:
+                result['diff'] = file_diff
+
             if result.get('failed') is True:
                 result['msg'] = "failed to copy file %s: %s" % (file_src, result['msg'])
             result['changed'] = True

--- a/plugins/action/win_copy.py
+++ b/plugins/action/win_copy.py
@@ -506,8 +506,7 @@ class ActionModule(ActionBase):
             # we only need to copy 1 file, don't mess around with zips
             file_src = query_return['files'][0]['src']
             file_dest = query_return['files'][0]['dest']
-            basename = original_basename or file_dest
-            if self._play_context.diff:
+            if self._task.diff:
                 result['diff'] = self._get_diff_data(dest, source_full, task_vars, content is None)
             result.update(self._copy_single_file(file_src, dest, basename, file_dest,
                                                  task_vars, self._connection._shell.tmpdir, backup))

--- a/plugins/action/win_copy.py
+++ b/plugins/action/win_copy.py
@@ -507,6 +507,8 @@ class ActionModule(ActionBase):
             file_src = query_return['files'][0]['src']
             file_dest = query_return['files'][0]['dest']
             basename = original_basename or file_dest
+            if self._play_context.diff:
+                result['diff'] = self._get_diff_data(dest, source_full, task_vars, content is None)
             result.update(self._copy_single_file(file_src, dest, basename, file_dest,
                                                  task_vars, self._connection._shell.tmpdir, backup))
             if result.get('failed') is True:

--- a/plugins/modules/win_file.ps1
+++ b/plugins/modules/win_file.ps1
@@ -181,19 +181,23 @@ function Update-Timestamp {
     return $changed
 }
 
-function Test-FileAppearsBinary($path) {
+function Test-FileAppearsBinary {
+    [CmdletBinding()]
+    param ($Path)
+
+    $fs = $null
     try {
-        # Open file for binary read
-        $fs = [IO.File]::OpenRead($path)
-        # Read up to 8192 bytes
-        $b = New-Object byte[] 8192
+        $resolvedPath = $PSCmdlet.GetUnresolvedProviderPathFromPSPath($Path)
+        $fs = [IO.File]::OpenRead($resolvedPath)
+        $b = [byte[]]::new(8192)
         $n = $fs.Read($b, 0, 8192)
-        $fs.Dispose()
-        # Check for null byte
-        return ($n -gt 0) -and ($b[0..($n - 1)] -contains 0x00)
+        return ($n -gt 0) -and ([Array]::IndexOf($b, [byte]0, 0, $n) -ge 0)
     }
     catch {
         return $false
+    }
+    finally {
+        if ($fs) { $fs.Dispose() }
     }
 }
 

--- a/plugins/modules/win_file.ps1
+++ b/plugins/modules/win_file.ps1
@@ -180,6 +180,28 @@ function Update-Timestamp {
     return $changed
 }
 
+function Test-FileAppearsBinary($path) {
+    try {
+        # Open file for binary read
+        $fs = [IO.File]::OpenRead($path)
+        # Read up to 8192 bytes
+        $b = New-Object byte[] 8192
+        $n = $fs.Read($b, 0, 8192)
+        $fs.Dispose()
+        # Check for null byte
+        return ($n -gt 0) -and ($b[0..($n-1)] -contains 0x00)
+    } catch {
+        return $false
+    }
+}
+
+# Short circuit for diff_peek
+if ($null -ne $diff_peek) {
+    $appears_binary = Test-FileAppearsBinary -path $path
+    $state = if (Test-Path -LiteralPath $path) { 'file' } else { 'absent' }
+    Exit-Json @{path=$path; change=$false; appears_binary=$appears_binary; state=$state}
+}
+
 if ($state -eq "touch") {
     $newCreation = $false
     if (Test-Path -LiteralPath $path) {

--- a/plugins/modules/win_file.ps1
+++ b/plugins/modules/win_file.ps1
@@ -189,8 +189,9 @@ function Test-FileAppearsBinary($path) {
         $n = $fs.Read($b, 0, 8192)
         $fs.Dispose()
         # Check for null byte
-        return ($n -gt 0) -and ($b[0..($n-1)] -contains 0x00)
-    } catch {
+        return ($n -gt 0) -and ($b[0..($n - 1)] -contains 0x00)
+    }
+    catch {
         return $false
     }
 }
@@ -199,7 +200,7 @@ function Test-FileAppearsBinary($path) {
 if ($null -ne $diff_peek) {
     $appears_binary = Test-FileAppearsBinary -path $path
     $state = if (Test-Path -LiteralPath $path) { 'file' } else { 'absent' }
-    Exit-Json @{path=$path; change=$false; appears_binary=$appears_binary; state=$state}
+    Exit-Json @{ path = $path; change = $false; appears_binary = $appears_binary; state = $state }
 }
 
 if ($state -eq "touch") {

--- a/plugins/modules/win_file.ps1
+++ b/plugins/modules/win_file.ps1
@@ -12,6 +12,7 @@ $params = Parse-Args $args -supports_check_mode $true
 
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -default $false
 $_remote_tmp = Get-AnsibleParam $params "_ansible_remote_tmp" -type "path" -default $env:TMP
+$diff_peek = Get-AnsibleParam -obj $params -name '_diff_peek' -type 'bool'
 
 $access_time = Get-AnsibleParam -obj $params -name "access_time" -type "str"
 $access_time_format = Get-AnsibleParam -obj $params -name "access_time_format" -type "str" -default "yyyy-MM-dd HH:mm:ss"

--- a/tests/integration/targets/win_copy/tasks/diff_tests.yml
+++ b/tests/integration/targets/win_copy/tasks/diff_tests.yml
@@ -1,0 +1,111 @@
+- name: diff with non-existent destination
+  win_copy:
+    src: foo.txt
+    dest: '{{ test_win_copy_path }}\diff_tests-foo.txt'
+  register: diff_non_existent
+  diff: true
+
+- name: assert diff with non-existent destination
+  assert:
+    that:
+    - diff_non_existent.diff.after == "foo.txt\n"
+    - diff_non_existent.diff.after_header == role_path ~ '/files/foo.txt'
+    - diff_non_existent.diff.before == ''
+
+- name: diff with same file
+  win_copy:
+    src: foo.txt
+    dest: '{{ test_win_copy_path }}\diff_tests-foo.txt'
+  register: diff_same_file
+  diff: true
+
+- name: assert diff with same file
+  assert:
+    that:
+    - diff_same_file.diff is not defined
+
+- name: diff with different file
+  win_copy:
+    src: subdir/bar.txt
+    dest: '{{ test_win_copy_path }}\diff_tests-foo.txt'
+  register: diff_different_file
+  diff: true
+
+- name: assert diff with different file
+  assert:
+    that:
+    - diff_different_file.diff.after == "baz\n"
+    - diff_different_file.diff.after_header == role_path ~ '/files/subdir/bar.txt'
+    - diff_different_file.diff.before == "foo.txt\n"
+    - diff_different_file.diff.before_header == test_win_copy_path ~ '\diff_tests-foo.txt'
+
+- name: diff with content
+  win_copy:
+    content: 'this is some content'
+    dest: '{{ test_win_copy_path }}\diff_tests-foo.txt'
+  register: diff_content
+  diff: true
+
+- name: assert diff with content
+  assert:
+    that:
+    - diff_content.diff.after == 'this is some content'
+    - diff_content.diff.after_header == test_win_copy_path ~ '\diff_tests-foo.txt'
+    - diff_content.diff.before == "baz\n"
+    - diff_content.diff.before_header == test_win_copy_path ~ '\diff_tests-foo.txt'
+
+- name: set local bin file paths
+  set_fact:
+    local_bin1: "{{ local_tmp.path ~ '/win_copy-bin1' }}"
+    local_bin2: "{{ local_tmp.path ~ '/win_copy-bin2' }}"
+
+# Binary tests use the first 8192 bytes so our second binary should just fit
+# and be detected as binary
+- name: create local binary files
+  shell:
+    cmd: >
+      printf 'abc\x00' > {{ local_bin1 | quote }} &&
+      printf '%8191s' '' | tr ' ' 'a' > {{ local_bin2 | quote }} &&
+      printf '\x00' >> {{ local_bin2 | quote }}
+  delegate_to: localhost
+
+- name: diff with binary replacing text
+  win_copy:
+    src: '{{ local_bin1 }}'
+    dest: '{{ test_win_copy_path }}\diff_tests-foo.txt'
+  register: diff_binary_replacing_text
+  diff: true
+
+- name: assert diff with binary replacing text
+  assert:
+    that:
+    - diff_binary_replacing_text.diff.src_binary == 1
+    - diff_binary_replacing_text.diff.before == 'this is some content'
+    - diff_binary_replacing_text.diff.before_header == test_win_copy_path ~ '\diff_tests-foo.txt'
+
+- name: diff with binary replacing binary
+  win_copy:
+    src: '{{ local_bin2 }}'
+    dest: '{{ test_win_copy_path }}\diff_tests-foo.txt'
+  register: diff_binary_replacing_binary
+  diff: true
+
+- name: assert diff with binary replacing binary
+  assert:
+    that:
+    - diff_binary_replacing_binary.diff.dst_binary == 1
+    - diff_binary_replacing_binary.diff.src_binary == 1
+
+- name: diff with text replacing binary
+  win_copy:
+    src: foo.txt
+    dest: '{{ test_win_copy_path }}\diff_tests-foo.txt'
+  register: diff_text_replacing_binary
+  diff: true
+
+- name: assert diff with text replacing binary
+  assert:
+    that:
+    - diff_text_replacing_binary.diff.after == 'foo.txt\n'
+    - diff_text_replacing_binary.diff.after_header == role_path ~ '/files/foo.txt'
+    - diff_text_replacing_binary.diff.dst_binary == 1

--- a/tests/integration/targets/win_copy/tasks/diff_tests.yml
+++ b/tests/integration/targets/win_copy/tasks/diff_tests.yml
@@ -64,9 +64,9 @@
 - name: create local binary files
   shell:
     cmd: >
-      printf 'abc\x00' > {{ local_bin1 | quote }} &&
+      printf 'abc\000' > {{ local_bin1 | quote }} &&
       printf '%8191s' '' | tr ' ' 'a' > {{ local_bin2 | quote }} &&
-      printf '\x00' >> {{ local_bin2 | quote }}
+      printf '\000' >> {{ local_bin2 | quote }}
   delegate_to: localhost
 
 - name: diff with binary replacing text

--- a/tests/integration/targets/win_copy/tasks/main.yml
+++ b/tests/integration/targets/win_copy/tasks/main.yml
@@ -20,15 +20,30 @@
     path: '{{test_win_copy_path}}'
     state: directory
 
+- name: create local temp directory
+  tempfile:
+    state: directory
+  register: local_tmp
+  delegate_to: localhost
+
 - block:
   - name: run tests for local to remote
     include_tasks: tests.yml
-  
+
   - name: run tests for remote to remote
     include_tasks: remote_tests.yml
+
+  - name: run diff tests
+    include_tasks: diff_tests.yml
 
   always:
   - name: remove test folder
     win_file:
       path: '{{test_win_copy_path}}'
       state: absent
+
+  - name: remove local temp directory
+    file:
+      path: '{{ local_tmp.path }}'
+      state: absent
+    delegate_to: localhost


### PR DESCRIPTION
##### SUMMARY
Diff-mode was not working, but is a crucial part of using Ansible.

Fixes #16
Fixes #512
Fixes ansible/ansible#34226

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_copy
win_template

##### ADDITIONAL INFORMATION
This implements the necessary parts in ansible.windows to support diff-mode.
I also have a fix to Ansible core to fix the diff when using 'content`parameter (dynamically generated) content.
See: ansible/ansible#87119