### PR TITLE
Add win_lineinfile module

### DIFF
--- a/plugins/modules/win_lineinfile.ps1
+++ b/plugins/modules/win_lineinfile.ps1
@@ -1,0 +1,593 @@
+#!powershell
+
+# Copyright: (c) 2015, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#AnsibleRequires -CSharpUtil Ansible.Basic
+#AnsibleRequires -PowerShell Ansible.ModuleUtils.Backup
+#AnsibleRequires -PowerShell ..module_utils.Process
+
+$spec = @{
+    options = @{
+        path = @{ type = "path"; required = $true; aliases = @("dest", "destfile", "name") }
+        regex = @{ type = "str"; aliases = @("regexp") }
+        state = @{ type = "str"; default = "present"; choices = @("absent", "present") }
+        line = @{ type = "str" }
+        backrefs = @{ type = "bool"; default = $false }
+        insertafter = @{ type = "str" }
+        insertbefore = @{ type = "str" }
+        create = @{ type = "bool"; default = $false }
+        backup = @{ type = "bool"; default = $false }
+        validate = @{ type = "str" }
+        encoding = @{ type = "str"; default = "auto" }
+        newline = @{ type = "str"; default = "windows"; choices = @("unix", "windows") }
+    }
+    supports_check_mode = $true
+}
+
+$module = [Ansible.Basic.AnsibleModule]::Create($args, $spec)
+
+$path = $module.Params.path
+$regex = $module.Params.regex
+$state = $module.Params.state
+$line = $module.Params.line
+$backrefs = $module.Params.backrefs
+$insertafter = $module.Params.insertafter
+$insertbefore = $module.Params.insertbefore
+$create = $module.Params.create
+$backup = $module.Params.backup
+$validate = $module.Params.validate
+$encoding = $module.Params.encoding
+$newline = $module.Params.newline
+
+$module.Result.msg = ""
+
+function Write-TargetFile {
+    <#
+    .SYNOPSIS
+    Write the supplied lines to a temporary file, optionally validate it and then commit it to the target path.
+    #>
+    [CmdletBinding()]
+    [OutputType([String])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [Ansible.Basic.AnsibleModule]
+        $Module,
+
+        [Parameter(Mandatory = $true)]
+        [AllowNull()]
+        [AllowEmptyCollection()]
+        $OutLines,
+
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Path,
+
+        [Parameter(Mandatory = $true)]
+        [String]
+        $LineSep,
+
+        [Parameter(Mandatory = $true)]
+        [System.Text.Encoding]
+        $Encoding,
+
+        [String]
+        $Validate
+    )
+
+    try {
+        $tempPath = [System.IO.Path]::GetTempFileName()
+    }
+    catch {
+        $Module.FailJson("Cannot create temporary file! ($($_.Exception.Message))", $_)
+    }
+
+    $joined = $OutLines -join $LineSep
+
+    try {
+        [System.IO.File]::WriteAllText($tempPath, $joined, $Encoding)
+
+        if ($Validate) {
+            if ($Validate -notlike "*%s*") {
+                $Module.FailJson("validate must contain %s: $Validate")
+            }
+
+            $commandLine = $Validate.Replace("%s", $tempPath)
+
+            try {
+                $res = Start-AnsibleWindowsProcess -CommandLine $commandLine
+            }
+            catch {
+                $Module.FailJson("failed to run validation command '$commandLine': $($_.Exception.Message)", $_)
+            }
+
+            if ($res.ExitCode -ne 0) {
+                $Module.FailJson("failed to validate $commandLine with error: $($res.Stdout) $($res.Stderr)")
+            }
+        }
+
+        # Commit changes to the path. Note that we have to clean up the path because Ansible wants to treat / and \
+        # as interchangeable in Windows pathnames, but .NET framework internals do not support that.
+        $cleanPath = $Path.Replace("/", "\")
+        $checkMode = $Module.CheckMode
+        try {
+            Copy-Item -LiteralPath $tempPath -Destination $cleanPath -Force -WhatIf:$checkMode
+        }
+        catch {
+            $Module.FailJson("Cannot write to: $cleanPath ($($_.Exception.Message))", $_)
+        }
+    }
+    finally {
+        # Always remove the temporary file, even in check mode, so that it is not left behind on the remote host.
+        Remove-Item -LiteralPath $tempPath -Force -ErrorAction SilentlyContinue
+    }
+
+    $joined
+}
+
+function Get-TargetEncoding {
+    <#
+    .SYNOPSIS
+    Determine the encoding used to read from and write to the target file.
+    #>
+    [CmdletBinding()]
+    [OutputType([System.Text.Encoding])]
+    param (
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Path,
+
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Encoding
+    )
+
+    # The default encoding is UTF-8 without a BOM.
+    $encodingObj = [System.Text.UTF8Encoding]$false
+
+    # If an explicit encoding is specified, use that instead.
+    if ($Encoding -ne "auto") {
+        return [System.Text.Encoding]::GetEncoding($Encoding)
+    }
+
+    # Otherwise see if we can determine the current encoding of the target file. If the file doesn't exist yet
+    # (create=true) we use the default encoding set above.
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return $encodingObj
+    }
+
+    # Get a sorted list of encodings with preambles, longest first.
+    $maxPreambleLength = 0
+    $sortedList = New-Object -TypeName System.Collections.SortedList
+    foreach ($encodingInfo in [System.Text.Encoding]::GetEncodings()) {
+        $candidate = $encodingInfo.GetEncoding()
+        $preambleLength = $candidate.GetPreamble().Length
+        if ($preambleLength -gt $maxPreambleLength) {
+            $maxPreambleLength = $preambleLength
+        }
+        if ($preambleLength -gt 0) {
+            # Negate the key so that the longest preamble is checked first.
+            $sortKey = ($preambleLength * 1000000 + $candidate.CodePage) * -1
+            $sortedList.Add($sortKey, $candidate) > $null
+        }
+    }
+
+    # Get the first N bytes from the file, where N is the max preamble length we saw.
+    $bom = [byte[]]@()
+    $fs = $null
+    try {
+        $fs = [System.IO.File]::Open(
+            $Path.Replace("/", "\"),
+            [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::Read,
+            [System.IO.FileShare]::ReadWrite)
+        $buffer = New-Object -TypeName byte[] -ArgumentList $maxPreambleLength
+        $read = $fs.Read($buffer, 0, $maxPreambleLength)
+        if ($read -gt 0) {
+            $bom = $buffer[0..($read - 1)]
+        }
+    }
+    finally {
+        if ($fs) {
+            $fs.Dispose()
+        }
+    }
+
+    # Iterate through the sorted encodings, looking for a full match.
+    foreach ($candidate in $sortedList.GetValueList()) {
+        $preamble = $candidate.GetPreamble()
+        if (-not $preamble -or -not $bom -or $preamble.Length -gt $bom.Length) {
+            continue
+        }
+
+        $isMatch = $true
+        foreach ($idx in 0..($preamble.Length - 1)) {
+            if ($preamble[$idx] -ne $bom[$idx]) {
+                $isMatch = $false
+                break
+            }
+        }
+        if ($isMatch) {
+            return $candidate
+        }
+    }
+
+    $encodingObj
+}
+
+function Set-TargetLine {
+    <#
+    .SYNOPSIS
+    Implements the functionality for state=present.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [Ansible.Basic.AnsibleModule]
+        $Module,
+
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Path,
+
+        [String]
+        $Regex,
+
+        [String]
+        $Line,
+
+        [String]
+        $InsertAfter,
+
+        [String]
+        $InsertBefore,
+
+        [bool]
+        $Create,
+
+        [bool]
+        $Backup,
+
+        [bool]
+        $Backrefs,
+
+        [String]
+        $Validate,
+
+        [Parameter(Mandatory = $true)]
+        [System.Text.Encoding]
+        $Encoding,
+
+        [Parameter(Mandatory = $true)]
+        [String]
+        $LineSep
+    )
+
+    # Note that we have to clean up the path because Ansible wants to treat / and \ as interchangeable in Windows
+    # pathnames, but .NET framework internals do not support that.
+    $cleanPath = $Path.Replace("/", "\")
+    $endsWithNewline = $null
+
+    # Check if path exists. If it does not exist, either create it if create=true was specified or fail with a
+    # reasonable error message.
+    if (-not (Test-Path -LiteralPath $Path)) {
+        if (-not $Create) {
+            $Module.FailJson("Path $Path does not exist !")
+        }
+        # Create a new empty file, using the specified encoding to write the correct BOM.
+        [System.IO.File]::WriteAllLines($cleanPath, "", $Encoding)
+        $endsWithNewline = $false
+    }
+
+    if ($InsertBefore -and $InsertAfter) {
+        $Module.Warn("Both insertbefore and insertafter parameters found, ignoring `"insertafter=$InsertAfter`"")
+    }
+
+    # Read the dest file lines using the indicated encoding into a mutable ArrayList.
+    $before = [System.IO.File]::ReadAllLines($cleanPath, $Encoding)
+    if ($null -eq $before) {
+        $lines = New-Object -TypeName System.Collections.ArrayList
+    }
+    else {
+        $lines = [System.Collections.ArrayList]$before
+        if ($null -eq $endsWithNewline) {
+            $allText = [System.IO.File]::ReadAllText($cleanPath, $Encoding)
+            $endsWithNewline = (($allText[-1] -eq "`n") -or ($allText[-1] -eq "`r"))
+        }
+    }
+
+    if ($Module.DiffMode) {
+        if ($endsWithNewline) {
+            $before += ""
+        }
+        $Module.Diff.before = $before -join $LineSep
+    }
+
+    # Compile the regex specified, if provided.
+    $mre = $null
+    if ($Regex) {
+        $mre = [regex]::new($Regex, [System.Text.RegularExpressions.RegexOptions]::Compiled)
+    }
+
+    # Compile the regex for insertafter or insertbefore, if provided.
+    $insre = $null
+    if ($InsertAfter -and $InsertAfter -ne "BOF" -and $InsertAfter -ne "EOF") {
+        $insre = [regex]::new($InsertAfter, [System.Text.RegularExpressions.RegexOptions]::Compiled)
+    }
+    elseif ($InsertBefore -and $InsertBefore -ne "BOF") {
+        $insre = [regex]::new($InsertBefore, [System.Text.RegularExpressions.RegexOptions]::Compiled)
+    }
+
+    # index[0] is the line number where the regex has been found.
+    # index[1] is the line number where insertafter/insertbefore has been found.
+    $index = -1, -1
+    $lineno = 0
+
+    # The most recently matched line.
+    $matchedLine = ""
+
+    # Iterate through the lines in the file looking for matches.
+    foreach ($curLine in $lines) {
+        if ($Regex) {
+            $matchFound = $mre.Match($curLine).Success
+            if ($matchFound) {
+                $matchedLine = $curLine
+            }
+        }
+        else {
+            $matchFound = $Line -ceq $curLine
+        }
+
+        if ($matchFound) {
+            $index[0] = $lineno
+        }
+        elseif ($insre -and $insre.Match($curLine).Success) {
+            if ($InsertAfter) {
+                $index[1] = $lineno + 1
+            }
+            if ($InsertBefore) {
+                $index[1] = $lineno
+            }
+        }
+        $lineno = $lineno + 1
+    }
+
+    if ($index[0] -ne -1) {
+        if ($Backrefs) {
+            $newLine = [regex]::Replace($matchedLine, $Regex, $Line)
+        }
+        else {
+            $newLine = $Line
+        }
+        if ($lines[$index[0]] -cne $newLine) {
+            $lines[$index[0]] = $newLine
+            $Module.Result.changed = $true
+            $Module.Result.msg = "line replaced"
+        }
+    }
+    elseif ($Backrefs) {
+        # No matches - no-op
+    }
+    elseif ($InsertBefore -eq "BOF" -or $InsertAfter -eq "BOF") {
+        $lines.Insert(0, $Line)
+        $Module.Result.changed = $true
+        $Module.Result.msg = "line added"
+    }
+    elseif ($InsertAfter -eq "EOF" -or $index[1] -eq -1) {
+        $lines.Add($Line) > $null
+        $Module.Result.changed = $true
+        $Module.Result.msg = "line added"
+    }
+    else {
+        $lines.Insert($index[1], $Line)
+        $Module.Result.changed = $true
+        $Module.Result.msg = "line added"
+    }
+
+    # Write changes to the path if changes were made.
+    if ($Module.Result.changed) {
+        if ($Backup) {
+            $checkMode = $Module.CheckMode
+            $Module.Result.backup_file = Backup-File -path $Path -WhatIf:$checkMode
+        }
+
+        if ($endsWithNewline) {
+            $lines.Add("") > $null
+        }
+
+        $writeParams = @{
+            Module = $Module
+            OutLines = $lines
+            Path = $Path
+            LineSep = $LineSep
+            Encoding = $Encoding
+            Validate = $Validate
+        }
+        $after = Write-TargetFile @writeParams
+
+        if ($Module.DiffMode) {
+            $Module.Diff.after = $after
+        }
+    }
+
+    $Module.Result.encoding = $Encoding.WebName
+}
+
+function Remove-TargetLine {
+    <#
+    .SYNOPSIS
+    Implements the functionality for state=absent.
+    #>
+    [CmdletBinding()]
+    param (
+        [Parameter(Mandatory = $true)]
+        [Ansible.Basic.AnsibleModule]
+        $Module,
+
+        [Parameter(Mandatory = $true)]
+        [String]
+        $Path,
+
+        [String]
+        $Regex,
+
+        [String]
+        $Line,
+
+        [bool]
+        $Backup,
+
+        [String]
+        $Validate,
+
+        [Parameter(Mandatory = $true)]
+        [System.Text.Encoding]
+        $Encoding,
+
+        [Parameter(Mandatory = $true)]
+        [String]
+        $LineSep
+    )
+
+    # Check if path exists. If it does not exist, fail with a reasonable error message.
+    if (-not (Test-Path -LiteralPath $Path)) {
+        $Module.FailJson("Path $Path does not exist !")
+    }
+
+    # Read the dest file lines using the indicated encoding into a mutable ArrayList. Note that we have to clean up
+    # the path because Ansible wants to treat / and \ as interchangeable in Windows pathnames, but .NET framework
+    # internals do not support that.
+    $cleanPath = $Path.Replace("/", "\")
+    $before = [System.IO.File]::ReadAllLines($cleanPath, $Encoding)
+    if ($null -eq $before) {
+        $lines = New-Object -TypeName System.Collections.ArrayList
+    }
+    else {
+        $lines = [System.Collections.ArrayList]$before
+        $allText = [System.IO.File]::ReadAllText($cleanPath, $Encoding)
+        if (($allText[-1] -eq "`n") -or ($allText[-1] -eq "`r")) {
+            $lines.Add("") > $null
+            $before += ""
+        }
+    }
+
+    if ($Module.DiffMode) {
+        $Module.Diff.before = $before -join $LineSep
+    }
+
+    # Compile the regex specified, if provided.
+    $cre = $null
+    if ($Regex) {
+        $cre = [regex]::new($Regex, [System.Text.RegularExpressions.RegexOptions]::Compiled)
+    }
+
+    $found = New-Object -TypeName System.Collections.ArrayList
+    $left = New-Object -TypeName System.Collections.ArrayList
+
+    foreach ($curLine in $lines) {
+        if ($Regex) {
+            $matchFound = $cre.Match($curLine).Success
+        }
+        else {
+            $matchFound = $Line -ceq $curLine
+        }
+
+        if ($matchFound) {
+            $found.Add($curLine) > $null
+            $Module.Result.changed = $true
+        }
+        else {
+            $left.Add($curLine) > $null
+        }
+    }
+
+    # Write changes to the path if changes were made.
+    if ($Module.Result.changed) {
+        if ($Backup) {
+            $checkMode = $Module.CheckMode
+            $Module.Result.backup_file = Backup-File -path $Path -WhatIf:$checkMode
+        }
+
+        $writeParams = @{
+            Module = $Module
+            OutLines = $left
+            Path = $Path
+            LineSep = $LineSep
+            Encoding = $Encoding
+            Validate = $Validate
+        }
+        $after = Write-TargetFile @writeParams
+
+        if ($Module.DiffMode) {
+            $Module.Diff.after = $after
+        }
+    }
+
+    $Module.Result.encoding = $Encoding.WebName
+    $Module.Result.found = $found.Count
+    $Module.Result.msg = "$($found.Count) line(s) removed"
+}
+
+# Fail if the path is not a file.
+if (Test-Path -LiteralPath $path -PathType Container) {
+    $module.FailJson("Path $path is a directory")
+}
+
+# Default to the windows line separator - probably the most common.
+$linesep = "`r`n"
+if ($newline -eq "unix") {
+    $linesep = "`n"
+}
+
+# Figure out the proper encoding to use for reading from / writing to the target file.
+$encodingObj = Get-TargetEncoding -Path $path -Encoding $encoding
+
+# Main dispatch - based on the value of 'state', perform argument validation and call the appropriate handler.
+if ($state -eq "present") {
+    if ($backrefs -and -not $regex) {
+        $module.FailJson("regexp= is required with backrefs=true")
+    }
+
+    if (-not $line) {
+        $module.FailJson("line= is required with state=present")
+    }
+
+    if (-not $insertbefore -and -not $insertafter) {
+        $insertafter = "EOF"
+    }
+
+    $presentParams = @{
+        Module = $module
+        Path = $path
+        Regex = $regex
+        Line = $line
+        InsertAfter = $insertafter
+        InsertBefore = $insertbefore
+        Create = $create
+        Backup = $backup
+        Backrefs = $backrefs
+        Validate = $validate
+        Encoding = $encodingObj
+        LineSep = $linesep
+    }
+    Set-TargetLine @presentParams
+}
+else {
+    if (-not $regex -and -not $line) {
+        $module.FailJson("one of line= or regexp= is required with state=absent")
+    }
+
+    $absentParams = @{
+        Module = $module
+        Path = $path
+        Regex = $regex
+        Line = $line
+        Backup = $backup
+        Validate = $validate
+        Encoding = $encodingObj
+        LineSep = $linesep
+    }
+    Remove-TargetLine @absentParams
+}
+
+$module.ExitJson()

--- a/plugins/modules/win_lineinfile.py
+++ b/plugins/modules/win_lineinfile.py
@@ -1,0 +1,205 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2015, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r'''
+---
+module: win_lineinfile
+version_added: 3.9.0
+short_description: Ensure a particular line is in a file, or replace an existing line using a back-referenced regular expression
+description:
+- This module will search a file for a line, and ensure that it is present or absent.
+- This is primarily useful when you want to change a single line in a file only.
+- For non-Windows targets, use the M(ansible.builtin.lineinfile) module instead.
+options:
+  path:
+    description:
+    - The path of the file to modify.
+    - Note that the Windows path delimiter C(\\) must be escaped as C(\\\\) when the line is double quoted.
+    type: path
+    required: true
+    aliases: [ dest, destfile, name ]
+  backup:
+    description:
+    - Determine whether a backup should be created.
+    - When set to V(true), create a backup file including the timestamp information
+      so you can get the original file back if you somehow clobbered it incorrectly.
+    type: bool
+    default: false
+  regex:
+    description:
+    - The regular expression to look for in every line of the file.
+    - For O(state=present), the pattern to replace if found; only the last line found will be replaced.
+    - For O(state=absent), the pattern of the line to remove.
+    - Uses .NET compatible regular expressions, see
+      U(https://learn.microsoft.com/en-us/dotnet/standard/base-types/regular-expression-language-quick-reference).
+    type: str
+    aliases: [ regexp ]
+  state:
+    description:
+    - Whether the line should be there or not.
+    type: str
+    choices: [ absent, present ]
+    default: present
+  line:
+    description:
+    - Required for O(state=present). The line to insert/replace into the file.
+    - If O(backrefs) is set, may contain backreferences that will get expanded with the O(regex) capture
+      groups if the regex matches.
+    - Be aware that the line is processed first on the controller and thus is dependent on yaml quoting rules.
+      Any double quoted line will have control characters, such as C(\\r\\n), expanded. To print such characters
+      literally, use single or no quotes.
+    type: str
+  backrefs:
+    description:
+    - Used with O(state=present).
+    - If set, O(line) can contain backreferences (both positional and named) that will get populated if the
+      O(regex) matches.
+    - This flag changes the operation of the module slightly; O(insertbefore) and O(insertafter) will be ignored,
+      and if the O(regex) does not match anywhere in the file, the file will be left unchanged.
+    - If the O(regex) does match, the last matching line will be replaced by the expanded O(line) parameter.
+    type: bool
+    default: false
+  insertafter:
+    description:
+    - Used with O(state=present).
+    - If specified, the line will be inserted after the last match of the specified regular expression.
+    - A special value V(EOF) is available for inserting the line at the end of the file.
+    - If the specified regular expression has no matches, V(EOF) will be used instead.
+    - May not be used with O(backrefs).
+    - Defaults to V(EOF) when neither O(insertafter) nor O(insertbefore) is specified.
+    type: str
+  insertbefore:
+    description:
+    - Used with O(state=present).
+    - If specified, the line will be inserted before the last match of the specified regular expression.
+    - A special value V(BOF) is available for inserting the line at the beginning of the file.
+    - If the specified regular expression has no matches, the line will be inserted at the end of the file.
+    - May not be used with O(backrefs).
+    type: str
+  create:
+    description:
+    - Used with O(state=present).
+    - If specified, the file will be created if it does not already exist.
+    - By default it will fail if the file is missing.
+    type: bool
+    default: false
+  validate:
+    description:
+    - Validation to run before copying into place.
+    - Use C(%s) in the command to indicate the current file to validate.
+    - The command is passed securely so shell features like expansion and pipes will not work.
+    type: str
+  encoding:
+    description:
+    - Specifies the encoding of the source text file to operate on (and thus what the output encoding will be).
+    - The default of V(auto) will cause the module to auto-detect the encoding of the source file and ensure that
+      the modified file is written with the same encoding.
+    - An explicit encoding can be passed as a string that is a valid value to pass to the .NET framework
+      C(System.Text.Encoding.GetEncoding()) method, see
+      U(https://learn.microsoft.com/en-us/dotnet/api/system.text.encoding.getencoding).
+    - This is mostly useful with O(create=true) if you want to create a new file with a specific encoding.
+    - If O(create=true) is specified without a specific encoding, the default encoding (UTF-8, no BOM) will be used.
+    type: str
+    default: auto
+  newline:
+    description:
+    - Specifies the line separator style to use for the modified file.
+    - This defaults to the windows line separator C(\\r\\n).
+    - Note that the indicated line separator will be used for file output regardless of the original line
+      separator that appears in the input file.
+    type: str
+    choices: [ unix, windows ]
+    default: windows
+seealso:
+- module: ansible.builtin.assemble
+- module: ansible.builtin.lineinfile
+- module: ansible.windows.win_copy
+- module: ansible.windows.win_template
+author:
+- Brian Lloyd (@brianlloyd)
+'''
+
+EXAMPLES = r'''
+- name: Insert path without converting \r\n
+  ansible.windows.win_lineinfile:
+    path: c:\file.txt
+    line: c:\return\new
+
+- name: Replace a line matching a regex
+  ansible.windows.win_lineinfile:
+    path: C:\Temp\example.conf
+    regex: '^name='
+    line: 'name=JohnDoe'
+
+- name: Remove a line matching a regex
+  ansible.windows.win_lineinfile:
+    path: C:\Temp\example.conf
+    regex: '^name='
+    state: absent
+
+- name: Ensure the localhost entry is correct
+  ansible.windows.win_lineinfile:
+    path: C:\Temp\example.conf
+    regex: '^127\.0\.0\.1'
+    line: '127.0.0.1 localhost'
+
+- name: Uncomment and set a Listen directive
+  ansible.windows.win_lineinfile:
+    path: C:\Temp\httpd.conf
+    regex: '^Listen '
+    insertafter: '^#Listen '
+    line: Listen 8080
+
+- name: Insert a comment before a services entry
+  ansible.windows.win_lineinfile:
+    path: C:\Temp\services
+    regex: '^# port for http'
+    insertbefore: '^www.*80/tcp'
+    line: '# port for http by default'
+
+- name: Create file if it doesn't exist with a specific encoding
+  ansible.windows.win_lineinfile:
+    path: C:\Temp\utf16.txt
+    create: true
+    encoding: utf-16
+    line: This is a utf-16 encoded file
+
+- name: Add a line to a file and ensure the resulting file uses unix line separators
+  ansible.windows.win_lineinfile:
+    path: C:\Temp\testfile.txt
+    line: Line added to file
+    newline: unix
+
+- name: Update a line using backrefs
+  ansible.windows.win_lineinfile:
+    path: C:\Temp\example.conf
+    backrefs: true
+    regex: '(^name=)'
+    line: '$1JohnDoe'
+'''
+
+RETURN = r'''
+backup_file:
+  description: Name of the backup file that was created.
+  returned: if O(backup=true) and a change was made
+  type: str
+  sample: C:\Path\To\File.txt.11540.20150212-220915.bak
+encoding:
+  description: The encoding that was used to read from and write to the file.
+  returned: success
+  type: str
+  sample: utf-8
+found:
+  description: The number of lines that matched and were removed.
+  returned: O(state=absent)
+  type: int
+  sample: 1
+msg:
+  description: A short description of the change that was made.
+  returned: success
+  type: str
+  sample: line added
+'''

--- a/tests/integration/targets/win_lineinfile/aliases
+++ b/tests/integration/targets/win_lineinfile/aliases
@@ -1,0 +1,1 @@
+shippable/windows/group1

--- a/tests/integration/targets/win_lineinfile/files/expectations/.gitattributes
+++ b/tests/integration/targets/win_lineinfile/files/expectations/.gitattributes
@@ -1,0 +1,4 @@
+*.text text eol=LF
+*.txt text eol=CRLF
+*.txt16 text working-tree-encoding=UTF-16 eol=CRLF
+*.txt32	text working-tree-encoding=UTF-32 eol=CRLF

--- a/tests/integration/targets/win_lineinfile/files/expectations/01_new_line_at_bof.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/01_new_line_at_bof.txt
@@ -1,0 +1,6 @@
+New line at the beginning
+This is line 1
+This is line 2
+REF this is a line for backrefs REF
+This is line 4
+This is line 5

--- a/tests/integration/targets/win_lineinfile/files/expectations/02_new_line_at_eof.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/02_new_line_at_eof.txt
@@ -1,0 +1,7 @@
+New line at the beginning
+This is line 1
+This is line 2
+REF this is a line for backrefs REF
+This is line 4
+This is line 5
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/03_new_line_after_1.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/03_new_line_after_1.txt
@@ -1,0 +1,8 @@
+New line at the beginning
+This is line 1
+New line after line 1
+This is line 2
+REF this is a line for backrefs REF
+This is line 4
+This is line 5
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/04_new_line_before_5.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/04_new_line_before_5.txt
@@ -1,0 +1,9 @@
+New line at the beginning
+This is line 1
+New line after line 1
+This is line 2
+REF this is a line for backrefs REF
+This is line 4
+New line before line 5
+This is line 5
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/05_new_line_at_REF.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/05_new_line_at_REF.txt
@@ -1,0 +1,9 @@
+New line at the beginning
+This is line 1
+New line after line 1
+This is line 2
+This is line 3
+This is line 4
+New line before line 5
+This is line 5
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/06_remove_middle_line.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/06_remove_middle_line.txt
@@ -1,0 +1,8 @@
+New line at the beginning
+This is line 1
+New line after line 1
+This is line 2
+This is line 4
+New line before line 5
+This is line 5
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/07_remove_line_5.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/07_remove_line_5.txt
@@ -1,0 +1,7 @@
+New line at the beginning
+This is line 1
+New line after line 1
+This is line 2
+This is line 4
+New line before line 5
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/08_no_expected_change.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/08_no_expected_change.txt
@@ -1,0 +1,7 @@
+New line at the beginning
+This is line 1
+New line after line 1
+This is line 2
+This is line 4
+New line before line 5
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/09_new_file.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/09_new_file.txt
@@ -1,0 +1,1 @@
+This is a new file

--- a/tests/integration/targets/win_lineinfile/files/expectations/10_no_eof_new_at_eof.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/10_no_eof_new_at_eof.txt
@@ -1,0 +1,3 @@
+This is line 1
+This is line 2
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/11_multiline_at_eof.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/11_multiline_at_eof.txt
@@ -1,0 +1,9 @@
+New line at the beginning
+This is line 1
+New line after line 1
+This is line 2
+This is line 4
+New line before line 5
+New line at the end
+This is a line
+with newline character

--- a/tests/integration/targets/win_lineinfile/files/expectations/12_empty_file_add_at_eof.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/12_empty_file_add_at_eof.txt
@@ -1,0 +1,1 @@
+New line at the end

--- a/tests/integration/targets/win_lineinfile/files/expectations/13_new_4_with_backref.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/13_new_4_with_backref.txt
@@ -1,0 +1,9 @@
+New line at the beginning
+This is line 1
+New line after line 1
+This is line 2
+New line 4 created with the backref
+New line before line 5
+New line at the end
+This is a line
+with newline character

--- a/tests/integration/targets/win_lineinfile/files/expectations/14_quoting_code.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/14_quoting_code.txt
@@ -1,0 +1,3 @@
+var dotenv = require('dotenv');
+dotenv.load();
+'foo'

--- a/tests/integration/targets/win_lineinfile/files/expectations/15_single_quote.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/15_single_quote.txt
@@ -1,0 +1,4 @@
+var dotenv = require('dotenv');
+dotenv.load();
+'foo'
+import g'

--- a/tests/integration/targets/win_lineinfile/files/expectations/16_multiple_quotes.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/16_multiple_quotes.txt
@@ -1,0 +1,5 @@
+var dotenv = require('dotenv');
+dotenv.load();
+'foo'
+import g'
+"quote" and "unquote"

--- a/tests/integration/targets/win_lineinfile/files/expectations/17_new_file_win.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/17_new_file_win.txt
@@ -1,0 +1,1 @@
+This is a new file

--- a/tests/integration/targets/win_lineinfile/files/expectations/18_sep_win.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/18_sep_win.txt
@@ -1,0 +1,2 @@
+This is a new file
+This is the last line

--- a/tests/integration/targets/win_lineinfile/files/expectations/19_new_file_unix.text
+++ b/tests/integration/targets/win_lineinfile/files/expectations/19_new_file_unix.text
@@ -1,0 +1,1 @@
+This is a new file

--- a/tests/integration/targets/win_lineinfile/files/expectations/20_sep_unix.text
+++ b/tests/integration/targets/win_lineinfile/files/expectations/20_sep_unix.text
@@ -1,0 +1,2 @@
+This is a new file
+This is the last line

--- a/tests/integration/targets/win_lineinfile/files/expectations/21_utf8_no_bom.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/21_utf8_no_bom.txt
@@ -1,0 +1,1 @@
+This is a new utf-8 file

--- a/tests/integration/targets/win_lineinfile/files/expectations/22_utf8_no_bom_line_added.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/22_utf8_no_bom_line_added.txt
@@ -1,0 +1,2 @@
+This is a new utf-8 file
+This is the last line

--- a/tests/integration/targets/win_lineinfile/files/expectations/23_utf8_bom.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/23_utf8_bom.txt
@@ -1,0 +1,1 @@
+﻿This is a new utf-8 file

--- a/tests/integration/targets/win_lineinfile/files/expectations/24_utf8_bom_line_added.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/24_utf8_bom_line_added.txt
@@ -1,0 +1,2 @@
+﻿This is a new utf-8 file
+This is the last line

--- a/tests/integration/targets/win_lineinfile/files/expectations/25_utf16.txt16
+++ b/tests/integration/targets/win_lineinfile/files/expectations/25_utf16.txt16
@@ -1,0 +1,1 @@
+This is a new utf-16 file

--- a/tests/integration/targets/win_lineinfile/files/expectations/26_utf16_line_added.txt16
+++ b/tests/integration/targets/win_lineinfile/files/expectations/26_utf16_line_added.txt16
@@ -1,0 +1,2 @@
+This is a new utf-16 file
+This is the last line

--- a/tests/integration/targets/win_lineinfile/files/expectations/27_utf32.txt32
+++ b/tests/integration/targets/win_lineinfile/files/expectations/27_utf32.txt32
@@ -1,0 +1,1 @@
+This is a new utf-32 file

--- a/tests/integration/targets/win_lineinfile/files/expectations/28_utf32_line_added.txt32
+++ b/tests/integration/targets/win_lineinfile/files/expectations/28_utf32_line_added.txt32
@@ -1,0 +1,2 @@
+This is a new utf-32 file
+This is the last line

--- a/tests/integration/targets/win_lineinfile/files/expectations/29_no_linebreak.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/29_no_linebreak.txt
@@ -1,0 +1,1 @@
+c:\return\new

--- a/tests/integration/targets/win_lineinfile/files/expectations/30_linebreaks_checksum_bad.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/30_linebreaks_checksum_bad.txt
@@ -1,0 +1,3 @@
+c:\return\new
+c:eturn
+ew

--- a/tests/integration/targets/win_lineinfile/files/expectations/31_relative_path.txt
+++ b/tests/integration/targets/win_lineinfile/files/expectations/31_relative_path.txt
@@ -1,0 +1,6 @@
+New line at the beginning
+This is line 1
+This is line 2
+REF this is a line for backrefs REF
+This is line 4
+This is line 5

--- a/tests/integration/targets/win_lineinfile/files/expectations/99_README.md
+++ b/tests/integration/targets/win_lineinfile/files/expectations/99_README.md
@@ -1,0 +1,36 @@
+***WIN LINEINFILE Expectations***
+
+This folder contains expected files as the tests in this playbook executes on the
+files in 'files'. 
+
+To get the checksum as would win_stat in the tests, go to this folder in powershell and
+execute
+
+```powershell
+Get-ChildItem | ForEach-Object {
+    $fp = [System.IO.File]::Open("$pwd/$($_.Name)", [System.IO.Filemode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite)
+    Write-Output $_.Name
+    try {
+        [System.BitConverter]::ToString($sp.ComputeHash($fp)).Replace("-", "").ToLower()
+    } finally {
+        $fp.Dispose()
+    }
+    Write-Output ""
+}
+```
+
+There is one exception right now: 30_linebreaks_checksum_bad.txt which requires mixed line endings that 
+git cannot handle without turning the file binary. The file should read
+
+```
+c:\return\newCRLF
+c:CR
+eturnLF
+ew
+```
+where CR and LF denote carriage return (\r) and line feed (\n) respectively, to get the correct checksum.
+
+Also, the .gitattributes files is important as it assures that the EOL characters
+for the files are correct, regardless of environment. The files may be checked out on
+linux but the resulting files will be created using windows EOL, and the comparison must
+match.

--- a/tests/integration/targets/win_lineinfile/files/test.txt
+++ b/tests/integration/targets/win_lineinfile/files/test.txt
@@ -1,0 +1,5 @@
+This is line 1
+This is line 2
+REF this is a line for backrefs REF
+This is line 4
+This is line 5

--- a/tests/integration/targets/win_lineinfile/files/testnoeof.txt
+++ b/tests/integration/targets/win_lineinfile/files/testnoeof.txt
@@ -1,0 +1,2 @@
+This is line 1
+This is line 2

--- a/tests/integration/targets/win_lineinfile/meta/main.yml
+++ b/tests/integration/targets/win_lineinfile/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- setup_remote_tmp_dir

--- a/tests/integration/targets/win_lineinfile/tasks/main.yml
+++ b/tests/integration/targets/win_lineinfile/tasks/main.yml
@@ -1,0 +1,1468 @@
+# Test code for the win_lineinfile module, adapted from the standard lineinfile module tests
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# The expected content behind each checksum used in this target is recorded in files/expectations/,
+# see files/expectations/99_README.md. Note that files/expectations/.gitattributes pins the line
+# endings and working tree encoding of those fixtures, without it the encoding tests silently break.
+
+- name: deploy the test file for lineinfile
+  ansible.windows.win_copy:
+    src: test.txt
+    dest: '{{ remote_tmp_dir }}/test.txt'
+  register: result
+
+- name: assert that the test file was deployed
+  assert:
+    that:
+    - result is changed
+
+- name: stat the test file
+  # Note: The test.txt is copied from a Linux host, therefore it will retain
+  # unix line ending when stat'd here. This affects checksum, meaning that
+  # when this repo is checked out to Windows, checksum does not match checked-
+  # out file checksum unless line-endings are altered.
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test.txt'
+  register: result
+
+- name: check win_stat file result
+  assert:
+    that:
+    - result.stat.exists
+    - not result.stat.isdir
+    - result.stat.checksum == '5feac65e442c91f557fc90069ce6efc4d346ab51'
+    - result is not failed
+    - result is not changed
+
+# 01
+- name: insert a line at the beginning of the file, and back it up
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: present
+    line: New line at the beginning
+    insertbefore: BOF
+    backup: true
+  register: result
+
+- name: stat the backup file
+  ansible.windows.win_stat:
+    path: '{{ result.backup_file }}'
+  register: backup_file
+
+- name: assert that the line was inserted at the head of the file
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+    - result.encoding == 'utf-8'
+    - backup_file.stat.exists
+    - backup_file.stat.checksum == '5feac65e442c91f557fc90069ce6efc4d346ab51'
+
+- name: insert a line at the beginning of the file again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: present
+    line: New line at the beginning
+    insertbefore: BOF
+    backup: true
+  register: result_again
+
+- name: assert that inserting the line at the head of the file is idempotent
+  assert:
+    that:
+    - result_again is not changed
+    - result_again.backup_file is not defined
+
+- name: stat the test after the insert at the head
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test.txt'
+  register: result
+
+- name: assert test hash is what we expect for the file with the insert at the head
+  assert:
+    that:
+    - result.stat.checksum == 'c61233b0ee2038aab41b5f30683c57b2a013b376'
+
+# 02
+- name: insert a line at the end of the file
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: present
+    line: New line at the end
+    insertafter: EOF
+  register: result
+
+- name: assert that the line was inserted at the end of the file
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+
+- name: insert a line at the end of the file again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: present
+    line: New line at the end
+    insertafter: EOF
+  register: result_again
+
+- name: assert that inserting the line at the end of the file is idempotent
+  assert:
+    that:
+    - result_again is not changed
+
+- name: stat the test after the insert at the end
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test.txt'
+  register: result
+
+- name: assert test checksum matches after the insert at the end
+  assert:
+    that:
+    - result.stat.checksum == 'a91260ad67b00609cc0737ff70ac5170c6a519a8'
+
+# 03
+- name: insert a line after the first line
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: present
+    line: New line after line 1
+    insertafter: '^This is line 1$'
+  register: result
+
+- name: assert that the line was inserted after the first line
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+
+- name: insert a line after the first line again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: present
+    line: New line after line 1
+    insertafter: '^This is line 1$'
+  register: result_again
+
+- name: assert that inserting a line after the first line is idempotent
+  assert:
+    that:
+    - result_again is not changed
+
+- name: stat the test after insert after the first line
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test.txt'
+  register: result
+
+- name: assert test checksum matches after the insert after the first line
+  assert:
+    that:
+    - result.stat.checksum == '6ffbabdaa21ecb3593d32144de535598cfd7c6ea'
+
+# 04
+- name: insert a line before the last line
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: present
+    line: New line before line 5
+    insertbefore: '^This is line 5$'
+  register: result
+
+- name: assert that the line was inserted before the last line
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+
+- name: insert a line before the last line again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: present
+    line: New line before line 5
+    insertbefore: '^This is line 5$'
+  register: result_again
+
+- name: assert that inserting a line before the last line is idempotent
+  assert:
+    that:
+    - result_again is not changed
+
+- name: stat the test after the insert before the last line
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test.txt'
+  register: result
+
+- name: assert test checksum matches after the insert before the last line
+  assert:
+    that:
+    - result.stat.checksum == '49d988ad97fb4cce3ad795c8459f1cde231a891b'
+
+# 05
+- name: replace a line with backrefs
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: present
+    line: This is line 3
+    backrefs: true
+    regex: '^(REF).*$'
+  register: result
+
+- name: assert that the line with backrefs was changed
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line replaced'
+
+- name: replace a line with backrefs again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: present
+    line: This is line 3
+    backrefs: true
+    regex: '^(REF).*$'
+  register: result_again
+
+- name: assert that replacing a line with backrefs is idempotent
+  assert:
+    that:
+    - result_again is not changed
+
+- name: stat the test after the backref line was replaced
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test.txt'
+  register: result
+
+- name: assert test checksum matches after backref line was replaced
+  assert:
+    that:
+    - result.stat.checksum == '6f9c2128f4c886f3c40c1f1cf50241d74f160437'
+
+# 06
+- name: remove the middle line
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: absent
+    regex: '^This is line 3$'
+  register: result
+
+- name: assert that the line was removed
+  assert:
+    that:
+    - result is changed
+    - result.msg == '1 line(s) removed'
+    - result.found == 1
+
+- name: remove the middle line again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: absent
+    regex: '^This is line 3$'
+  register: result_again
+
+- name: assert that removing the middle line is idempotent
+  assert:
+    that:
+    - result_again is not changed
+    - result_again.msg == '0 line(s) removed'
+    - result_again.found == 0
+
+- name: stat the test after the middle line was removed
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test.txt'
+  register: result
+
+- name: assert test checksum matches after the middle line was removed
+  assert:
+    that:
+    - result.stat.checksum == '4b7910c84bd1177b9013f277c85d5be55f384a36'
+
+# 07
+- name: run a validation script that succeeds
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: absent
+    regex: '^This is line 5$'
+    validate: sort.exe %s
+  register: result
+
+- name: assert that the file validated after removing a line
+  assert:
+    that:
+    - result is changed
+    - result.msg == '1 line(s) removed'
+
+- name: run a validation script that succeeds again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: absent
+    regex: '^This is line 5$'
+    validate: sort.exe %s
+  register: result_again
+
+- name: assert that removing a validated line is idempotent
+  assert:
+    that:
+    - result_again is not changed
+    - result_again.msg == '0 line(s) removed'
+
+- name: stat the test after the validation succeeded
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test.txt'
+  register: result
+
+- name: assert test checksum matches after the validation succeeded
+  assert:
+    that:
+    - result.stat.checksum == '938afecdcde51fda42ddbea6f2e92876e710f289'
+
+# 08 - this task is expected to fail, so there is no idempotency check for it
+- name: run a validation script that fails
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: absent
+    regex: '^This is line 1$'
+    validate: sort.exe %s.foo
+  register: result
+  ignore_errors: true
+
+- name: assert that the validate failed
+  assert:
+    that:
+    - result is failed
+    - "'failed to validate' in result.msg"
+
+- name: stat the test after the validation failed
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test.txt'
+  register: result
+
+- name: assert test checksum matches the previous after the validation failed
+  assert:
+    that:
+    - result.stat.checksum == '938afecdcde51fda42ddbea6f2e92876e710f289'
+
+- name: run a validation command that is missing the %s placeholder
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: absent
+    regex: '^This is line 1$'
+    validate: sort.exe
+  register: result
+  ignore_errors: true
+
+- name: assert that the missing placeholder was reported
+  assert:
+    that:
+    - result is failed
+    - result.msg == 'validate must contain %s: sort.exe'
+
+- name: stat the test after the validate placeholder failure
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test.txt'
+  register: result
+
+- name: assert the file was left alone after the validate placeholder failure
+  assert:
+    that:
+    - result.stat.checksum == '938afecdcde51fda42ddbea6f2e92876e710f289'
+
+# 09
+- name: use create=true
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/new_test.txt'
+    create: true
+    insertbefore: BOF
+    state: present
+    line: This is a new file
+  register: result
+
+- name: assert that the new file was created
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+
+- name: use create=true again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/new_test.txt'
+    create: true
+    insertbefore: BOF
+    state: present
+    line: This is a new file
+  register: result_again
+
+- name: assert that creating the file is idempotent
+  assert:
+    that:
+    - result_again is not changed
+
+- name: validate that the newly created file exists
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/new_test.txt'
+  register: result
+
+- name: assert the newly created test checksum matches
+  assert:
+    that:
+    - result.stat.checksum == '84faac1183841c57434693752fc3debc91b9195d'
+
+- name: fail when the file is missing and create is not set
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/does_not_exist.txt'
+    state: present
+    line: This should not be written
+  register: result
+  ignore_errors: true
+
+- name: assert that a missing file without create failed
+  assert:
+    that:
+    - result is failed
+    - "'does not exist' in result.msg"
+
+# Test EOF in cases where file has no newline at EOF
+- name: testnoeof deploy the file for lineinfile
+  ansible.windows.win_copy:
+    src: testnoeof.txt
+    dest: '{{ remote_tmp_dir }}/testnoeof.txt'
+  register: result
+
+# 10
+- name: testnoeof insert a line at the end of the file
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/testnoeof.txt'
+    state: present
+    line: New line at the end
+    insertafter: EOF
+  register: result
+
+- name: testnoeof assert that the line was inserted at the end of the file
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+
+- name: testnoeof insert a line at the end of the file again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/testnoeof.txt'
+    state: present
+    line: New line at the end
+    insertafter: EOF
+  register: result_again
+
+- name: testnoeof assert that appending to a file without a trailing newline is idempotent
+  assert:
+    that:
+    - result_again is not changed
+
+- name: testnoeof stat the no newline EOF test after the insert at the end
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/testnoeof.txt'
+  register: result
+
+- name: testnoeof assert test checksum matches after the insert at the end
+  assert:
+    that:
+    - result.stat.checksum == '229852b09f7e9921fbcbb0ee0166ba78f7f7f261'
+
+# 11
+# The line below is a YAML double quoted scalar, so \r\n is expanded into a real line break before
+# the module ever sees it. The resulting line cannot be matched again when the file is read back
+# line by line, so this operation is inherently not idempotent and deliberately is not re-run.
+- name: add multiple lines at the end of the file
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: present
+    line: "This is a line\r\nwith newline character"
+    insertafter: EOF
+  register: result
+
+- name: assert that the multiple lines was inserted
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+
+- name: stat file after adding multiple lines
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test.txt'
+  register: result
+
+- name: assert test checksum matches after inserting multiple lines
+  assert:
+    that:
+    - result.stat.checksum == 'd10d70cb77a16fb54f143bccbf711f3177acd310'
+
+# Test EOF with empty file to make sure no unnecessary newline is added
+- name: testempty deploy the testempty file for lineinfile
+  ansible.windows.win_copy:
+    src: testempty.txt
+    dest: '{{ remote_tmp_dir }}/testempty.txt'
+  register: result
+
+# 12
+- name: testempty insert a line at the end of the file
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/testempty.txt'
+    state: present
+    line: New line at the end
+    insertafter: EOF
+  register: result
+
+- name: testempty assert that the line was inserted at the end of the file
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+
+- name: testempty insert a line at the end of the file again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/testempty.txt'
+    state: present
+    line: New line at the end
+    insertafter: EOF
+  register: result_again
+
+- name: testempty assert that appending to an empty file is idempotent
+  assert:
+    that:
+    - result_again is not changed
+
+- name: testempty stat the test after the insert at the end
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/testempty.txt'
+  register: result
+
+- name: testempty assert test checksum matches after the insert at the end
+  assert:
+    that:
+    - result.stat.checksum == 'd3d34f11edda51be7ca5dcb0757cf3e1257c0bfe'
+
+# 13
+- name: replace a line with backrefs included in the line
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: present
+    line: New $1 created with the backref
+    backrefs: true
+    regex: '^This is (line 4)$'
+  register: result
+
+- name: assert that the line with backrefs was changed
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line replaced'
+
+- name: replace a line with backrefs included in the line again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: present
+    line: New $1 created with the backref
+    backrefs: true
+    regex: '^This is (line 4)$'
+  register: result_again
+
+- name: assert that replacing a line with an expanded backref is idempotent
+  assert:
+    that:
+    - result_again is not changed
+
+- name: stat the test after the backref line was replaced
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test.txt'
+  register: result
+
+- name: assert test checksum matches after backref line was replaced
+  assert:
+    that:
+    - result.stat.checksum == '9c1a1451b50665e59be666c5d8c08fb99603d4f1'
+
+- name: fail when backrefs is used without a regex
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: present
+    line: This should not be written
+    backrefs: true
+  register: result
+  ignore_errors: true
+
+- name: assert that backrefs without a regex failed
+  assert:
+    that:
+    - result is failed
+    - result.msg == 'regexp= is required with backrefs=true'
+
+- name: fail when state=absent is used without a line or regex
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test.txt'
+    state: absent
+  register: result
+  ignore_errors: true
+
+- name: assert that state=absent without a line or regex failed
+  assert:
+    that:
+    - result is failed
+    - result.msg == 'one of line= or regexp= is required with state=absent'
+
+- name: fail when the path is a directory
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}'
+    state: present
+    line: This should not be written
+  register: result
+  ignore_errors: true
+
+- name: assert that a directory path failed
+  assert:
+    that:
+    - result is failed
+    - "'is a directory' in result.msg"
+
+###################################################################
+# issue 8535
+
+# 14
+- name: create a new file for testing quoting issues
+  ansible.windows.win_copy:
+    src: test_quoting.txt
+    dest: '{{ remote_tmp_dir }}/test_quoting.txt'
+  register: result
+
+- name: assert the new file was created
+  assert:
+    that:
+    - result is changed
+
+- name: use with_items to add code-like strings to the quoting txt file
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_quoting.txt'
+    line: '{{ item }}'
+    insertbefore: BOF
+  with_items:
+  - "'foo'"
+  - "dotenv.load();"
+  - "var dotenv = require('dotenv');"
+  register: result
+
+- name: assert the quote test file was modified correctly
+  assert:
+    that:
+    - result.results | length == 3
+    - result.results[0] is changed
+    - result.results[0].item == "'foo'"
+    - result.results[1] is changed
+    - result.results[1].item == "dotenv.load();"
+    - result.results[2] is changed
+    - result.results[2].item == "var dotenv = require('dotenv');"
+
+- name: use with_items to add code-like strings to the quoting txt file again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_quoting.txt'
+    line: '{{ item }}'
+    insertbefore: BOF
+  with_items:
+  - "'foo'"
+  - "dotenv.load();"
+  - "var dotenv = require('dotenv');"
+  register: result_again
+
+- name: assert adding the code-like strings is idempotent
+  assert:
+    that:
+    - result_again.results | length == 3
+    - result_again.results[0] is not changed
+    - result_again.results[1] is not changed
+    - result_again.results[2] is not changed
+
+- name: stat the quote test file
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_quoting.txt'
+  register: result
+
+- name: assert test checksum matches for quote test file
+  assert:
+    that:
+    - result.stat.checksum == 'f3bccdbdfa1d7176c497ef87d04957af40ab48d2'
+
+# 15
+- name: append a line into the quoted file with a single quote
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_quoting.txt'
+    line: "import g'"
+  register: result
+
+- name: assert that the quoted file was changed
+  assert:
+    that:
+    - result is changed
+
+- name: append a line into the quoted file with a single quote again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_quoting.txt'
+    line: "import g'"
+  register: result_again
+
+- name: assert appending a single quoted line is idempotent
+  assert:
+    that:
+    - result_again is not changed
+
+- name: stat the quote test file
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_quoting.txt'
+  register: result
+
+- name: assert test checksum matches adding line with single quote
+  assert:
+    that:
+    - result.stat.checksum == 'dabf4cbe471e1797d8dcfc773b6b638c524d5237'
+
+# 16
+- name: insert a line into the quoted file with many double quotation strings
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_quoting.txt'
+    line: '"quote" and "unquote"'
+  register: result
+
+- name: assert that the quoted file was changed
+  assert:
+    that:
+    - result is changed
+
+- name: insert a line into the quoted file with many double quotation strings again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_quoting.txt'
+    line: '"quote" and "unquote"'
+  register: result_again
+
+- name: assert inserting a double quoted line is idempotent
+  assert:
+    that:
+    - result_again is not changed
+
+- name: stat the quote test file
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_quoting.txt'
+  register: result
+
+- name: assert test checksum matches quoted line added
+  assert:
+    that:
+    - result.stat.checksum == '9dc1fc1ff19942e2936564102ad37134fa83b91d'
+
+# Windows vs. Unix line separator test cases
+
+# 17
+- name: Create windows test file with initial line
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_windows_sep.txt'
+    create: true
+    insertbefore: BOF
+    state: present
+    line: This is a new file
+  register: result
+
+- name: assert that the new file was created
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+
+- name: Create windows test file with initial line again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_windows_sep.txt'
+    create: true
+    insertbefore: BOF
+    state: present
+    line: This is a new file
+  register: result_again
+
+- name: assert that creating the windows test file is idempotent
+  assert:
+    that:
+    - result_again is not changed
+
+- name: validate that the newly created file exists
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_windows_sep.txt'
+  register: result
+
+- name: assert the newly created file checksum matches
+  assert:
+    that:
+    - result.stat.checksum == '84faac1183841c57434693752fc3debc91b9195d'
+
+# 18
+- name: Test appending to the file using the default (windows) line separator
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_windows_sep.txt'
+    insertbefore: EOF
+    state: present
+    line: This is the last line
+  register: result
+
+- name: assert that the new line was added
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+
+- name: Test appending to the file using the default (windows) line separator again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_windows_sep.txt'
+    insertbefore: EOF
+    state: present
+    line: This is the last line
+  register: result_again
+
+- name: assert appending with the windows line separator is idempotent
+  assert:
+    that:
+    - result_again is not changed
+
+- name: stat the file
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_windows_sep.txt'
+  register: result
+
+- name: assert the file checksum matches expected checksum
+  assert:
+    that:
+    - result.stat.checksum == '6c6f51f98eb499852fbb7ef3b212c26752c25c31'
+
+# 19
+- name: Create unix test file with initial line
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_unix_sep.txt'
+    create: true
+    insertbefore: BOF
+    state: present
+    line: This is a new file
+  register: result
+
+- name: assert that the new file was created
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+
+- name: validate that the newly created file exists
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_unix_sep.txt'
+  register: result
+
+- name: assert the newly created file checksum matches
+  assert:
+    that:
+    - result.stat.checksum == '84faac1183841c57434693752fc3debc91b9195d'
+
+# 20
+- name: Test appending to the file using unix line separator
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_unix_sep.txt'
+    insertbefore: EOF
+    state: present
+    line: This is the last line
+    newline: unix
+  register: result
+
+- name: assert that the new line was added
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+
+- name: Test appending to the file using unix line separator again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_unix_sep.txt'
+    insertbefore: EOF
+    state: present
+    line: This is the last line
+    newline: unix
+  register: result_again
+
+- name: assert appending with the unix line separator is idempotent
+  assert:
+    that:
+    - result_again is not changed
+
+- name: stat the file
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_unix_sep.txt'
+  register: result
+
+- name: assert the file checksum matches expected checksum
+  assert:
+    that:
+    - result.stat.checksum == '4aa2ad771bb1453406760eadee8234265d599dcf'
+
+# Encoding management test cases
+
+# 21 - default (auto) encoding should use utf-8 with no BOM
+- name: Test create file without explicit encoding results in utf-8 without BOM
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_auto_utf8.txt'
+    create: true
+    insertbefore: BOF
+    state: present
+    line: This is a new utf-8 file
+  register: result
+
+- name: assert that the new file was created
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+    - result.encoding == 'utf-8'
+
+- name: Test create file without explicit encoding again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_auto_utf8.txt'
+    create: true
+    insertbefore: BOF
+    state: present
+    line: This is a new utf-8 file
+  register: result_again
+
+- name: assert creating a utf-8 file without a BOM is idempotent
+  assert:
+    that:
+    - result_again is not changed
+    - result_again.encoding == 'utf-8'
+
+- name: validate that the newly created file exists
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_auto_utf8.txt'
+  register: result
+
+- name: assert the newly created file checksum matches
+  assert:
+    that:
+    - result.stat.checksum == 'b69fcbacca8291a4668f57fba91d7c022f1c3dc7'
+
+# 22
+- name: Test appending to the utf-8 without BOM file - should autodetect UTF-8 no BOM
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_auto_utf8.txt'
+    insertbefore: EOF
+    state: present
+    line: This is the last line
+  register: result
+
+- name: assert that the new line was added and encoding did not change
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+    - result.encoding == 'utf-8'
+
+- name: Test appending to the utf-8 without BOM file again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_auto_utf8.txt'
+    insertbefore: EOF
+    state: present
+    line: This is the last line
+  register: result_again
+
+- name: assert appending to a utf-8 file without a BOM is idempotent
+  assert:
+    that:
+    - result_again is not changed
+    - result_again.encoding == 'utf-8'
+
+- name: stat the file
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_auto_utf8.txt'
+  register: result
+
+- name: assert the file checksum matches
+  assert:
+    that:
+    - result.stat.checksum == 'aeb246a40f614889534f4983f47c5567625ade53'
+
+# 23 - UTF-8 explicit (with BOM)
+- name: Test create file with explicit utf-8 encoding results in utf-8 with a BOM
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_utf8.txt'
+    create: true
+    encoding: utf-8
+    insertbefore: BOF
+    state: present
+    line: This is a new utf-8 file
+  register: result
+
+- name: assert that the new file was created
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+    - result.encoding == 'utf-8'
+
+- name: Test create file with explicit utf-8 encoding again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_utf8.txt'
+    create: true
+    encoding: utf-8
+    insertbefore: BOF
+    state: present
+    line: This is a new utf-8 file
+  register: result_again
+
+- name: assert creating a utf-8 file with a BOM is idempotent
+  assert:
+    that:
+    - result_again is not changed
+    - result_again.encoding == 'utf-8'
+
+- name: validate that the newly created file exists
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_utf8.txt'
+  register: result
+
+- name: assert the newly created file checksum matches
+  assert:
+    that:
+    - result.stat.checksum == 'd45344b2b3bf1cf90eae851b40612f5f37a88bbb'
+
+# 24
+- name: Test appending to the utf-8 with BOM file - should autodetect utf-8 with BOM encoding
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_utf8.txt'
+    insertbefore: EOF
+    state: present
+    line: This is the last line
+  register: result
+
+- name: assert that the new line was added and encoding did not change
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+    - result.encoding == 'utf-8'
+
+- name: Test appending to the utf-8 with BOM file again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_utf8.txt'
+    insertbefore: EOF
+    state: present
+    line: This is the last line
+  register: result_again
+
+- name: assert appending to a utf-8 file with a BOM is idempotent
+  assert:
+    that:
+    - result_again is not changed
+    - result_again.encoding == 'utf-8'
+
+- name: stat the file
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_utf8.txt'
+  register: result
+
+- name: assert the file checksum matches
+  assert:
+    that:
+    - result.stat.checksum == '64c62066d06ea6c807a8fe98bc40c4903cf4c119'
+
+# 25 - UTF-16 explicit
+- name: Test create file with explicit utf-16 encoding
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_utf16.txt'
+    create: true
+    encoding: utf-16
+    insertbefore: BOF
+    state: present
+    line: This is a new utf-16 file
+  register: result
+
+- name: assert that the new file was created
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+    - result.encoding == 'utf-16'
+
+- name: Test create file with explicit utf-16 encoding again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_utf16.txt'
+    create: true
+    encoding: utf-16
+    insertbefore: BOF
+    state: present
+    line: This is a new utf-16 file
+  register: result_again
+
+- name: assert creating a utf-16 file is idempotent
+  assert:
+    that:
+    - result_again is not changed
+    - result_again.encoding == 'utf-16'
+
+- name: validate that the newly created file exists
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_utf16.txt'
+  register: result
+
+- name: assert the newly created file checksum matches
+  assert:
+    that:
+    - result.stat.checksum == '785b0693cec13b60e2c232782adeda2f8a967434'
+
+# 26
+- name: Test appending to the utf-16 file - should autodetect utf-16 encoding
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_utf16.txt'
+    insertbefore: EOF
+    state: present
+    line: This is the last line
+  register: result
+
+- name: assert that the new line was added and encoding did not change
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+    - result.encoding == 'utf-16'
+
+- name: Test appending to the utf-16 file again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_utf16.txt'
+    insertbefore: EOF
+    state: present
+    line: This is the last line
+  register: result_again
+
+- name: assert appending to a utf-16 file is idempotent
+  assert:
+    that:
+    - result_again is not changed
+    - result_again.encoding == 'utf-16'
+
+- name: stat the file
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_utf16.txt'
+  register: result
+
+- name: assert the file checksum matches
+  assert:
+    that:
+    - result.stat.checksum == '7f790f323e496b7138883a3634514cc2a3426919'
+
+# 27 - UTF-32 explicit
+- name: Test create file with explicit utf-32 encoding
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_utf32.txt'
+    create: true
+    encoding: utf-32
+    insertbefore: BOF
+    state: present
+    line: This is a new utf-32 file
+  register: result
+
+- name: assert that the new file was created
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+    - result.encoding == 'utf-32'
+
+- name: Test create file with explicit utf-32 encoding again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_utf32.txt'
+    create: true
+    encoding: utf-32
+    insertbefore: BOF
+    state: present
+    line: This is a new utf-32 file
+  register: result_again
+
+- name: assert creating a utf-32 file is idempotent
+  assert:
+    that:
+    - result_again is not changed
+    - result_again.encoding == 'utf-32'
+
+- name: validate that the newly created file exists
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_utf32.txt'
+  register: result
+
+- name: assert the newly created file checksum matches
+  assert:
+    that:
+    - result.stat.checksum == '7a6e3f3604c0def431aaa813173a4ddaa10fd1fb'
+
+# 28
+- name: Test appending to the utf-32 file - should autodetect utf-32 encoding
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_utf32.txt'
+    insertbefore: EOF
+    state: present
+    line: This is the last line
+  register: result
+
+- name: assert that the new line was added and encoding did not change
+  assert:
+    that:
+    - result is changed
+    - result.msg == 'line added'
+    - result.encoding == 'utf-32'
+
+- name: Test appending to the utf-32 file again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_utf32.txt'
+    insertbefore: EOF
+    state: present
+    line: This is the last line
+  register: result_again
+
+- name: assert appending to a utf-32 file is idempotent
+  assert:
+    that:
+    - result_again is not changed
+    - result_again.encoding == 'utf-32'
+
+- name: stat the file
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_utf32.txt'
+  register: result
+
+- name: assert the file checksum matches
+  assert:
+    that:
+    - result.stat.checksum == 'd13e135c7d466cc2f985d72f12ffaa73567772e6'
+
+# Check mode and diff mode
+- name: create a file to exercise check mode
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_check_mode.txt'
+    create: true
+    insertbefore: BOF
+    state: present
+    line: This is a new file
+  register: check_mode_setup
+
+- name: add a line in check mode
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_check_mode.txt'
+    state: present
+    line: This line is only added in check mode
+  register: check_mode_add
+  check_mode: true
+  diff: true
+
+- name: stat the check mode file after the check mode addition
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_check_mode.txt'
+  register: check_mode_stat
+
+- name: assert check mode reported the addition without touching the file
+  assert:
+    that:
+    - check_mode_setup is changed
+    - check_mode_add is changed
+    - check_mode_add.msg == 'line added'
+    - "'This line is only added in check mode' not in check_mode_add.diff.before"
+    - "'This line is only added in check mode' in check_mode_add.diff.after"
+    - check_mode_stat.stat.checksum == '84faac1183841c57434693752fc3debc91b9195d'
+
+- name: remove a line in check mode
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_check_mode.txt'
+    state: absent
+    regex: '^This is a new file$'
+  register: check_mode_remove
+  check_mode: true
+
+- name: stat the check mode file after the check mode removal
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_check_mode.txt'
+  register: check_mode_stat
+
+- name: assert check mode reported the removal without touching the file
+  assert:
+    that:
+    - check_mode_remove is changed
+    - check_mode_remove.msg == '1 line(s) removed'
+    - check_mode_remove.found == 1
+    - check_mode_stat.stat.checksum == '84faac1183841c57434693752fc3debc91b9195d'
+
+#########################################################################
+# issue #33858
+# \r\n causes line break instead of printing literally which breaks paths.
+
+- name: create testing file
+  ansible.windows.win_copy:
+    src: test_linebreak.txt
+    dest: '{{ remote_tmp_dir }}/test_linebreak.txt'
+
+- name: stat the test file
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_linebreak.txt'
+  register: result
+
+- name: check win_stat file result
+  assert:
+    that:
+    - result.stat.exists
+    - not result.stat.isdir
+    - result.stat.checksum == 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
+    - result is not failed
+    - result is not changed
+
+# 29 - the line below is a YAML plain scalar so the backslashes stay literal
+- name: insert path c:\return\new to test file
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_linebreak.txt'
+    line: c:\return\new
+  register: result_literal
+
+- name: assert that the literal line was inserted
+  assert:
+    that:
+    - result_literal is changed
+    - result_literal.msg == 'line added'
+
+- name: insert path c:\return\new to test file again
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_linebreak.txt'
+    line: c:\return\new
+  register: result_literal_again
+
+- name: assert that inserting a literal path is idempotent
+  assert:
+    that:
+    - result_literal_again is not changed
+
+# 30
+# The line below is a YAML double quoted scalar, so \r and \n are expanded into real control
+# characters. The resulting line cannot be matched again when the file is read back line by line,
+# so this operation is inherently not idempotent and deliberately is not re-run.
+- name: insert path "c:\return\new" to test file, will cause line breaks
+  ansible.windows.win_lineinfile:
+    path: '{{ remote_tmp_dir }}/test_linebreak.txt'
+    line: "c:\return\new"
+  register: result_expand
+
+- name: assert that the expanded line was inserted
+  assert:
+    that:
+    - result_expand is changed
+    - result_expand.msg == 'line added'
+
+- name: stat the test file
+  ansible.windows.win_stat:
+    path: '{{ remote_tmp_dir }}/test_linebreak.txt'
+  register: result
+
+- name: assert that one line is literal and the other has breaks
+  assert:
+    that:
+    - result.stat.checksum == 'd2dfd11bc70526ff13a91153c76a7ae5595a845b'
+
+# 31 - relative paths
+- name: Get current working directory
+  ansible.windows.win_shell: $pwd.Path
+  register: pwd
+
+- name: create a relative tmp dir
+  ansible.windows.win_tempfile:
+    path: '{{ pwd.stdout | trim | win_dirname }}'
+    state: directory
+  register: relative_tmp_dir
+
+- name: Check that relative paths work
+  block:
+  - name: deploy the test file for lineinfile
+    ansible.windows.win_copy:
+      src: test.txt
+      dest: '{{ relative_tmp_dir.path }}/test.txt'
+    register: result
+
+  - name: assert that the test file was deployed
+    assert:
+      that:
+      - result is changed
+
+  - name: stat the test file
+    ansible.windows.win_stat:
+      path: '{{ relative_tmp_dir.path }}/test.txt'
+    register: result
+
+  - name: check win_stat file result
+    assert:
+      that:
+      - result.stat.exists
+      - not result.stat.isdir
+      - result.stat.checksum == '5feac65e442c91f557fc90069ce6efc4d346ab51'
+      - result is not failed
+      - result is not changed
+
+  - name: insert a line at the beginning of the file, and back it up
+    ansible.windows.win_lineinfile:
+      path: '../{{ relative_tmp_dir.path | win_basename }}/test.txt'
+      state: present
+      line: New line at the beginning
+      insertbefore: BOF
+      backup: true
+    register: result
+
+  - name: stat the backup file
+    ansible.windows.win_stat:
+      path: '{{ result.backup_file }}'
+    register: backup_file
+
+  - name: assert that the line was inserted at the head of the file
+    assert:
+      that:
+      - result is changed
+      - result.msg == 'line added'
+      - backup_file.stat.exists
+      - backup_file.stat.checksum == '5feac65e442c91f557fc90069ce6efc4d346ab51'
+
+  - name: insert a line at the beginning of the file using a relative path again
+    ansible.windows.win_lineinfile:
+      path: '../{{ relative_tmp_dir.path | win_basename }}/test.txt'
+      state: present
+      line: New line at the beginning
+      insertbefore: BOF
+      backup: true
+    register: result_again
+
+  - name: assert that inserting a line using a relative path is idempotent
+    assert:
+      that:
+      - result_again is not changed
+      - result_again.backup_file is not defined
+
+  - name: stat the test after the insert at the head
+    ansible.windows.win_stat:
+      path: '{{ relative_tmp_dir.path }}/test.txt'
+    register: result
+
+  - name: assert test hash is what we expect for the file with the insert at the head
+    assert:
+      that:
+      - result.stat.checksum == 'c61233b0ee2038aab41b5f30683c57b2a013b376'
+
+  always:
+  - name: remove the relative tmp dir
+    ansible.windows.win_file:
+      path: '{{ relative_tmp_dir.path }}'
+      state: absent

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,1 +1,4 @@
 tests/integration/targets/win_dsc/files/xTestCompositeDsc/1.0.0/DSCResources/xTestComposite/xTestComposite.schema.psm1 pslint!skip # Pwsh cannot parse DSC to MOF on Linux
+tests/integration/targets/win_lineinfile/files/expectations/23_utf8_bom.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/24_utf8_bom_line_added.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/30_linebreaks_checksum_bad.txt line-endings

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,1 +1,4 @@
 tests/integration/targets/win_dsc/files/xTestCompositeDsc/1.0.0/DSCResources/xTestComposite/xTestComposite.schema.psm1 pslint!skip # Pwsh cannot parse DSC to MOF on Linux
+tests/integration/targets/win_lineinfile/files/expectations/23_utf8_bom.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/24_utf8_bom_line_added.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/30_linebreaks_checksum_bad.txt line-endings

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,1 +1,4 @@
 tests/integration/targets/win_dsc/files/xTestCompositeDsc/1.0.0/DSCResources/xTestComposite/xTestComposite.schema.psm1 pslint!skip # Pwsh cannot parse DSC to MOF on Linux
+tests/integration/targets/win_lineinfile/files/expectations/23_utf8_bom.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/24_utf8_bom_line_added.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/30_linebreaks_checksum_bad.txt line-endings

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -1,1 +1,4 @@
 tests/integration/targets/win_dsc/files/xTestCompositeDsc/1.0.0/DSCResources/xTestComposite/xTestComposite.schema.psm1 pslint!skip # Pwsh cannot parse DSC to MOF on Linux
+tests/integration/targets/win_lineinfile/files/expectations/23_utf8_bom.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/24_utf8_bom_line_added.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/30_linebreaks_checksum_bad.txt line-endings

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,1 +1,4 @@
 tests/integration/targets/win_dsc/files/xTestCompositeDsc/1.0.0/DSCResources/xTestComposite/xTestComposite.schema.psm1 pslint!skip # Pwsh cannot parse DSC to MOF on Linux
+tests/integration/targets/win_lineinfile/files/expectations/23_utf8_bom.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/24_utf8_bom_line_added.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/30_linebreaks_checksum_bad.txt line-endings

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,1 +1,4 @@
 tests/integration/targets/win_dsc/files/xTestCompositeDsc/1.0.0/DSCResources/xTestComposite/xTestComposite.schema.psm1 pslint!skip # Pwsh cannot parse DSC to MOF on Linux
+tests/integration/targets/win_lineinfile/files/expectations/23_utf8_bom.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/24_utf8_bom_line_added.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/30_linebreaks_checksum_bad.txt line-endings

--- a/tests/sanity/ignore-2.22.txt
+++ b/tests/sanity/ignore-2.22.txt
@@ -1,1 +1,4 @@
 tests/integration/targets/win_dsc/files/xTestCompositeDsc/1.0.0/DSCResources/xTestComposite/xTestComposite.schema.psm1 pslint!skip # Pwsh cannot parse DSC to MOF on Linux
+tests/integration/targets/win_lineinfile/files/expectations/23_utf8_bom.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/24_utf8_bom_line_added.txt shebang
+tests/integration/targets/win_lineinfile/files/expectations/30_linebreaks_checksum_bad.txt line-endings


### PR DESCRIPTION
##### SUMMARY

Promotes `win_lineinfile` from `community.windows` into `ansible.windows`, closing a parity gap: `ansible.builtin.lineinfile` is supported, but its Windows equivalent has only ever lived in the unsupported community collection.

The module is not copied across as-is. It is ported to the current `ansible.windows` house style, and the following design decisions were made during the port:

- **`Ansible.Basic` replaces the legacy module utils.** The community version is built on `Ansible.ModuleUtils.Legacy` with `Fail-Json`/`Exit-Json` and `Get-AnsibleParam`. This version uses `#AnsibleRequires -CSharpUtil Ansible.Basic`, an argument spec, and `$module.FailJson()`/`$module.ExitJson()`, matching every other module in this collection.
- **Validation runs through `Start-AnsibleWindowsProcess`** from `ansible.windows.module_utils.Process`, rather than the community version's bare process invocation. Stdout and stderr are captured reliably and both are reported when validation fails, instead of the caller getting a truncated or empty error.
- **The staging temp file is removed in a `finally` block.** In the community version a failed validation or a failed copy could leave the temporary file behind on the remote host.
- **Diff support is preserved, not added.** The community module already supported diff via the legacy `_ansible_diff` parameter; it is reimplemented here using `$module.DiffMode` and `$module.Diff`, which is the `Ansible.Basic` equivalent. Check mode is likewise carried over.
- **Documentation converted to semantic markup** (`O()`, `V()`, `C()`), and all example and `seealso` FQCNs now point at `ansible.windows`.

Jira: ACA-6306

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

win_lineinfile

##### ADDITIONAL INFORMATION

`version_added: 3.9.0` is set on the module.

**Test coverage.** The integration target ports the community target in full and adds coverage it lacked: an idempotency re-run asserting `changed=false` for every mutating task, explicit check mode and diff mode cases, and the `validate must contain %s` failure path.

Each operation is compared against a checked-in expected-output fixture byte for byte. The 31 fixtures cover insertion at BOF/EOF, insertion relative to a regex match, line removal, backreferences, quoting, files with no trailing newline, empty files, relative paths, and UTF-8, UTF-8 with BOM, UTF-16 and UTF-32 encodings. The fixtures and their `.gitattributes` are carried over from the community target unchanged — the `.gitattributes` pins line endings and working-tree encoding, and without it git rewrites the CRLF/LF and BOM fixtures on checkout and the encoding tests silently stop testing anything.

**On the three sanity ignore entries.** All three are for test fixtures, not for module code:

```
tests/integration/targets/win_lineinfile/files/expectations/23_utf8_bom.txt shebang
tests/integration/targets/win_lineinfile/files/expectations/24_utf8_bom_line_added.txt shebang
tests/integration/targets/win_lineinfile/files/expectations/30_linebreaks_checksum_bad.txt line-endings
```

The two `shebang` entries are UTF-8 files beginning with a byte-order mark, which causes the shebang check to misread their first bytes. The `line-endings` entry is a fixture that deliberately contains mixed line endings in order to test that case; normalising it to satisfy the check would defeat the test it exists for.

No changelog fragment is included, per the convention for new modules in this collection.

Testing performed:

- `ansible-test sanity` — passing
- `ansible-test windows-integration win_lineinfile` — passing against Windows Server 2025, PowerShell 5.1

A corresponding deprecation redirect for `community.windows.win_lineinfile` will be raised against `community.windows` once this merges.
