### PR TITLE
Fix win_template error handling

### DIFF
--- a/changelogs/fragments/win_template-error-handling.yml
+++ b/changelogs/fragments/win_template-error-handling.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    win_template - Fix issue where errors during templating, like an undefined variable, were ignored and the task
+    continued without a failure - https://github.com/ansible-collections/ansible.windows/issues/926

--- a/plugins/action/win_template.py
+++ b/plugins/action/win_template.py
@@ -20,7 +20,7 @@ from jinja2.defaults import (
 
 from ansible import constants as C
 from ansible.config.manager import ensure_type
-from ansible.errors import AnsibleError, AnsibleFileNotFound, AnsibleAction, AnsibleActionFail
+from ansible.errors import AnsibleError, AnsibleFileNotFound, AnsibleActionFail
 from ansible.module_utils.common.text.converters import to_bytes, to_text, to_native
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action import ActionBase

--- a/plugins/action/win_template.py
+++ b/plugins/action/win_template.py
@@ -200,10 +200,6 @@ class ActionModule(ActionBase):
                         escape_backslashes=False,
                         overrides=overrides,
                     )
-            except AnsibleAction:
-                raise
-            except Exception as e:
-                raise AnsibleActionFail("%s: %s" % (type(e).__name__, to_text(e)))
             finally:
                 self._loader.cleanup_tmp_file(b_tmp_source)
 
@@ -238,8 +234,6 @@ class ActionModule(ActionBase):
             finally:
                 shutil.rmtree(to_bytes(local_tempdir, errors='surrogate_or_strict'))
 
-        except AnsibleAction as e:
-            result.update(e.result)
         finally:
             self._remove_tmp_path(self._connection._shell.tmpdir)
 

--- a/tests/integration/targets/win_template/tasks/main.yml
+++ b/tests/integration/targets/win_template/tasks/main.yml
@@ -291,3 +291,16 @@
     that:
     - actual_managed_default is contains expected_managed_default
     - actual_managed_override is contains expected_managed_override
+
+- name: expect error with invalid template
+  win_template:
+    src: invalid.j2
+    dest: '{{ remote_tmp_dir }}/invalid.templated'
+  register: template_result_invalid
+  ignore_errors: true
+
+- name: verify that the invalid template failure message
+  assert:
+    that:
+    - template_result_invalid is failed
+    - template_result_invalid.msg is search("'undefined_var' is undefined")

--- a/tests/integration/targets/win_template/templates/invalid.j2
+++ b/tests/integration/targets/win_template/templates/invalid.j2
@@ -1,0 +1,1 @@
+var: {{ undefined_var }}


### PR DESCRIPTION
##### SUMMARY
Fixed the error handling in win_template that caused errors to be ignored and the task not report any failures. This was due to a change in the underlying task result and exception handler added in register projections. Simple fix is to just not wrap exceptions in a custom handler and continue to raise them like normal.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/926

##### ISSUE TYPE
- Bugfix Pull Request