### PR TITLE
win_updates: Add assigned_only switch for WSUS environments

### DIFF
--- a/changelogs/fragments/win-updates-support-is-assigned-wsus.yml
+++ b/changelogs/fragments/win-updates-support-is-assigned-wsus.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - win_updates - Add the "is_assigned" parameter to only query WSUS servers for updates assigned to the specific host

--- a/changelogs/fragments/win-updates-support-is-assigned-wsus.yml
+++ b/changelogs/fragments/win-updates-support-is-assigned-wsus.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - win_updates - Add the "is_assigned" parameter to only query WSUS servers for updates assigned to the specific host
+  - win_updates - Add the ``assigned_only`` option to query WSUS servers for updates assigned to the specific host only

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -618,6 +618,7 @@ class ActionModule(ActionBase):
 
     _VALID_ARGS = [
         'accept_list',
+        'assigned_only',
         'category_names',
         'log_path',
         'reboot',

--- a/plugins/modules/win_updates.ps1
+++ b/plugins/modules/win_updates.ps1
@@ -1751,22 +1751,47 @@ namespace Ansible.Windows.WinUpdates
 
     $query = 'IsInstalled = 0'
     if ($AssignedOnly) {
+        $useAssigned = $false
         if ($ServerSelection -eq 'managed_server') {
-            # Narrow the server-side search to updates assigned/approved to this
-            # host by the managed update server (WSUS). Mirrors a manual WUA scan
-            # of 'IsInstalled=0 AND IsAssigned=1' and avoids pulling metadata for
-            # the entire non-installed catalog.
+            $useAssigned = $true
+        }
+        elseif ($ServerSelection -eq 'default') {
+            # Under 'default' the WUA uses whatever source the host is configured for.
+            # If the host is GPO-configured for a managed server (WSUS) then IsAssigned
+            # is meaningful, so honour assigned_only. Detect via the WindowsUpdate policy
+            # keys (UseWUServer = 1 and a WUServer set).
+            try {
+                $auKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey('SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate\AU')
+                $wuKey = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey('SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate')
+                $useWUServer = if ($auKey) { $auKey.GetValue('UseWUServer') } else { $null }
+                $wuServer = if ($wuKey) { $wuKey.GetValue('WUServer') } else { $null }
+                if ($auKey) { $auKey.Dispose() }
+                if ($wuKey) { $wuKey.Dispose() }
+                if (($useWUServer -eq 1) -and (-not [string]::IsNullOrEmpty($wuServer))) {
+                    $useAssigned = $true
+                    $api.WriteLog("'assigned_only': server_selection is 'default' but the host is " +
+                        "GPO-configured for a managed server (UseWUServer=1, WUServer='$wuServer'); " +
+                        "applying 'IsAssigned = 1'.")
+                }
+            }
+            catch {
+                $api.WriteLog("WARNING: 'assigned_only': could not inspect WindowsUpdate policy " +
+                    "registry to detect WSUS configuration: $($_.Exception.Message)")
+            }
+        }
+
+        if ($useAssigned) {
+            # Narrow the server-side search to updates assigned/approved to this host.
+            # Mirrors a manual WUA scan of 'IsInstalled=0 AND IsAssigned=1' and avoids
+            # pulling metadata for the entire non-installed catalog from the server.
             $query = "$query AND IsAssigned = 1"
         }
         else {
-            # IsAssigned only has a defined meaning against a managed server.
-            # Against Windows Update / Microsoft Update it can return an empty
-            # result, so ignore the option and warn instead of silently finding
-            # nothing.
-            $api.WriteLog("WARNING: 'assigned_only' is ignored because " +
-                "'server_selection' is '$ServerSelection', not 'managed_server'. " +
-                "IsAssigned only applies to a managed update server (for example
-		 WSUS).")
+            # IsAssigned only has a defined meaning against a managed server. Ignore the
+            # option and warn instead of risking an empty result against Windows Update.
+            $api.WriteLog("WARNING: 'assigned_only' is ignored because the host is not using " +
+                "a managed update server (server_selection='$ServerSelection' and no WSUS " +
+                "policy detected). 'IsAssigned' only applies to a managed server (e.g. WSUS).")
         }
     }
     $api.WriteLog("Searching for updates to install with query '$query'")

--- a/plugins/modules/win_updates.ps1
+++ b/plugins/modules/win_updates.ps1
@@ -22,6 +22,7 @@ $spec = @{
         server_selection = @{ type = 'str'; choices = 'default', 'managed_server', 'windows_update'; default = 'default' }
         state = @{ type = 'str'; choices = 'installed', 'searched', 'downloaded'; default = 'installed' }
         skip_optional = @{ type = 'bool'; default = $false }
+        assigned_only = @{ type = 'bool'; default = $false }
 
         # options used by the action plugin - ignored here
         reboot = @{ type = 'bool'; default = $false }
@@ -1083,6 +1084,10 @@ Function Install-WindowsUpdate {
         $SkipOptional,
 
         [Parameter()]
+        [Switch]
+        $AssignedOnly,
+
+        [Parameter()]
         [AllowEmptyCollection()]
         [String[]]
         $Reject = @(),
@@ -1745,6 +1750,24 @@ namespace Ansible.Windows.WinUpdates
     $api.WriteLog("Search source set to '$($ServerSelection)' (ServerSelection = $($serverSelectionValue))")
 
     $query = 'IsInstalled = 0'
+    if ($AssignedOnly) {
+        if ($ServerSelection -eq 'managed_server') {
+            # Narrow the server-side search to updates assigned/approved to this
+            # host by the managed update server (WSUS). Mirrors a manual WUA scan
+            # of 'IsInstalled=0 AND IsAssigned=1' and avoids pulling metadata for
+            # the entire non-installed catalog.
+            $query = "$query AND IsAssigned = 1"
+        }
+        else {
+            # IsAssigned only has a defined meaning against a managed server.
+            # Against Windows Update / Microsoft Update it can return an empty
+            # result, so ignore the option and warn instead of silently finding
+            # nothing.
+            $api.WriteLog("WARNING: 'assigned_only' is ignored because " +
+                "'server_selection' is '$ServerSelection', not 'managed_server'. " +
+                "IsAssigned only applies to a managed update server (e.g. WSUS).")
+        }
+    }
     $api.WriteLog("Searching for updates to install with query '$query'")
     $searchResult = Invoke-AsyncMethod 'Searching for updates' $api.SearchAsync($searcher, $query, $CancelToken)
     $resCode = [Ansible.Windows.WinUpdates.OperationResultCode]$searchResult.ResultCode
@@ -2142,6 +2165,7 @@ $updateParameters = @{
     ServerSelection = $module.Params.server_selection
     State = $module.Params.state
     SkipOptional = $module.Params.skip_optional
+    AssignedOnly = $module.Params.assigned_only
     TempPath = $module.Tmpdir
     CheckMode = $module.CheckMode
 }

--- a/plugins/modules/win_updates.ps1
+++ b/plugins/modules/win_updates.ps1
@@ -1765,7 +1765,8 @@ namespace Ansible.Windows.WinUpdates
             # nothing.
             $api.WriteLog("WARNING: 'assigned_only' is ignored because " +
                 "'server_selection' is '$ServerSelection', not 'managed_server'. " +
-                "IsAssigned only applies to a managed update server (e.g. WSUS).")
+                "IsAssigned only applies to a managed update server (for example
+		 WSUS).")
         }
     }
     $api.WriteLog("Searching for updates to install with query '$query'")

--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -45,6 +45,25 @@ options:
         type: bool
         default: no
         version_added: 1.8.0
+    assigned_only:
+        description:
+        - Limit the search to updates that are assigned (approved/deployed) to
+          the host by a managed update server such as WSUS.
+        - When V(true) and O(server_selection=managed_server), the underlying
+          Windows Update Agent search query is narrowed to
+          C(IsInstalled = 0 AND IsAssigned = 1) so the update server only returns
+          metadata for updates targeted at this host instead of the full
+          non-installed catalog.
+        - This mirrors a manual Windows Update / WUA scan and can avoid large
+          metadata transfers and errors such as C(0x80244010)
+          (WU_E_PT_EXCEEDED_MAX_SERVER_TRIPS) on hosts pointed at a WSUS server
+          that publishes a large catalog.
+        - The C(IsAssigned) criterion only has a defined meaning against a managed
+          update server. If O(server_selection) is not C(managed_server) this
+          option is ignored and a warning is written to the update log, because
+          against Windows Update / Microsoft Update it may return no updates.
+        type: bool
+        default: no
     reboot:
         description:
         - Ansible will automatically reboot the remote host if it is required

--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -64,6 +64,7 @@ options:
           against Windows Update / Microsoft Update it may return no updates.
         type: bool
         default: no
+        version_added: '3.7.0'
     reboot:
         description:
         - Ansible will automatically reboot the remote host if it is required

--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -49,19 +49,21 @@ options:
         description:
         - Limit the search to updates that are assigned (approved/deployed) to
           the host by a managed update server such as WSUS.
-        - When V(true) and O(server_selection=managed_server), the underlying
-          Windows Update Agent search query is narrowed to
-          C(IsInstalled = 0 AND IsAssigned = 1) so the update server only returns
-          metadata for updates targeted at this host instead of the full
-          non-installed catalog.
-        - This mirrors a manual Windows Update / WUA scan and can avoid large
-          metadata transfers and errors such as C(0x80244010)
-          (WU_E_PT_EXCEEDED_MAX_SERVER_TRIPS) on hosts pointed at a WSUS server
-          that publishes a large catalog.
-        - The C(IsAssigned) criterion only has a defined meaning against a managed
-          update server. If O(server_selection) is not C(managed_server) this
-          option is ignored and a warning is written to the update log, because
-          against Windows Update / Microsoft Update it may return no updates.
+        - When V(true) the underlying Windows Update Agent search query is
+          narrowed to C(IsInstalled = 0 AND IsAssigned = 1) so the update server
+          only returns metadata for updates targeted at this host instead of the
+          full non-installed catalog. This mirrors a manual Windows Update / WUA
+          scan and can avoid large metadata transfers and errors such as
+          C(0x80244010) (WU_E_PT_EXCEEDED_MAX_SERVER_TRIPS) on hosts pointed at a
+          WSUS server that publishes a large catalog.
+        - The narrowing is applied when O(server_selection=managed_server), and
+          also when O(server_selection=default) if the host is GPO-configured for
+          a managed server (registry C(UseWUServer=1) and C(WUServer) set under
+          C(HKLM\SOFTWARE\Policies\Microsoft\Windows\WindowsUpdate)).
+        - If neither condition is met (for example O(server_selection=windows_update),
+          or C(default) with no WSUS policy) the option is ignored and a warning is
+          written to the update log, because C(IsAssigned) only has a defined
+          meaning against a managed update server and may otherwise return no updates.
         type: bool
         default: no
         version_added: '3.7.0'


### PR DESCRIPTION
##### SUMMARY
In environments using WSUS, the WSUS server can pre-select updates for a given client. The client may resort to looking for assigned patches in WSUS only, avoiding to overload the WSUS server or to run into the WSUS roundtrip limit, which is set to 200. This patch adds the corresponding parameter to use when using the module.

Investigations in a local setup lead to noticing that freshly delpoyed systems, when told to install Windows updates from WSUS through Ansible, would regularly corrupt their local update database. Numerous reports all over the web confirm this behaviour (cf. https://www.codeschoepfer.de/en/installing-updates-on-windows-server-systems-using-ansible/ and others). We've seen the effect of the client showing the error message 0x80244010, indicating having exceeded the WSUS server's roundtrip limit for individual queries.

A comparison of the current update handling of win_updates with a script used locally unveiled a possibly relevant difference: Said local script would allow to limit the search focus for WSUS on updates generally pre-selected by WSUS for the specific client. I am not 100% sure that this patch will actually fix the issue of corrupted local update caches, but being able to limit the updates to download to those pre-selected by WSUS for the client is not a bad thing one way or another.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
win_updates
