### PR TITLE
reboot: Replace deprecated datetime.datetime.utcnow()

### DIFF
--- a/changelogs/fragments/reboot-utcnow-deprecation.yml
+++ b/changelogs/fragments/reboot-utcnow-deprecation.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - reboot - Replace deprecated ``datetime.datetime.utcnow()`` with ``datetime.now(timezone.utc)``
+    for Python 3.12+ compatibility.

--- a/plugins/plugin_utils/_reboot.py
+++ b/plugins/plugin_utils/_reboot.py
@@ -15,13 +15,14 @@ interface is not final and count be subject to change.
 # Please open an issue if you have questions about this.
 
 import base64
-import datetime
 import json
 import random
 import time
 import traceback
 import uuid
 import typing as t
+
+from datetime import datetime, timedelta, timezone
 
 from ansible.errors import AnsibleConnectionFailure, AnsibleError
 from ansible.module_utils.common.text.converters import to_text
@@ -221,7 +222,7 @@ ConvertTo-Json -Compress -InputObject @{
     try:
         _perform_reboot(task_action, connection, reboot_command)
 
-        start = datetime.datetime.utcnow()
+        start = datetime.now(timezone.utc)
         result["changed"] = True
         result["rebooted"] = True
 
@@ -283,7 +284,7 @@ ConvertTo-Json -Compress -InputObject @{
         result["exception"] = traceback.format_exc()
 
     if start:
-        elapsed = datetime.datetime.utcnow() - start
+        elapsed = datetime.now(timezone.utc) - start
         result["elapsed"] = elapsed.seconds
 
     return result
@@ -350,10 +351,10 @@ def _do_until_success_or_timeout(
     **kwargs: t.Any,
 ) -> t.Optional[T]:
     """Runs the function multiple times ignoring errors until a timeout occurs"""
-    max_end_time = datetime.datetime.utcnow() + datetime.timedelta(seconds=timeout)
+    max_end_time = datetime.now(timezone.utc) + timedelta(seconds=timeout)
 
     def wait_condition(idx):
-        return datetime.datetime.utcnow() < max_end_time
+        return datetime.now(timezone.utc) < max_end_time
 
     try:
         return _do_until_success_or_condition(


### PR DESCRIPTION
##### SUMMARY

* Replace deprecated ``datetime.datetime.utcnow()`` with ``datetime.now(timezone.utc)``
  for Python 3.12+ compatibility.

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/reboot-utcnow-deprecation.yml
plugins/plugin_utils/_reboot.py


