### PR TITLE
win_package - Use proper filename for HTTP URLs

### DIFF
--- a/changelogs/fragments/win_package-url-filename.yml
+++ b/changelogs/fragments/win_package-url-filename.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >-
+    win_package - Favour the HTTP response's ``Content-Disposition`` for the temporary filename when downloading a
+    the temporary package from a URL. This ensures the package detection mechanism on the file extension continues
+    to work - https://github.com/ansible-collections/ansible.windows/issues/503

--- a/plugins/modules/win_package.ps1
+++ b/plugins/modules/win_package.ps1
@@ -437,6 +437,8 @@ Function Add-SystemReadAce {
 }
 
 Function Get-UrlFile {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingEmptyCatchBlock', '',
+        Justification = 'Failing to parse CD header is not critical')]
     [CmdletBinding()]
     param (
         [Parameter(Mandatory = $true)]
@@ -452,7 +454,28 @@ Function Get-UrlFile {
     Invoke-AnsibleWindowsWebRequest -Module $module -Request $request -Script {
         Param ([System.Net.WebResponse]$Response, [System.IO.Stream]$Stream)
 
-        $tempPath = Join-Path -Path $module.Tmpdir -ChildPath $Response.ResponseUri.Segments[-1]
+        $fileName = $Response.ResponseUri.Segments[-1]
+
+        # We use the Content-Disposition header to determine the proper filename.
+        # The extension used is important in later checks for determining what
+        # type of package it is and the URI in the response may not have the
+        # expected filename. If this fails we fallback to the last segment of
+        # the URI like we did in the past.
+        # https://github.com/ansible-collections/ansible.windows/issues/503
+        $contentDisposition = $Response.Headers['Content-Disposition']
+        if ($contentDisposition) {
+            try {
+                $parsedContentDisposition = [System.Net.Mime.ContentDisposition]::new($contentDisposition)
+                if ($parsedContentDisposition.FileName) {
+                    # Ensure the filename is unique by including a random prefix
+                    $randomName = [IO.Path]::GetRandomFileName()
+                    $fileName = "$randomName-$($parsedContentDisposition.FileName)"
+                }
+            }
+            catch {}
+        }
+
+        $tempPath = Join-Path -Path $module.Tmpdir -ChildPath $fileName
         $fs = [System.IO.File]::Create($tempPath)
         try {
             $Stream.CopyTo($fs)


### PR DESCRIPTION
##### SUMMARY
Use the `Content-Disposition` value when downloading a HTTP package. This is important as the response URI used currently may not have a valid extension and both the module and Windows uses that when determining how to run such a package.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/503

Creating a test for this could be possible but would require spawning a background process for the HTTP server or relying on a 3rd party service. The former can be unreliable in CI and could result in flaky tests.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_package