### PR TITLE
Ensure ansible_domain is also set when not domain-joined

### DIFF
--- a/changelogs/fragments/setup-ansible-domain-standalone.yml
+++ b/changelogs/fragments/setup-ansible-domain-standalone.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >-
+    setup - Ensure the ``ansible_domain`` fact has the DNS domain name the host is registered with through the IP
+    properties. In the past we only returned a value for this fact when the host was joined to an Active Directory
+    domain - https://github.com/ansible-collections/ansible.windows/pull/917

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -928,7 +928,15 @@ $factMeta = @(
             if ($ipProps.DomainName) {
                 $fqdn = "$($fqdn).$($ipProps.DomainName)"
             }
-            $domainSuffix = if ($domainInfo.PartOfDomain) { [string]$domainInfo.Domain } elseif ($ipProps.DomainName) { [string]$ipProps.DomainName } else { '' }
+            $domainSuffix = if ($domainInfo.PartOfDomain) {
+                [string]$domainInfo.Domain
+            }
+            elseif ($ipProps.DomainName) {
+                [string]$ipProps.DomainName
+            }
+            else {
+                ''
+            }
 
             $ownerParams = @{
                 LiteralPath = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion'

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -928,7 +928,7 @@ $factMeta = @(
             if ($ipProps.DomainName) {
                 $fqdn = "$($fqdn).$($ipProps.DomainName)"
             }
-            $domainSuffix = if ($domainInfo.PartOfDomain) { [string]$domainInfo.Domain } else { "" }
+            $domainSuffix = if ($domainInfo.PartOfDomain) { [string]$domainInfo.Domain } elseif ($ipProps.DomainName) { [string]$ipProps.DomainName } else { '' }
 
             $ownerParams = @{
                 LiteralPath = 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion'


### PR DESCRIPTION
##### SUMMARY
Currently, we only get an ansible_domain when we are domain-joined. But this is incorrect.

The AD domain is set in ansible_windows_domain, the DNS domain is set in ansible_domain.

When domain-joined this is typically the same, but a stand-alone system should also have its domain set.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup.ps1