### PR TITLE
win_acl - add check mode support

### DIFF
--- a/changelogs/fragments/911-win_acl-check-mode.yml
+++ b/changelogs/fragments/911-win_acl-check-mode.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - win_acl - Add check mode support so the module reports whether changes
+    would be made without modifying ACL permissions
+    (https://github.com/ansible-collections/ansible.windows/issues/911).

--- a/plugins/modules/win_acl.ps1
+++ b/plugins/modules/win_acl.ps1
@@ -48,7 +48,8 @@ function Get-UserSID {
     return $userSID
 }
 
-$params = Parse-Args $args
+$params = Parse-Args $args -supports_check_mode $true
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
 
 Function SetPrivilegeTokens() {
     # Set privilege tokens only if admin.
@@ -239,16 +240,46 @@ Try {
     }
 
     If ($state -eq "present" -And $match -eq $false) {
-        Try {
-            $objACL.AddAccessRule($objACE)
-            if ($path_item.PSProvider.Name -eq "Certificate") {
-                $certSecurityHandle.Acl = $objACL
+        If (-not $check_mode) {
+            Try {
+                $objACL.AddAccessRule($objACE)
+                if ($path_item.PSProvider.Name -eq "Certificate") {
+                    $certSecurityHandle.Acl = $objACL
+                }
+                else {
+                    Try {
+                        Set-ACL -LiteralPath $path -AclObject $objACL
+                    }
+                    Catch {
+                        $fileObj = Get-Item -LiteralPath $path
+
+                        # Newer .NET versions use an extension method instead of an instance method.
+                        if ('System.IO.FileSystemAclExtensions' -as [Type]) {
+                            [System.IO.FileSystemAclExtensions]::SetAccessControl($fileObj, $objACL)
+                        }
+                        else {
+                            $fileObj.SetAccessControl($objACL)
+                        }
+                    }
+                }
             }
-            else {
-                Try {
+            Catch {
+                Fail-Json -obj $result -message "an exception occurred when adding the specified rule - $($_.Exception.Message)"
+            }
+        }
+        $result.changed = $true
+    }
+    ElseIf ($state -eq "absent" -And $match -eq $true) {
+        If (-not $check_mode) {
+            Try {
+                $objACL.RemoveAccessRule($objACE)
+                If ($path_item.PSProvider.Name -eq "Registry") {
                     Set-ACL -LiteralPath $path -AclObject $objACL
                 }
-                Catch {
+                elseif ($path_item.PSProvider.Name -eq "Certificate") {
+                    $certSecurityHandle.Acl = $objACL
+                }
+                else {
                     $fileObj = Get-Item -LiteralPath $path
 
                     # Newer .NET versions use an extension method instead of an instance method.
@@ -260,37 +291,11 @@ Try {
                     }
                 }
             }
-            $result.changed = $true
-        }
-        Catch {
-            Fail-Json -obj $result -message "an exception occurred when adding the specified rule - $($_.Exception.Message)"
-        }
-    }
-    ElseIf ($state -eq "absent" -And $match -eq $true) {
-        Try {
-            $objACL.RemoveAccessRule($objACE)
-            If ($path_item.PSProvider.Name -eq "Registry") {
-                Set-ACL -LiteralPath $path -AclObject $objACL
+            Catch {
+                Fail-Json -obj $result -message "an exception occurred when removing the specified rule - $($_.Exception.Message)"
             }
-            elseif ($path_item.PSProvider.Name -eq "Certificate") {
-                $certSecurityHandle.Acl = $objACL
-            }
-            else {
-                $fileObj = Get-Item -LiteralPath $path
-
-                # Newer .NET versions use an extension method instead of an instance method.
-                if ('System.IO.FileSystemAclExtensions' -as [Type]) {
-                    [System.IO.FileSystemAclExtensions]::SetAccessControl($fileObj, $objACL)
-                }
-                else {
-                    $fileObj.SetAccessControl($objACL)
-                }
-            }
-            $result.changed = $true
         }
-        Catch {
-            Fail-Json -obj $result -message "an exception occurred when removing the specified rule - $($_.Exception.Message)"
-        }
+        $result.changed = $true
     }
     Else {
         # A rule was attempting to be added but already exists

--- a/plugins/modules/win_acl.py
+++ b/plugins/modules/win_acl.py
@@ -75,6 +75,8 @@ options:
     default: false
     version_added: 1.12.0
 notes:
+- Supports C(check_mode). In check mode the module reports whether the specified
+  rule would be added or removed without modifying ACL permissions.
 - If adding ACL's for AppPool identities, the Windows Feature "Web-Scripting-Tools" must be enabled.
 seealso:
 - module: ansible.windows.win_acl_inheritance

--- a/tests/integration/targets/win_acl/tasks/tests.yml
+++ b/tests/integration/targets/win_acl/tasks/tests.yml
@@ -43,6 +43,26 @@
       Pop-Location
       ConvertTo-Json -InputObject @($ace_list)
 
+# Check mode tests - file system
+- name: add write rights to Guest - check mode
+  win_acl:
+    path: '{{ test_acl_path }}'
+    type: allow
+    user: Guests
+    rights: Write
+  check_mode: true
+  register: check_mode_add
+
+- name: get result of add write rights to Guest - check mode
+  win_shell: '$path = ''{{ test_acl_path }}''; {{ test_ace_cmd }}'
+  register: check_mode_add_actual
+
+- name: assert add write rights to Guest - check mode
+  assert:
+    that:
+    - check_mode_add is changed
+    - check_mode_add_actual.stdout_lines == ["[", "", "]"]
+
 - name: add write rights to Guest
   win_acl:
     path: '{{ test_acl_path }}'
@@ -78,6 +98,26 @@
   assert:
     that:
     - not allow_right_again is changed
+
+- name: remove write rights from Guest - check mode
+  win_acl:
+    path: '{{ test_acl_path }}'
+    type: allow
+    user: Guests
+    rights: Write
+    state: absent
+  check_mode: true
+  register: check_mode_remove
+
+- name: get result of remove write rights from Guest - check mode
+  win_shell: '$path = ''{{ test_acl_path }}''; {{ test_ace_cmd }}'
+  register: check_mode_remove_actual
+
+- name: assert remove write rights from Guest - check mode
+  assert:
+    that:
+    - check_mode_remove is changed
+    - (check_mode_remove_actual.stdout|from_json)|count == 1
 
 - name: remove write rights from Guest
   win_acl:
@@ -464,10 +504,16 @@
   check_mode: true
   register: add_fullcontrol_rights_on_certificate_check_mode
 
+- name: get result of add FullControl rights on certificate - check mode
+  win_shell: '$thumbprint = ''{{ test_acl_certificiate_cng_thumbprint }}''; {{ test_cert_ace_cmd }}'
+  register: add_fullcontrol_rights_on_certificate_check_mode_actual
+
 - name: assert add FullControl rights on certificate - check mode
   assert:
     that:
-    - not add_fullcontrol_rights_on_certificate_check_mode is changed
+    - add_fullcontrol_rights_on_certificate_check_mode is changed
+    - item.IdentityReference.Value != 'BUILTIN\Guests' or item.FileSystemRights != 2032127
+  with_items: '{{ add_fullcontrol_rights_on_certificate_check_mode_actual.stdout|from_json }}'
 
 - name: add FullControl rights on certificate
   win_acl:
@@ -516,7 +562,7 @@
 - name: assert remove FullControl rights on certificate - check mode
   assert:
     that:
-    - not remove_fullcontrol_rights_on_certificate_check_mode is changed
+    - remove_fullcontrol_rights_on_certificate_check_mode is changed
 
 - name: remove FullControl rights on certificate
   win_acl:


### PR DESCRIPTION
##### SUMMARY

Add check mode support to the `win_acl` module.

When run with `--check`, the module now queries the current ACL state and
reports whether a change *would* be made, without modifying any permissions.

Fixes #911

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

win_acl

##### ADDITIONAL INFORMATION

Previously, `win_acl` did not declare `supports_check_mode` and Ansible
skipped the task entirely during `--check` runs:

```
skipping: [host] => {"changed": false, "msg": "remote module does not support check mode"}
```

The module already performs a full comparison of the desired ACE against
existing ACL rules before deciding to add or remove. This change guards only
the write paths (`AddAccessRule`, `RemoveAccessRule`, `Set-ACL`,
`SetAccessControl`) behind `$check_mode`, so the diff/changed logic runs
identically in both normal and check mode.

Two prior PRs (#129, #197) attempted this but were closed due to scope.
This PR is scoped to check mode only.

**Changes:**

| File | Change |
|------|--------|
| `plugins/modules/win_acl.ps1` | Add `-supports_check_mode $true`, read `_ansible_check_mode`, guard write paths |
| `plugins/modules/win_acl.py` | Add check mode note to DOCUMENTATION |
| `tests/integration/targets/win_acl/tasks/tests.yml` | Add check mode test cases for file system and fix cert check mode assertions |
| `changelogs/fragments/911-win_acl-check-mode.yml` | Changelog fragment |