### PR TITLE
win_copy - Fix issues with dest being a filename

### DIFF
--- a/changelogs/fragments/win_copy-dest-filename.yml
+++ b/changelogs/fragments/win_copy-dest-filename.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - >-
+    win_copy - Fix error when setting ``dest`` to just the filename. The destination in this case will be the
+    working directory set by the connection plugin.

--- a/plugins/action/win_copy.py
+++ b/plugins/action/win_copy.py
@@ -464,6 +464,11 @@ class ActionModule(ActionBase):
                 filename = os.path.basename(unix_path)
                 check_dest = os.path.dirname(unix_path)
 
+                # If dest=filename.txt then there is no dirname so we use '.'
+                # ensure Get-AnsibleParam does not fail on an empty value.
+                if not check_dest:
+                    check_dest = '.'
+
             file_checksum = _get_local_checksum(force, source_full)
             source_files['files'].append(
                 dict(

--- a/plugins/modules/win_copy.ps1
+++ b/plugins/modules/win_copy.ps1
@@ -395,6 +395,10 @@ elseif ($copy_mode -eq "remote") {
         }
         $result.dest = $remote_dest
         $parent_dir = Split-Path -LiteralPath $remote_dest
+        if (-not $parent_dir) {
+            $parent_dir = $pwd.Path
+            $remote_dest = Join-Path -Path $parent_dir -ChildPath $remote_dest
+        }
 
         if (Test-Path -LiteralPath $parent_dir -PathType Leaf) {
             Fail-Json -obj $result -message "object at destination parent dir '$parent_dir' is currently a file"
@@ -438,6 +442,11 @@ elseif ($copy_mode -eq "single") {
         $remote_dest = Join-Path -Path $dest -ChildPath $original_basename
     }
     $parent_dir = Split-Path -LiteralPath $remote_dest
+
+    # If $remote_dest is just the filename, it is relative to the cwd
+    if (-not $parent_dir) {
+        $parent_dir = $pwd.Path
+    }
 
     # check if the dest parent dirs exist, need to fail if they don't
     if (Test-Path -LiteralPath $parent_dir -PathType Leaf) {

--- a/plugins/modules/win_copy.py
+++ b/plugins/modules/win_copy.py
@@ -27,7 +27,13 @@ options:
     default: yes
   dest:
     description:
-    - Remote absolute path where the file should be copied to.
+    - Remote path where the file should be copied to.
+    - If the path is not absolute, the path will be relative to the current
+      working directory of the module process. As the cwd is dependent on the
+      connection plugin being used and how it spawns the remote process there
+      there are no guarantees that the cwd will be the same between different
+      connection plugins. Using an absolute path is recommended to ensure a
+      consistent result.
     - If C(src) is a directory, this must be a directory too.
     - Use \ for path separators or \\ when in "double quotes".
     - If C(dest) ends with \ then source or the contents of source will be

--- a/tests/integration/targets/win_copy/tasks/main.yml
+++ b/tests/integration/targets/win_copy/tasks/main.yml
@@ -15,6 +15,15 @@
     state: absent
   delegate_to: localhost
 
+- name: get working directory set for connection plugin
+  win_powershell:
+    script: '$pwd.Path'
+  register: win_cwd_raw
+
+- name: set working directory for connection plugin
+  set_fact:
+    win_cwd: '{{ win_cwd_raw.output[0] }}'
+
 - name: create test folder
   win_file:
     path: '{{test_win_copy_path}}'
@@ -37,10 +46,14 @@
     include_tasks: diff_tests.yml
 
   always:
-  - name: remove test folder
+  - name: remove test files
     win_file:
-      path: '{{test_win_copy_path}}'
+      path: '{{ item }}'
       state: absent
+    loop:
+    - '{{ test_win_copy_path }}'
+    - '{{ win_cwd }}\local-file.txt'
+    - '{{ win_cwd }}\remote-file.txt'
 
   - name: remove local temp directory
     file:

--- a/tests/integration/targets/win_copy/tasks/remote_tests.yml
+++ b/tests/integration/targets/win_copy/tasks/remote_tests.yml
@@ -536,3 +536,26 @@
     - copy_complex.size == 8  # 4 bytes for copy and (4 + 4) bytes for existing files in dest
     - copy_complex_actual.stat.exists
     - copy_complex_actual.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+
+- name: copy remote file using just filename for dest
+  win_copy:
+    src: '{{ test_win_copy_path }}\source\foo.txt'
+    dest: remote-file.txt
+    remote_src: true
+  register: copy_remote_file_using_filename_for_dest
+
+- name: get result of copy remote file using just filename for dest
+  win_stat:
+    path: '{{ win_cwd }}\remote-file.txt'
+  register: copy_remote_file_using_filename_for_dest_actual
+
+- name: assert copy file using just filename for dest
+  assert:
+    that:
+    - copy_remote_file_using_filename_for_dest is changed
+    - copy_remote_file_using_filename_for_dest.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+    - copy_remote_file_using_filename_for_dest.dest == 'remote-file.txt'
+    - copy_remote_file_using_filename_for_dest.operation == 'file_copy'
+    - copy_remote_file_using_filename_for_dest.size == 8
+    - copy_remote_file_using_filename_for_dest_actual.stat.exists == True
+    - copy_remote_file_using_filename_for_dest_actual.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'

--- a/tests/integration/targets/win_copy/tasks/tests.yml
+++ b/tests/integration/targets/win_copy/tasks/tests.yml
@@ -571,3 +571,25 @@
   win_file:
     path: '{{test_win_copy_path}}'
     state: absent
+
+- name: copy file using just filename for dest
+  win_copy:
+    src: foo.txt
+    dest: local-file.txt
+  register: copy_file_using_filename_for_dest
+
+- name: get result of copy file using just filename for dest
+  win_stat:
+    path: '{{ win_cwd }}\local-file.txt'
+  register: copy_file_using_filename_for_dest_actual
+
+- name: assert copy file using just filename for dest
+  assert:
+    that:
+    - copy_file_using_filename_for_dest is changed
+    - copy_file_using_filename_for_dest.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
+    - copy_file_using_filename_for_dest.dest == 'local-file.txt'
+    - copy_file_using_filename_for_dest.operation == 'file_copy'
+    - copy_file_using_filename_for_dest.size == 8
+    - copy_file_using_filename_for_dest_actual.stat.exists == True
+    - copy_file_using_filename_for_dest_actual.stat.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'


### PR DESCRIPTION
##### SUMMARY
Fixes the issues where `dest` was set to just the filename to indicate the current working directory. While not documented, the code supported using `.\` or `./` as a prefix for the `dest` path. To make things consistent this fixes the error and adds a doc entry warning that it is unreliable to use a relative path.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
win_copy