### PR TITLE
Ensure ansible_machine_id works when LanmanServer is stopped/disabled (hardened Windows)

### DIFF
--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -920,7 +920,18 @@ $factMeta = @(
                 $groupMembers.Dispose()
             }
             catch {
-                $module.Warn("Error during machine sid retrieval: $($_.Exception.Message)")
+                if ($_.Exception.ToString() -match 'Server service is not started') {
+                    $admin = Get-CimInstance Win32_UserAccount -Filter "LocalAccount=True AND SID LIKE '%-500'"
+                    if ($admin) {
+                        $machineSid = ($admin.SID -replace '-500$')
+                    }
+                    else {
+                        $module.Warn('Error retrieving machine sid from Win32_UserAccount')
+                    }
+                }
+                else {
+                    $module.Warn("Error during machine sid retrieval: $($_.Exception.Message)")
+                }
             }
 
             $ipProps = [System.Net.NetworkInformation.IPGlobalProperties]::GetIPGlobalProperties()


### PR DESCRIPTION
##### SUMMARY
On a hardened Windows OS, the LanManserver service may be stopped or disabled, this will cause an exception when trying to retrieve the machine id.

This fix will try an alternative implementation when this occurs. This was tested on a hardened server affected by this bug.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup.ps1

##### ADDITIONAL INFORMATION
The following exception would be thrown on a hardened system:
```powershell
    [WARNING]: Error during machine sid retrieval: Exception calling ".ctor" with "2" argument(s): "The service is not started.  "
```