### PR TITLE
Fix typo in SMBIOS version check

### DIFF
--- a/changelogs/fragments/setup-smbios-proc-count.yml
+++ b/changelogs/fragments/setup-smbios-proc-count.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >-
+    setup - Fix logic for checking SMBIOS version for ``ansible_processor_*`` facts when the host's SMBIOS version was
+    greater than ``2.4`` but less than ``3.0`` -
+    https://github.com/ansible-collections/ansible.windows/pull/919

--- a/plugins/modules/setup.ps1
+++ b/plugins/modules/setup.ps1
@@ -444,7 +444,7 @@ namespace Ansible.Windows.Setup
 
                         // SMBIOS 2.5 is when the core and thread count fields
                         // were added.
-                        if (rawData.SMBIOSMajorVersion > 3 || (rawData.SMBIOSMajorVersion == 2 && rawData.SMBIOSMajorVersion > 4))
+                        if (rawData.SMBIOSMajorVersion > 3 || (rawData.SMBIOSMajorVersion == 2 && rawData.SMBIOSMinorVersion > 4))
                         {
                             if ((header.Length - headerSize) >= 34)
                             {


### PR DESCRIPTION
##### SUMMARY
Without this change, any SMBIOS version lower than v3.0 (and higher than v2.4) would still not be considered for CPU core and thread count fields.

On our hardened KVM-based  systems, this would result in and **Get-CimInstance : Access Denied** on accessing Win32_Processor and subsequently a n **Attempted to divide by zero** exception.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
setup.ps1

##### ADDITIONAL INFORMATION
Without this change we get the below exceptions on hardened Windows OS running on a KVM-based server running SMBIOS v2.8:
```paste below
[WARNING]: Error when collecting processor facts: Get-CimInstance : Access Denied
At line:41 char:30
+ ... win32Proc = Get-CimInstance -ClassName Win32_Processor -Property Numb ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo : PermissionDenied: (:) [Get-CimInstance], CimException
+ FullyQualifiedErrorId : HRESULT 0x80041003, Microsoft.Management.Infrastructure.CimCmdlets.GetCimInstanceCommand at <ScriptBlock>, <No file>: line 41

[WARNING]: Error when collecting processor facts: Attempted to divide by zero
At line 44 char:17
+ ...$ansibleFacts.ansible_processor_threads_per_core = $win32 ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo : NotSPecified: (:) [], RuntimeException
+ FullyQualifiedErrorId : RuntimeException    at <ScriptBlock>, <No file>: line 44
```