### PR TITLE
win_updates - Add maximum_retries_on_failed_updates option

### DIFF
--- a/changelogs/fragments/06082026-win-updates-rollback-attempts.yml
+++ b/changelogs/fragments/06082026-win-updates-rollback-attempts.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - win_updates - Add maximum_retries_on_failed_updates option to control how many attempts the module
+    can take at installing a rolled back update.
+    (Fixes https://github.com/ansible-collections/ansible.windows/issues/762)

--- a/plugins/action/win_updates.py
+++ b/plugins/action/win_updates.py
@@ -656,6 +656,7 @@ class ActionModule(ActionBase):
         'reject_list',
         'server_selection',
         'state',
+        'maximum_retries_on_failed_updates',
         '_operation',  # Internal use only. Used in CI tests
     ]
 
@@ -775,10 +776,11 @@ class ActionModule(ActionBase):
         }
         installed_updates = set()
         has_rebooted_on_failure = False
-        round = 0
+        attempt_round = 0
+        attempt_rolled_back_round = 0
         while True:
-            round += 1
-            display.v("Running win_updates - round %s" % round, host=task_vars.get('inventory_hostname', None))
+            attempt_round += 1
+            display.v("Running win_updates - round %s" % attempt_round, host=task_vars.get('inventory_hostname', None))
 
             update_result = self._run_updates(task_vars, module_options, for_testing=for_testing)
 
@@ -795,7 +797,10 @@ class ActionModule(ActionBase):
             new_updates = current_updates.difference(installed_updates)
             installed_updates.update(current_updates)
 
-            if current_updates and not new_updates:
+            if (current_updates and not new_updates):
+                attempt_rolled_back_round += 1
+
+            if attempt_rolled_back_round >= module_options.get('maximum_retries_on_failed_updates', 1):
                 for update_id in current_updates:
                     self._install_results[update_id]['result_code'] = 4
                     self._install_results[update_id]['hresult'] = -1

--- a/plugins/modules/win_updates.ps1
+++ b/plugins/modules/win_updates.ps1
@@ -26,6 +26,7 @@ $spec = @{
         # options used by the action plugin - ignored here
         reboot = @{ type = 'bool'; default = $false }
         reboot_timeout = @{ type = 'int'; default = 1200 }
+        maximum_retries_on_failed_updates = @{ type = 'int'; default = 1 }
         _operation = @{ type = 'str'; choices = 'start', 'cancel', 'poll', 'test'; default = 'start' }
         _operation_options = @{ type = 'dict' }
     }

--- a/plugins/modules/win_updates.py
+++ b/plugins/modules/win_updates.py
@@ -45,6 +45,18 @@ options:
         type: bool
         default: no
         version_added: 1.8.0
+    maximum_retries_on_failed_updates:
+        description:
+        - The maximum number of times the module will attempt to install an
+          update that appears to have been rolled back or not applied after a
+          reboot.
+        - Some updates, particularly feature updates, may require multiple
+          install attempts before completing successfully.
+        - This is only used when C(reboot=true) and the module detects the
+          same updates being reported as available after a reboot cycle.
+        type: int
+        default: 1
+        version_added: 3.8.0
     reboot:
         description:
         - Ansible will automatically reboot the remote host if it is required


### PR DESCRIPTION
##### SUMMARY
Adds a new `maximum_retries_on_failed_updates` option to `win_updates` that controls how many times the module will attempt to install an update that appears to have been rolled back or not applied after a reboot cycle.

Some updates, particularly Windows feature updates, may require multiple install attempts before completing successfully. Previously, the module would immediately fail with an "update loop detected" error on the first occurrence of a rolled-back update. This option allows users to configure the number of retry attempts before the module gives up.

The default value of `1` aligns with the module's current behavior.

Fixes: https://github.com/ansible-collections/ansible.windows/issues/762

##### ISSUE TYPE
- Feature Pull Request