### PR TITLE
win_updates - try to improve testing

### DIFF
--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -656,6 +656,7 @@ class ActionModule(ActionBase):
         'reject_list',
         'server_selection',
         'state',
+        '_operation',  # Internal use only. Used in CI tests
     ]
 
     DEFAULT_REBOOT_TIMEOUT = 1200
@@ -692,12 +693,21 @@ class ActionModule(ActionBase):
 
         module_options = self._task.args.copy()
 
+        operation_val = module_options.pop('_operation', None)
+        for_testing = False
+        if operation_val == 'test':
+            for_testing = True
+        elif operation_val is not None:
+            raise AnsibleActionFail("_operation is an internal option and cannot be set")
+
         if self._task.async_val > 0:
             if reboot:
                 raise AnsibleActionFail("async is not supported for this task when reboot=yes")
 
             # When running in async the module itself waits for the result and formats the results.
+            module_options['_operation'] = 'test' if for_testing else 'start'
             module_options['_operation_options'] = {"wait": True}
+
             result = self._execute_module(
                 module_name='ansible.windows.win_updates',
                 module_args=module_options,
@@ -706,7 +716,7 @@ class ActionModule(ActionBase):
 
         else:
             try:
-                result = self._run_sync(task_vars, module_options, reboot, reboot_timeout)
+                result = self._run_sync(task_vars, module_options, reboot, reboot_timeout, for_testing=for_testing)
             except Exception as e:
                 result = {}
                 if isinstance(e, _ReturnResultException):
@@ -754,7 +764,8 @@ class ActionModule(ActionBase):
 
         return result
 
-    def _run_sync(self, task_vars, module_options, reboot, reboot_timeout):  # type: (Dict, Dict, bool, int) -> Dict
+    def _run_sync(self, task_vars, module_options, reboot, reboot_timeout, for_testing=False):
+        # type: (Dict, Dict, bool, int, bool) -> Dict
         """Installs the updates in a synchronous fashion with multiple update invocations if needed."""
         # In case we are running with become we need to make sure the module uses the correct dir
         result = {
@@ -769,7 +780,7 @@ class ActionModule(ActionBase):
             round += 1
             display.v("Running win_updates - round %s" % round, host=task_vars.get('inventory_hostname', None))
 
-            update_result = self._run_updates(task_vars, module_options)
+            update_result = self._run_updates(task_vars, module_options, for_testing=for_testing)
 
             self._updates.update(update_result.updates)
             self._filtered_updates.update(update_result.filtered_updates)
@@ -874,14 +885,15 @@ class ActionModule(ActionBase):
 
         return result
 
-    def _run_updates(self, task_vars, module_options):
-        # type: (Dict, Dict) -> UpdateResult
+    def _run_updates(self, task_vars, module_options, for_testing=False):
+        # type: (Dict, Dict, bool) -> UpdateResult
         """Runs the win_updates module and returns the raw results from that task."""
         inventory_hostname = task_vars.get('inventory_hostname', None)
 
         display.vv("Starting update task", host=inventory_hostname)
         start_result = self._execute_win_updates(
             task_vars=task_vars,
+            operation="test" if for_testing else "start",
             module_options=module_options,
         )
         cancel_options = start_result.pop('cancel_options', {})

--- a/plugins/modules/win_updates.ps1
+++ b/plugins/modules/win_updates.ps1
@@ -26,7 +26,7 @@ $spec = @{
         # options used by the action plugin - ignored here
         reboot = @{ type = 'bool'; default = $false }
         reboot_timeout = @{ type = 'int'; default = 1200 }
-        _operation = @{ type = 'str'; choices = 'start', 'cancel', 'poll'; default = 'start' }
+        _operation = @{ type = 'str'; choices = 'start', 'cancel', 'poll', 'test'; default = 'start' }
         _operation_options = @{ type = 'dict' }
     }
     supports_check_mode = $true
@@ -1095,7 +1095,10 @@ Function Install-WindowsUpdate {
         $CheckMode,
 
         [Switch]
-        $LocalDebugger
+        $LocalDebugger,
+
+        [Switch]
+        $ForTesting
     )
 
     Add-CSharpType -TempPath $TempPath -References @'
@@ -1770,6 +1773,15 @@ namespace Ansible.Windows.WinUpdates
     $searcher.ServerSelection = $serverSelectionValue
     $api.WriteLog("Search source set to '$($ServerSelection)' (ServerSelection = $($serverSelectionValue))")
 
+    if ($ForTesting) {
+        # We use this for testing in CI to avoid actually talking to the WU
+        # endpoint. We've found the service is flaky and times out often enough
+        # to cause test failures. Instead we just test that we can access WUA
+        # in our custom wrapper.
+        $api.WriteProgress('exit', $exitResult)
+        return
+    }
+
     $query = 'IsInstalled = 0'
     $api.WriteLog("Searching for updates to install with query '$query'")
     $searchResult = Invoke-AsyncMethod 'Searching for updates' $api.SearchAsync($searcher, $query, $CancelToken)
@@ -2170,6 +2182,7 @@ $updateParameters = @{
     SkipOptional = $module.Params.skip_optional
     TempPath = $module.Tmpdir
     CheckMode = $module.CheckMode
+    ForTesting = $module.Params._operation -eq 'test'
 }
 $wait = [bool]$module.Params._operation_options.wait
 

--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -105,6 +105,7 @@ options:
         - start
         - cancel
         - poll
+        - test
         default: start
     _operation_options:
         description:

--- a/tests/integration/targets/win_updates/tasks/main.yml
+++ b/tests/integration/targets/win_updates/tasks/main.yml
@@ -38,6 +38,10 @@
     - async_reboot_fail is failed
     - async_reboot_fail.msg == 'async is not supported for this task when reboot=yes'
 
+# We do at least 1 run not with _operation: test to ensure the logic for
+# searching and polling is sound. The rest of the tests skip this to speed up
+# the CI runs and avoid flaky failure due to the WUA service being unreliable
+# in CI.
 - name: expect failure when state is not a valid option
   win_updates:
     state: invalid
@@ -54,6 +58,7 @@
   win_updates:
     category_names: '*'
     state: searched
+    _operation: test
   register: search_async
   async: 60
 
@@ -61,6 +66,7 @@
   win_updates:
     category_names: '*'
     state: searched
+    _operation: test
   register: search_become
   become: yes
   become_method: runas
@@ -70,6 +76,7 @@
   win_updates:
     category_names: '*'
     state: searched
+    _operation: test
   register: search_async_and_become
   async: 60
   become: yes
@@ -110,6 +117,7 @@
     - UpdateRollups
     state: searched
     log_path: '{{ remote_tmp_dir }}\update.log'
+    _operation: test
   register: search_check
   check_mode: yes
 
@@ -141,12 +149,14 @@
     win_updates:
       category_names: '*'
       state: searched
+      _operation: test
     register: search_sync
 
   - name: search for all updates with async without batch logon
     win_updates:
       category_names: '*'
       state: searched
+      _operation: test
     register: search_async
     async: 60
 


### PR DESCRIPTION
##### SUMMARY
Try to improve the stability of the win_updates CI tests by avoiding subsequent checks on the search API. Instead we test that scenario once and include a flag that can exit early once we've verified the WUA API is accessible and our module wrapper works properly.

##### ISSUE TYPE
- Test Pull Request