### PR TITLE
Add win_reboot_info module

### DIFF
--- a/changelogs/fragments/06082026-win_reboot_info.yml
+++ b/changelogs/fragments/06082026-win_reboot_info.yml
@@ -1,4 +1,0 @@
----
-minor_changes:
-  - win_reboot_info - Add module to gather information about the last reboot and any pending
-    reboots

--- a/changelogs/fragments/06082026-win_reboot_info.yml
+++ b/changelogs/fragments/06082026-win_reboot_info.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - win_reboot_info - Add module to gather information about the last reboot and any pending
+    reboots

--- a/plugins/modules/win_reboot_info.ps1
+++ b/plugins/modules/win_reboot_info.ps1
@@ -1,0 +1,183 @@
+#!powershell
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+
+function Get-LastBootTime {
+    param([Ansible.Basic.AnsibleModule]$Module)
+
+    try {
+        $epochStart = New-Object -TypeName DateTime -ArgumentList @(1970, 1, 1, 0, 0, 0, [DateTimeKind]::Utc)
+        $lastBoot = (Get-CimInstance -ClassName Win32_OperatingSystem -Property LastBootUpTime).LastBootUpTime
+        $utcBoot = $lastBoot.ToUniversalTime()
+
+        return @{
+            last_boot_time = $utcBoot.ToString("yyyy-MM-ddTHH:mm:ssZ")
+            last_boot_time_epoch = (New-TimeSpan -Start $epochStart -End $utcBoot).TotalSeconds
+            utc_datetime = $utcBoot
+        }
+    }
+    catch {
+        $Module.FailJson("Failed to get last boot time from CIM: $($_.Exception.Message)")
+    }
+}
+
+function Get-LastRebootEvent {
+    param(
+        [Ansible.Basic.AnsibleModule]$Module,
+        [DateTime]$BootTime
+    )
+
+    try {
+        $rebootEvent = Get-WinEvent -FilterHashtable @{
+            LogName = 'System'
+            Id = 1074
+        } -MaxEvents 1 -ErrorAction SilentlyContinue
+
+        if ($rebootEvent) {
+            $eventTime = $rebootEvent.TimeCreated.ToUniversalTime()
+            if ($eventTime -lt $BootTime.AddMinutes(-5)) {
+                return $null
+            }
+
+            return @{
+                process = $rebootEvent.Properties[0].Value
+                reason = $rebootEvent.Properties[2].Value
+                type = $rebootEvent.Properties[4].Value
+                comment = $rebootEvent.Properties[5].Value
+                initiated_by = $rebootEvent.Properties[6].Value
+                event_time = $eventTime.ToString("yyyy-MM-ddTHH:mm:ssZ")
+            }
+        }
+    }
+    catch {
+        $Module.Warn("Failed to query the System event log for reboot events: $($_.Exception.Message)")
+    }
+
+    return $null
+}
+
+function Test-ComponentBasedServicing {
+    $cbsPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending'
+    if (Test-Path -LiteralPath $cbsPath) {
+        return @{
+            source = 'component_based_servicing'
+            description = 'Component Based Servicing has a pending reboot.'
+        }
+    }
+}
+
+function Test-WindowsUpdate {
+    $wuPath = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired'
+    if (Test-Path -LiteralPath $wuPath) {
+        return @{
+            source = 'windows_update'
+            description = 'Windows Update has installed updates that require a reboot.'
+        }
+    }
+}
+
+function Test-PendingFileRename {
+    $params = @{
+        LiteralPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager'
+        Name = 'PendingFileRenameOperations'
+        ErrorAction = 'SilentlyContinue'
+    }
+    $pendingRenames = (Get-ItemProperty @params)."$($params.Name)"
+    if ($pendingRenames) {
+        return @{
+            source = 'pending_file_rename'
+            description = 'There are pending file rename operations that require a reboot.'
+        }
+    }
+}
+
+function Test-PendingComputerRename {
+    $pendingParams = @{
+        LiteralPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ComputerName'
+        Name = 'ComputerName'
+        ErrorAction = 'SilentlyContinue'
+    }
+    $activeParams = @{
+        LiteralPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\ComputerName\ActiveComputerName'
+        Name = 'ComputerName'
+        ErrorAction = 'SilentlyContinue'
+    }
+    $pendingName = (Get-ItemProperty @pendingParams)."$($pendingParams.Name)"
+    $activeName = (Get-ItemProperty @activeParams)."$($activeParams.Name)"
+    if ($pendingName -and $activeName -and $pendingName -ne $activeName) {
+        return @{
+            source = 'pending_computer_rename'
+            description = "Computer name change pending from '$activeName' to '$pendingName'."
+        }
+    }
+}
+
+function Test-DomainJoin {
+    $params = @{
+        LiteralPath = 'HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon'
+        ErrorAction = 'SilentlyContinue'
+    }
+    $props = Get-ItemProperty @params
+    if ($props -and ($props.PSObject.Properties.Name -contains 'JoinDomain' -or $props.PSObject.Properties.Name -contains 'AvoidSpnSet')) {
+        return @{
+            source = 'domain_join'
+            description = 'A domain join operation is pending and requires a reboot.'
+        }
+    }
+}
+
+function Test-ServerManager {
+    $params = @{
+        LiteralPath = 'HKLM:\SOFTWARE\Microsoft\ServerManager\ServicingStorage\ServerComponentCache'
+        Name = 'RestartRequired'
+        ErrorAction = 'SilentlyContinue'
+    }
+    $restart = (Get-ItemProperty @params)."$($params.Name)"
+    if ($restart) {
+        return @{
+            source = 'server_manager'
+            description = 'Server Manager indicates a component change requires a reboot.'
+        }
+    }
+}
+
+function Get-PendingRebootReason {
+    <#
+    .SYNOPSIS
+    Checks multiple registry sources for pending reboot indicators and returns a list of matching reasons.
+    If a check is null, that result is filtered out.
+    #>
+    $checks = @(
+        Test-ComponentBasedServicing
+        Test-WindowsUpdate
+        Test-PendingFileRename
+        Test-PendingComputerRename
+        Test-DomainJoin
+        Test-ServerManager
+    ) | Where-Object { $_ }
+
+    return , @($checks)
+}
+
+$spec = @{
+    options = @{}
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$bootTime = Get-LastBootTime -Module $module
+$module.Result.last_reboot = @{
+    time = $bootTime.last_boot_time
+    time_epoch = $bootTime.last_boot_time_epoch
+    details = Get-LastRebootEvent -Module $module -BootTime $bootTime.utc_datetime
+}
+
+$reasons = Get-PendingRebootReason
+$module.Result.pending_reboot = $reasons.Count -gt 0
+$module.Result.pending_reboot_reasons = @($reasons)
+
+$module.ExitJson()

--- a/plugins/modules/win_reboot_info.ps1
+++ b/plugins/modules/win_reboot_info.ps1
@@ -45,7 +45,7 @@ function Get-LastRebootEvent {
             return @{
                 process = $rebootEvent.Properties[0].Value
                 reason = $rebootEvent.Properties[2].Value
-                reason_code = $rebootEvent.Properties[3].Value
+                reason_code = '0x{0:x8}' -f [uint32]$rebootEvent.Properties[3].Value
                 type = $rebootEvent.Properties[4].Value
                 comment = $rebootEvent.Properties[5].Value
                 initiated_by = $rebootEvent.Properties[6].Value

--- a/plugins/modules/win_reboot_info.ps1
+++ b/plugins/modules/win_reboot_info.ps1
@@ -28,10 +28,12 @@ function Format-ReasonCode {
     param($Value)
 
     # The reason code from event 1074 is returned as a string. Parse it as an integer since
-    # that's what it actually represents, using Int64 rather than Int32 since the high bit
-    # (the "planned" flag, e.g. 0x80040002) makes the value exceed Int32's range. Fall back
-    # to returning the raw value unchanged if it can't be parsed so a malformed field doesn't
-    # drop the rest of the reboot details.
+    # that's what it actually represents, using Int64 rather than Int32 since the signed bit
+    # (the "planned" flag, e.g. 0x80040002) makes the value negative whereas YAML
+    # parses hex values as unsigned. This allows users to more easily compare the returned
+    # value with a hex literal '- res.reason_code == 0x80000000'. Fall back to returning the
+    # raw value unchanged if it can't be parsed so a malformed field doesn't drop the rest of
+    # the reboot details.
     $reasonCode = $null
     if ([System.Management.Automation.LanguagePrimitives]::TryConvertTo($Value, [long], [ref]$reasonCode)) {
         return $reasonCode

--- a/plugins/modules/win_reboot_info.ps1
+++ b/plugins/modules/win_reboot_info.ps1
@@ -27,18 +27,16 @@ function Get-LastBootTime {
 function Format-ReasonCode {
     param($Value)
 
-    # The reason code from event 1074 is a 32-bit value (major + minor reason + flag bits).
-    # Format it as an unpadded lowercase hex string (e.g. 0x80040002) to match the value
-    # shown in the Windows event viewer. Fall back to returning the raw value unchanged if
-    # it can't be interpreted as a number so a malformed field doesn't drop the rest of the
-    # reboot details.
-    try {
-        # Mask to 32 bits so a value deserialized as a signed integer still formats correctly.
-        return '0x{0:x}' -f ([int64]$Value -band 0xFFFFFFFFL)
+    # The reason code from event 1074 is returned as a string. Parse it as an integer since
+    # that's what it actually represents, using Int64 rather than Int32 since the high bit
+    # (the "planned" flag, e.g. 0x80040002) makes the value exceed Int32's range. Fall back
+    # to returning the raw value unchanged if it can't be parsed so a malformed field doesn't
+    # drop the rest of the reboot details.
+    $reasonCode = $null
+    if ([System.Management.Automation.LanguagePrimitives]::TryConvertTo($Value, [long], [ref]$reasonCode)) {
+        return $reasonCode
     }
-    catch {
-        return $Value
-    }
+    return $Value
 }
 
 function Get-LastRebootEvent {

--- a/plugins/modules/win_reboot_info.ps1
+++ b/plugins/modules/win_reboot_info.ps1
@@ -24,6 +24,23 @@ function Get-LastBootTime {
     }
 }
 
+function Format-ReasonCode {
+    param($Value)
+
+    # The reason code from event 1074 is a 32-bit value (major + minor reason + flag bits).
+    # Format it as an unpadded lowercase hex string (e.g. 0x80040002) to match the value
+    # shown in the Windows event viewer. Fall back to returning the raw value unchanged if
+    # it can't be interpreted as a number so a malformed field doesn't drop the rest of the
+    # reboot details.
+    try {
+        # Mask to 32 bits so a value deserialized as a signed integer still formats correctly.
+        return '0x{0:x}' -f ([int64]$Value -band 0xFFFFFFFFL)
+    }
+    catch {
+        return $Value
+    }
+}
+
 function Get-LastRebootEvent {
     param(
         [Ansible.Basic.AnsibleModule]$Module,
@@ -45,7 +62,7 @@ function Get-LastRebootEvent {
             return @{
                 process = $rebootEvent.Properties[0].Value
                 reason = $rebootEvent.Properties[2].Value
-                reason_code = '0x{0:x8}' -f [uint32]$rebootEvent.Properties[3].Value
+                reason_code = Format-ReasonCode -Value $rebootEvent.Properties[3].Value
                 type = $rebootEvent.Properties[4].Value
                 comment = $rebootEvent.Properties[5].Value
                 initiated_by = $rebootEvent.Properties[6].Value

--- a/plugins/modules/win_reboot_info.ps1
+++ b/plugins/modules/win_reboot_info.ps1
@@ -45,6 +45,7 @@ function Get-LastRebootEvent {
             return @{
                 process = $rebootEvent.Properties[0].Value
                 reason = $rebootEvent.Properties[2].Value
+                reason_code = $rebootEvent.Properties[3].Value
                 type = $rebootEvent.Properties[4].Value
                 comment = $rebootEvent.Properties[5].Value
                 initiated_by = $rebootEvent.Properties[6].Value
@@ -52,9 +53,9 @@ function Get-LastRebootEvent {
             }
         }
     }
+    catch {
         $Module.Warn("Failed to query the System event log for reboot events: $_", $_)
     }
-
 }
 
 function Test-ComponentBasedServicing {
@@ -142,23 +143,6 @@ function Test-ServerManager {
     }
 }
 
-function Get-PendingRebootReason {
-    <#
-    .SYNOPSIS
-    Checks multiple registry sources for pending reboot indicators and returns a list of matching reasons.
-    If a check is null, that result is filtered out.
-    #>
-    $checks = @(
-        Test-ComponentBasedServicing
-        Test-WindowsUpdate
-        Test-PendingFileRename
-        Test-PendingComputerRename
-        Test-DomainJoin
-        Test-ServerManager
-    ) | Where-Object { $_ }
-
-    return , @($checks)
-}
 
 $spec = @{
     options = @{}
@@ -174,8 +158,15 @@ $module.Result.last_reboot = @{
     details = Get-LastRebootEvent -Module $module -BootTime $bootTime.utc_datetime
 }
 
-$reasons = Get-PendingRebootReason
-$module.Result.pending_reboot = $reasons.Count -gt 0
-$module.Result.pending_reboot_reasons = @($reasons)
+$reasons = @(
+    Test-ComponentBasedServicing
+    Test-WindowsUpdate
+    Test-PendingFileRename
+    Test-PendingComputerRename
+    Test-DomainJoin
+    Test-ServerManager
+)
+$module.Result.reboot_required = $reasons.Count -gt 0
+$module.Result.reboot_required_reasons = $reasons
 
 $module.ExitJson()

--- a/plugins/modules/win_reboot_info.ps1
+++ b/plugins/modules/win_reboot_info.ps1
@@ -20,7 +20,7 @@ function Get-LastBootTime {
         }
     }
     catch {
-        $Module.FailJson("Failed to get last boot time from CIM: $($_.Exception.Message)")
+        $Module.FailJson("Failed to get last boot time from CIM: $_", $_)
     }
 }
 
@@ -39,7 +39,7 @@ function Get-LastRebootEvent {
         if ($rebootEvent) {
             $eventTime = $rebootEvent.TimeCreated.ToUniversalTime()
             if ($eventTime -lt $BootTime.AddMinutes(-5)) {
-                return $null
+                return
             }
 
             return @{
@@ -52,11 +52,9 @@ function Get-LastRebootEvent {
             }
         }
     }
-    catch {
-        $Module.Warn("Failed to query the System event log for reboot events: $($_.Exception.Message)")
+        $Module.Warn("Failed to query the System event log for reboot events: $_", $_)
     }
 
-    return $null
 }
 
 function Test-ComponentBasedServicing {

--- a/plugins/modules/win_reboot_info.py
+++ b/plugins/modules/win_reboot_info.py
@@ -85,11 +85,12 @@ last_reboot:
           - The shutdown reason code associated with the reboot, as recorded in the event log.
           - This is a 32-bit value combining the major reason, minor reason, and flag bits
             (for example the high bit indicates a planned shutdown).
-          - This is normally returned as a lowercase hexadecimal string matching the value
-            shown in the Windows event viewer, but may fall back to the raw value from the
-            event log if it could not be formatted as a hexadecimal string.
+          - This is normally returned as an integer, but may fall back to the raw value from
+            the event log if it could not be parsed as an integer.
+          - The Windows event viewer displays this value as a hexadecimal string (for example
+            C(0x80040002)); this is equivalent to the integer returned here.
           type: raw
-          sample: "0x80040002"
+          sample: 2147745794
         comment:
           description: The comment or message provided when the reboot was initiated.
           type: str

--- a/plugins/modules/win_reboot_info.py
+++ b/plugins/modules/win_reboot_info.py
@@ -27,7 +27,7 @@ EXAMPLES = r'''
 
 - name: Reboot if required
   ansible.windows.win_reboot:
-  when: reboot_info.pending_reboot
+  when: reboot_info.reboot_required
 
 - name: Display last boot time
   ansible.builtin.debug:
@@ -43,8 +43,8 @@ EXAMPLES = r'''
 
 - name: Show pending reboot sources
   ansible.builtin.debug:
-    msg: "Pending reboot due to: {{ reboot_info.pending_reboot_reasons | map(attribute='source') | list }}"
-  when: reboot_info.pending_reboot
+    msg: "Pending reboot due to: {{ reboot_info.reboot_required_reasons | map(attribute='source') | list }}"
+  when: reboot_info.reboot_required
 '''
 
 RETURN = r'''
@@ -92,12 +92,12 @@ last_reboot:
           description: The time the shutdown event was logged as an ISO 8601 UTC timestamp.
           type: str
           sample: "2024-01-15T08:29:45Z"
-pending_reboot:
+reboot_required:
   description: Whether the system has a pending reboot from any source.
   returned: always
   type: bool
   sample: true
-pending_reboot_reasons:
+reboot_required_reasons:
   description:
   - A list of sources that require a reboot.
   - Will be an empty list if no reboot is pending.

--- a/plugins/modules/win_reboot_info.py
+++ b/plugins/modules/win_reboot_info.py
@@ -1,0 +1,119 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2026, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r'''
+---
+module: win_reboot_info
+version_added: 3.8.0
+short_description: Get reboot status information for a Windows host
+description:
+- Returns information about the last boot time and whether a reboot is pending on the target Windows host.
+- A pending reboot can be caused by Windows Update, Component Based Servicing, pending file rename operations,
+  domain join operations, or Server Manager component changes.
+options: {}
+seealso:
+- module: ansible.windows.win_reboot
+author:
+- Mike Morency (@mikemorency)
+'''
+
+EXAMPLES = r'''
+- name: Get reboot info
+  ansible.windows.win_reboot_info:
+  register: reboot_info
+
+- name: Reboot if required
+  ansible.windows.win_reboot:
+  when: reboot_info.pending_reboot
+
+- name: Display last boot time
+  ansible.builtin.debug:
+    msg: "Last boot: {{ reboot_info.last_reboot.time }}"
+
+- name: Show who initiated the last reboot
+  ansible.builtin.debug:
+    msg: >-
+      Last reboot was initiated by {{ reboot_info.last_reboot.details.initiated_by }}
+      via {{ reboot_info.last_reboot.details.process }}
+      with comment: {{ reboot_info.last_reboot.details.comment }}
+  when: reboot_info.last_reboot.details is not none
+
+- name: Show pending reboot sources
+  ansible.builtin.debug:
+    msg: "Pending reboot due to: {{ reboot_info.pending_reboot_reasons | map(attribute='source') | list }}"
+  when: reboot_info.pending_reboot
+'''
+
+RETURN = r'''
+last_reboot:
+  description: Information about the last system boot.
+  returned: always
+  type: dict
+  contains:
+    time:
+      description: The last boot time of the system as an ISO 8601 UTC timestamp.
+      type: str
+      sample: "2024-01-15T08:30:00Z"
+    time_epoch:
+      description: The last boot time as a Unix epoch timestamp in seconds.
+      type: float
+      sample: 1705305000.0
+    details:
+      description:
+      - Details about the most recent shutdown or restart event from the Windows Event Log.
+      - This is gathered from Event ID 1074 in the System log.
+      - Will be C(null) if no shutdown event was found in the event log.
+      type: dict
+      contains:
+        initiated_by:
+          description: The user account that initiated the reboot.
+          type: str
+          sample: "DOMAIN\\admin"
+        process:
+          description: The process that triggered the reboot.
+          type: str
+          sample: "C:\\Windows\\system32\\shutdown.exe"
+        reason:
+          description: The reason category for the reboot.
+          type: str
+          sample: "Operating System: Recovery (Planned)"
+        comment:
+          description: The comment or message provided when the reboot was initiated.
+          type: str
+          sample: "Reboot initiated by Ansible"
+        type:
+          description: The type of action, such as C(restart), C(shutdown), or C(power off).
+          type: str
+          sample: "restart"
+        event_time:
+          description: The time the shutdown event was logged as an ISO 8601 UTC timestamp.
+          type: str
+          sample: "2024-01-15T08:29:45Z"
+pending_reboot:
+  description: Whether the system has a pending reboot from any source.
+  returned: always
+  type: bool
+  sample: true
+pending_reboot_reasons:
+  description:
+  - A list of sources that require a reboot.
+  - Will be an empty list if no reboot is pending.
+  returned: always
+  type: list
+  elements: dict
+  contains:
+    source:
+      description:
+      - The source that requires a reboot.
+      - Known sources are C(component_based_servicing), C(windows_update), C(pending_file_rename),
+        C(pending_computer_rename), C(domain_join), C(server_manager).
+      type: str
+      sample: windows_update
+    description:
+      description: A human-readable description of why a reboot is pending.
+      type: str
+      sample: Windows Update has installed updates that require a reboot.
+'''

--- a/plugins/modules/win_reboot_info.py
+++ b/plugins/modules/win_reboot_info.py
@@ -83,10 +83,13 @@ last_reboot:
         reason_code:
           description:
           - The shutdown reason code associated with the reboot, as recorded in the event log.
-          - This combines the major and minor reason codes and is returned as an 8-digit
-            hexadecimal string, matching the value shown in the Windows event viewer.
-          type: str
-          sample: "0x800000ff"
+          - This is a 32-bit value combining the major reason, minor reason, and flag bits
+            (for example the high bit indicates a planned shutdown).
+          - This is normally returned as a lowercase hexadecimal string matching the value
+            shown in the Windows event viewer, but may fall back to the raw value from the
+            event log if it could not be formatted as a hexadecimal string.
+          type: raw
+          sample: "0x80040002"
         comment:
           description: The comment or message provided when the reboot was initiated.
           type: str

--- a/plugins/modules/win_reboot_info.py
+++ b/plugins/modules/win_reboot_info.py
@@ -80,6 +80,13 @@ last_reboot:
           description: The reason category for the reboot.
           type: str
           sample: "Operating System: Recovery (Planned)"
+        reason_code:
+          description:
+          - The shutdown reason code associated with the reboot, as recorded in the event log.
+          - This combines the major and minor reason codes and is returned as an 8-digit
+            hexadecimal string, matching the value shown in the Windows event viewer.
+          type: str
+          sample: "0x800000ff"
         comment:
           description: The comment or message provided when the reboot was initiated.
           type: str

--- a/tests/integration/targets/win_reboot_info/aliases
+++ b/tests/integration/targets/win_reboot_info/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group1

--- a/tests/integration/targets/win_reboot_info/aliases
+++ b/tests/integration/targets/win_reboot_info/aliases
@@ -1,1 +1,1 @@
-shippable/windows/group1
+shippable/windows/group4

--- a/tests/integration/targets/win_reboot_info/tasks/main.yml
+++ b/tests/integration/targets/win_reboot_info/tasks/main.yml
@@ -1,0 +1,101 @@
+---
+- name: Get reboot info before any changes
+  ansible.windows.win_reboot_info:
+  register: reboot_info_initial
+
+- name: Assert no pending reboot initially
+  ansible.builtin.assert:
+    that:
+      - not reboot_info_initial is changed
+      - reboot_info_initial.last_reboot is defined
+      - reboot_info_initial.last_reboot.time is match("^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+      - reboot_info_initial.last_reboot.time_epoch is number
+      - reboot_info_initial.pending_reboot == false
+      - reboot_info_initial.pending_reboot_reasons | length == 0
+
+- name: Assert check mode returns the same data
+  ansible.windows.win_reboot_info:
+  register: reboot_info_check
+  check_mode: true
+
+- name: Validate check mode matches normal mode
+  ansible.builtin.assert:
+    that:
+      - not reboot_info_check is changed
+      - reboot_info_check.last_reboot.time == reboot_info_initial.last_reboot.time
+      - reboot_info_check.pending_reboot == false
+
+- block:
+    - name: Fake a pending reboot via Component Based Servicing
+      ansible.windows.win_regedit:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending
+        state: present
+
+    - name: Fake a pending reboot via Windows Update
+      ansible.windows.win_regedit:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired
+        state: present
+
+    - name: Get reboot info after faking pending reboot
+      ansible.windows.win_reboot_info:
+      register: reboot_info_pending
+
+    - name: Assert pending reboot is detected
+      ansible.builtin.assert:
+        that:
+          - reboot_info_pending.pending_reboot == true
+          - reboot_info_pending.pending_reboot_reasons | length >= 2
+          - "'component_based_servicing' in reboot_info_pending.pending_reboot_reasons | map(attribute='source')"
+          - "'windows_update' in reboot_info_pending.pending_reboot_reasons | map(attribute='source')"
+
+    - name: Assert each reason has expected structure
+      ansible.builtin.assert:
+        that:
+          - item.source is string
+          - item.description is string
+      loop: "{{ reboot_info_pending.pending_reboot_reasons }}"
+
+  always:
+    - name: Remove fake Component Based Servicing key
+      ansible.windows.win_regedit:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending
+        state: absent
+        delete_key: true
+
+    - name: Remove fake Windows Update key
+      ansible.windows.win_regedit:
+        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired
+        state: absent
+        delete_key: true
+
+- name: Get reboot info after cleanup
+  ansible.windows.win_reboot_info:
+  register: reboot_info_cleaned
+
+- name: Assert pending reboot is cleared after cleanup
+  ansible.builtin.assert:
+    that:
+      - reboot_info_cleaned.pending_reboot == false
+      - reboot_info_cleaned.pending_reboot_reasons | length == 0
+
+- name: Record last boot time before reboot
+  ansible.builtin.set_fact:
+    boot_time_before_reboot: "{{ reboot_info_cleaned.last_reboot.time }}"
+
+- name: Reboot the host
+  ansible.windows.win_reboot:
+
+- name: Get reboot info after reboot
+  ansible.windows.win_reboot_info:
+  register: reboot_info_post_reboot
+
+- name: Assert reboot info is updated after reboot
+  ansible.builtin.assert:
+    that:
+      - reboot_info_post_reboot.pending_reboot == false
+      - reboot_info_post_reboot.pending_reboot_reasons | length == 0
+      - reboot_info_post_reboot.last_reboot.time != boot_time_before_reboot
+      - reboot_info_post_reboot.last_reboot.details.initiated_by is string
+      - reboot_info_post_reboot.last_reboot.details.process is string
+      - reboot_info_post_reboot.last_reboot.details.type is string
+      - reboot_info_post_reboot.last_reboot.details.event_time is match("^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")

--- a/tests/integration/targets/win_reboot_info/tasks/main.yml
+++ b/tests/integration/targets/win_reboot_info/tasks/main.yml
@@ -13,8 +13,8 @@
       - reboot_info_initial.last_reboot is defined
       - reboot_info_initial.last_reboot.time is match("^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
       - reboot_info_initial.last_reboot.time_epoch is number
-      - reboot_info_initial.pending_reboot == false
-      - reboot_info_initial.pending_reboot_reasons | length == 0
+      - reboot_info_initial.reboot_required == false
+      - reboot_info_initial.reboot_required_reasons | length == 0
 
 - name: Assert check mode returns the same data
   ansible.windows.win_reboot_info:
@@ -26,7 +26,7 @@
     that:
       - not reboot_info_check is changed
       - reboot_info_check.last_reboot.time == reboot_info_initial.last_reboot.time
-      - reboot_info_check.pending_reboot == false
+      - reboot_info_check.reboot_required == false
 
 - block:
     - name: Fake a pending reboot via PendingFileRenameOperations
@@ -52,17 +52,17 @@
     - name: Assert pending reboot is detected
       ansible.builtin.assert:
         that:
-          - reboot_info_pending.pending_reboot == true
-          - reboot_info_pending.pending_reboot_reasons | length >= 2
-          - "'pending_file_rename' in reboot_info_pending.pending_reboot_reasons | map(attribute='source')"
-          - "'domain_join' in reboot_info_pending.pending_reboot_reasons | map(attribute='source')"
+          - reboot_info_pending.reboot_required == true
+          - reboot_info_pending.reboot_required_reasons | length >= 2
+          - "'pending_file_rename' in reboot_info_pending.reboot_required_reasons | map(attribute='source')"
+          - "'domain_join' in reboot_info_pending.reboot_required_reasons | map(attribute='source')"
 
     - name: Assert each reason has expected structure
       ansible.builtin.assert:
         that:
           - item.source is string
           - item.description is string
-      loop: "{{ reboot_info_pending.pending_reboot_reasons }}"
+      loop: "{{ reboot_info_pending.reboot_required_reasons }}"
 
   always:
     - name: Remove fake PendingFileRenameOperations value
@@ -84,8 +84,8 @@
 - name: Assert pending reboot is cleared after cleanup
   ansible.builtin.assert:
     that:
-      - reboot_info_cleaned.pending_reboot == false
-      - reboot_info_cleaned.pending_reboot_reasons | length == 0
+      - reboot_info_cleaned.reboot_required == false
+      - reboot_info_cleaned.reboot_required_reasons | length == 0
 
 - name: Record last boot time before reboot
   ansible.builtin.set_fact:
@@ -101,8 +101,8 @@
 - name: Assert reboot info is updated after reboot
   ansible.builtin.assert:
     that:
-      - reboot_info_post_reboot.pending_reboot == false
-      - reboot_info_post_reboot.pending_reboot_reasons | length == 0
+      - reboot_info_post_reboot.reboot_required == false
+      - reboot_info_post_reboot.reboot_required_reasons | length == 0
       - reboot_info_post_reboot.last_reboot.time != boot_time_before_reboot
       - reboot_info_post_reboot.last_reboot.details.initiated_by is string
       - reboot_info_post_reboot.last_reboot.details.process is string

--- a/tests/integration/targets/win_reboot_info/tasks/main.yml
+++ b/tests/integration/targets/win_reboot_info/tasks/main.yml
@@ -30,11 +30,17 @@
       ansible.windows.win_regedit:
         path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending
         state: present
+      become: true
+      become_method: runas
+      become_user: SYSTEM
 
     - name: Fake a pending reboot via Windows Update
       ansible.windows.win_regedit:
         path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired
         state: present
+      become: true
+      become_method: runas
+      become_user: SYSTEM
 
     - name: Get reboot info after faking pending reboot
       ansible.windows.win_reboot_info:
@@ -61,12 +67,18 @@
         path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending
         state: absent
         delete_key: true
+      become: true
+      become_method: runas
+      become_user: SYSTEM
 
     - name: Remove fake Windows Update key
       ansible.windows.win_regedit:
         path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired
         state: absent
         delete_key: true
+      become: true
+      become_method: runas
+      become_user: SYSTEM
 
 - name: Get reboot info after cleanup
   ansible.windows.win_reboot_info:

--- a/tests/integration/targets/win_reboot_info/tasks/main.yml
+++ b/tests/integration/targets/win_reboot_info/tasks/main.yml
@@ -26,21 +26,21 @@
       - reboot_info_check.pending_reboot == false
 
 - block:
-    - name: Fake a pending reboot via Component Based Servicing
+    - name: Fake a pending reboot via PendingFileRenameOperations
       ansible.windows.win_regedit:
-        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager
+        name: PendingFileRenameOperations
+        data: ['\\??\C:\temp\test.tmp', '']
+        type: multistring
         state: present
-      become: true
-      become_method: runas
-      become_user: SYSTEM
 
-    - name: Fake a pending reboot via Windows Update
+    - name: Fake a pending reboot via domain join
       ansible.windows.win_regedit:
-        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired
+        path: HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon
+        name: JoinDomain
+        data: test.local
+        type: string
         state: present
-      become: true
-      become_method: runas
-      become_user: SYSTEM
 
     - name: Get reboot info after faking pending reboot
       ansible.windows.win_reboot_info:
@@ -51,8 +51,8 @@
         that:
           - reboot_info_pending.pending_reboot == true
           - reboot_info_pending.pending_reboot_reasons | length >= 2
-          - "'component_based_servicing' in reboot_info_pending.pending_reboot_reasons | map(attribute='source')"
-          - "'windows_update' in reboot_info_pending.pending_reboot_reasons | map(attribute='source')"
+          - "'pending_file_rename' in reboot_info_pending.pending_reboot_reasons | map(attribute='source')"
+          - "'domain_join' in reboot_info_pending.pending_reboot_reasons | map(attribute='source')"
 
     - name: Assert each reason has expected structure
       ansible.builtin.assert:
@@ -62,23 +62,17 @@
       loop: "{{ reboot_info_pending.pending_reboot_reasons }}"
 
   always:
-    - name: Remove fake Component Based Servicing key
+    - name: Remove fake PendingFileRenameOperations value
       ansible.windows.win_regedit:
-        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\RebootPending
+        path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager
+        name: PendingFileRenameOperations
         state: absent
-        delete_key: true
-      become: true
-      become_method: runas
-      become_user: SYSTEM
 
-    - name: Remove fake Windows Update key
+    - name: Remove fake domain join value
       ansible.windows.win_regedit:
-        path: HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\WindowsUpdate\Auto Update\RebootRequired
+        path: HKLM:\SYSTEM\CurrentControlSet\Services\Netlogon
+        name: JoinDomain
         state: absent
-        delete_key: true
-      become: true
-      become_method: runas
-      become_user: SYSTEM
 
 - name: Get reboot info after cleanup
   ansible.windows.win_reboot_info:

--- a/tests/integration/targets/win_reboot_info/tasks/main.yml
+++ b/tests/integration/targets/win_reboot_info/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Reboot to clear any pending reboots
+  ansible.windows.win_reboot: {}
+
 - name: Get reboot info before any changes
   ansible.windows.win_reboot_info:
   register: reboot_info_initial
@@ -30,7 +33,7 @@
       ansible.windows.win_regedit:
         path: HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager
         name: PendingFileRenameOperations
-        data: ['\\??\C:\temp\test.tmp', '']
+        data: ['\\??\C:\temp\test.tmp', ""]
         type: multistring
         state: present
 


### PR DESCRIPTION
##### SUMMARY
Adds a new `win_reboot_info` module that returns detailed reboot status information for a Windows host, including:

- Last boot time (ISO 8601 and Unix epoch)
- Details about the most recent shutdown/restart event (Event ID 1074) — who initiated it, what process triggered it, and why
- Whether a reboot is pending, with a detailed breakdown of which sources require a reboot (Component Based Servicing, Windows Update, pending file renames, computer rename, domain join, Server Manager)

This module is designed to provide more granular reboot information than what is available through the `setup` module's `ansible_reboot_pending` fact. While there is some overlap in the pending reboot checks (both check CBS, PendingFileRename, and ServerManager), `win_reboot_info` covers additional sources (Windows Update, pending computer rename, domain join) and provides structured detail about each pending reason, as well as last reboot event context that `setup` does not offer.

##### ISSUE TYPE
- Feature Pull Request