### PR TITLE
Fix DomainInfo when LanmanWorkstation service is stopped/disabled (hardened Windows)

### DIFF
--- a/changelogs/fragments/915-setup-lanmanworkstation.yml
+++ b/changelogs/fragments/915-setup-lanmanworkstation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - setup - Fix DomainInfo collection when LanmanWorkstation service is stopped or disabled on hardened Windows systems (https://github.com/ansible-collections/ansible.windows/pull/915)

--- a/changelogs/fragments/915-setup-lanmanworkstation.yml
+++ b/changelogs/fragments/915-setup-lanmanworkstation.yml
@@ -1,2 +1,3 @@
 bugfixes:
-  - setup - Fix DomainInfo collection when LanmanWorkstation service is stopped or disabled on hardened Windows systems (https://github.com/ansible-collections/ansible.windows/pull/915)
+  - setup - Fix DomainInfo collection when LanmanWorkstation service is stopped or disabled
+    on hardened Windows systems (https://github.com/ansible-collections/ansible.windows/pull/915).

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -66,6 +66,7 @@ $currentUser = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsI
 $isAdmin = $currentUser.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 
 Add-CSharpType -AnsibleModule $module -References @'
+using Microsoft.win32;
 using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections.Generic;
@@ -322,6 +323,20 @@ namespace Ansible.Windows.Setup
             {
                 SafeNetAPIBuffer netBuffer;
                 res = NativeMethods.NetWkstaGetInfo(null, 100, out netBuffer);
+
+                // Hardened systems may have the LanmanWorkstation service disabled
+                if (res == 2138)  // NERR_WkstaNotStarted
+                {
+                    using (RegistryKey key = Registry.LocalMachine.OpenSubKey(@"SYSTEM\CurrentControlSet\Services\LanmanWorkstation\Parameters"))
+                    {
+                        if (key != null)
+                            Domain = key.GetValue("Workgroup", String.Empty).ToString();
+                        else
+                            Domain = String.Empty;
+                    }
+                    return;
+                }
+                
                 if (res != 0)
                     throw new Win32Exception(res, "Failed to get workstation information");
 

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -66,7 +66,7 @@ $currentUser = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsI
 $isAdmin = $currentUser.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 
 Add-CSharpType -AnsibleModule $module -References @'
-using Microsoft.win32;
+using Microsoft.Win32;
 using Microsoft.Win32.SafeHandles;
 using System;
 using System.Collections.Generic;

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -318,7 +318,6 @@ namespace Ansible.Windows.Setup
                 PartOfDomain = !String.IsNullOrEmpty(Domain);
             }
 
-
             if (!PartOfDomain)
             {
                 SafeNetAPIBuffer netBuffer;
@@ -336,7 +335,7 @@ namespace Ansible.Windows.Setup
                     }
                     return;
                 }
-                
+
                 if (res != 0)
                     throw new Win32Exception(res, "Failed to get workstation information");
 


### PR DESCRIPTION
##### SUMMARY
On a hardened Windows system the LanmanWorkstation service is stopped or disabled, and this is causing an ugly exception to be shown twice during facts gathering. Since this is a deliberate act, we should ignore this and return what we can.

Because of the exception, the setup module returns:
```yaml
    ansible_windows_domain: null
    ansible_windows_domain_member: null
    ansible_windows_domain_role: Unknown DomainRole
```

After this change, it returns:
```yaml
    ansible_windows_domain: ''
    ansible_windows_domain_member: false
    ansible_windows_domain_role: Stand-alone server
```



##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup.ps1

##### ADDITIONAL INFORMATION
This exception is occurring twice, during platform and windows_domain facts gathering.

```paste below
[WARNING]: Error when collecting platform facts: New-Object : Exception calling ".ctor" with "0" argument(s): "Failed to get workstation information (The Workstation service has not been started, Win32ErrorCode 2138 - 0x0000085A)"
At line: 9 char:27
+ ....   $domainInfo = New-Object-TypeName Ansible.Windows.Setup.DomainInfo
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo : InvalidOperation: (:) [New-Object], MethodInvocationException
+ FullyQualifiedErrorId : ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand at <ScriptBlock>, <No file>: line 9

[WARNING]: Error when collecting windows_domain facts: New-Object : Exception calling ".ctor" with "0" argument(s): "Failed to get workstation information (The Workstation service has not been started, Win32ErrorCode 2138 - 0x0000085A)"
At line: 2 char:27
+ ....   $domainInfo = New-Object-TypeName Ansible.Windows.Setup.DomainInfo
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo : InvalidOperation: (:) [New-Object], MethodInvocationException
+ FullyQualifiedErrorId : ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand at <ScriptBlock>, <No file>: line 2
```
