### PR TITLE
win_template - Add validate option and diff test coverage

### DIFF
--- a/changelogs/fragments/aca6280-win_template-diff-validate.yml
+++ b/changelogs/fragments/aca6280-win_template-diff-validate.yml
@@ -1,0 +1,8 @@
+minor_changes:
+  - >-
+    win_template - Add the ``validate`` option to run a command against the
+    rendered template on the remote host before it is copied to ``dest``. The
+    path of the rendered template is substituted into the command in place of
+    ``%s`` and is quoted for PowerShell so paths containing spaces are handled
+    correctly. If the command fails ``dest`` is left untouched -
+    https://github.com/ansible-collections/ansible.windows/issues/50

--- a/plugins/action/win_template.py
+++ b/plugins/action/win_template.py
@@ -45,9 +45,78 @@ except ImportError:
     from ansible.template import AnsibleEnvironment  # type: ignore[no-redef]
 
 
+# PowerShell treats all of these codepoints as a single quote, each one needs to be doubled up to be
+# escaped inside a single quoted string.
+# https://github.com/PowerShell/PowerShell/blob/b7cb335f03fe2992d0cbd61699de9d9aafa1d7c1/src/System.Management.Automation/engine/parser/CharTraits.cs#L265-L272
+_PWSH_QUOTE_CHARS = u"'\u2018\u2019\u201a\u201b"
+
+
+def _quote_pwsh_literal(value):
+    """Wrap value in a PowerShell single quoted string so it is used verbatim.
+
+    This is used instead of naive string concatenation so that paths containing spaces, backslashes
+    or quotes are passed through to the validation command unchanged.
+    """
+    value = to_text(value, errors='surrogate_or_strict')
+    for char in _PWSH_QUOTE_CHARS:
+        value = value.replace(char, char + char)
+
+    return u"'%s'" % value
+
+
 class ActionModule(ActionBase):
 
     TRANSFERS_FILES = True
+
+    def _validate_rendered_file(self, local_path, remote_filename, validate, task_vars):
+        """Run the validate command against the rendered template on the remote host.
+
+        The rendered template is transferred to a temporary directory on the remote host and the
+        validate command is run against it through the PowerShell shell. Nothing is written to the
+        final destination, so a failing command leaves the destination untouched.
+
+        :arg local_path: Path on the controller of the rendered template.
+        :arg remote_filename: Filename to use for the rendered template on the remote host.
+        :arg validate: The validation command containing the ``%s`` placeholder.
+        :arg task_vars: The task vars to run the validation module with.
+        :returns: ``None`` when the validation succeeded, otherwise a result dict for the failure.
+        """
+        # _make_tmp_path sets _shell.tmpdir, use our own directory that is cleaned up straight
+        # after the validation so it is not clobbered by the win_copy action that runs next.
+        previous_tmpdir = self._connection._shell.tmpdir
+        tmpdir = self._make_tmp_path()
+        try:
+            remote_path = self._connection._shell.join_path(tmpdir, remote_filename)
+            self._transfer_file(local_path, remote_path)
+
+            cmd = validate.replace('%s', _quote_pwsh_literal(remote_path))
+            validate_result = self._execute_module(
+                module_name='ansible.windows.win_shell',
+                module_args={'_raw_params': cmd},
+                task_vars=task_vars,
+            )
+        finally:
+            self._remove_tmp_path(tmpdir)
+            self._connection._shell.tmpdir = previous_tmpdir
+
+        rc = validate_result.get('rc', 0)
+        if not validate_result.get('failed') and rc == 0:
+            return None
+
+        stderr = validate_result.get('stderr') or ''
+        error = stderr.strip() or validate_result.get('msg') or ''
+
+        return dict(
+            failed=True,
+            changed=False,
+            msg="failed to validate: rc:%s error:%s" % (rc, error),
+            cmd=cmd,
+            rc=rc,
+            stdout=validate_result.get('stdout', ''),
+            stdout_lines=validate_result.get('stdout_lines', []),
+            stderr=stderr,
+            stderr_lines=validate_result.get('stderr_lines', []),
+        )
 
     def run(self, tmp=None, task_vars=None):
         ''' handler for template operations '''
@@ -61,7 +130,7 @@ class ActionModule(ActionBase):
         # Options type validation
         # stings
         for s_type in ('src', 'dest', 'state', 'newline_sequence', 'variable_start_string', 'variable_end_string', 'block_start_string',
-                       'block_end_string', 'comment_start_string', 'comment_end_string'):
+                       'block_end_string', 'comment_start_string', 'comment_end_string', 'validate'):
             if s_type in self._task.args:
                 value = ensure_type(self._task.args[s_type], 'string')
                 if value is not None and not isinstance(value, str):
@@ -87,6 +156,7 @@ class ActionModule(ActionBase):
         comment_start_string = self._task.args.get('comment_start_string', COMMENT_START_STRING)
         comment_end_string = self._task.args.get('comment_end_string', COMMENT_END_STRING)
         output_encoding = self._task.args.get('output_encoding', 'utf-8') or 'utf-8'
+        validate = self._task.args.get('validate', None)
 
         # Option `lstrip_blocks' was added in Jinja2 version 2.7.
         if lstrip_blocks:
@@ -115,6 +185,8 @@ class ActionModule(ActionBase):
                 raise AnsibleActionFail("src and dest are required")
             elif newline_sequence not in allowed_sequences:
                 raise AnsibleActionFail("newline_sequence needs to be one of: \n, \r or \r\n")
+            elif validate is not None and '%s' not in validate:
+                raise AnsibleActionFail("validate must contain %%s: %s" % validate)
             else:
                 try:
                     source = self._find_needle('templates', source)
@@ -207,7 +279,7 @@ class ActionModule(ActionBase):
 
             # remove 'template only' options:
             for remove in ('newline_sequence', 'block_start_string', 'block_end_string', 'variable_start_string', 'variable_end_string',
-                           'comment_start_string', 'comment_end_string', 'trim_blocks', 'lstrip_blocks', 'output_encoding'):
+                           'comment_start_string', 'comment_end_string', 'trim_blocks', 'lstrip_blocks', 'output_encoding', 'validate'):
                 new_task.args.pop(remove, None)
 
             local_tempdir = tempfile.mkdtemp(dir=C.DEFAULT_LOCAL_TMP)
@@ -216,6 +288,25 @@ class ActionModule(ActionBase):
                 result_file = os.path.join(local_tempdir, os.path.basename(source))
                 with open(to_bytes(result_file, errors='surrogate_or_strict'), 'wb') as f:
                     f.write(to_bytes(resultant, encoding=output_encoding, errors='surrogate_or_strict'))
+
+                # Validate the rendered template before win_copy places it at the destination.
+                # Nothing is run in check mode as the command could have side effects on the host.
+                if validate and not self._task.check_mode:
+                    if self._connection._shell.path_has_trailing_slash(dest):
+                        validate_filename = os.path.basename(source)
+                    else:
+                        # replace \ with / so os.path can be used to get the filename
+                        validate_filename = os.path.basename(dest.replace('\\', os.path.sep))
+
+                    validate_failure = self._validate_rendered_file(
+                        result_file,
+                        validate_filename or os.path.basename(source),
+                        validate,
+                        task_vars,
+                    )
+                    if validate_failure is not None:
+                        result.update(validate_failure)
+                        return result
 
                 new_task.args.update(
                     dict(

--- a/plugins/modules/win_template.py
+++ b/plugins/modules/win_template.py
@@ -96,6 +96,24 @@ options:
     - When set to C(true) the first newline after a block is removed (block, not variable tag!).
     type: bool
     default: yes
+  validate:
+    description:
+    - The validation command to run against the rendered template before it is copied to O(dest).
+    - The rendered template is transferred to a temporary directory on the remote host and its path
+      is substituted into the command wherever the placeholder C(%s) appears. Every occurrence of
+      C(%s) is replaced, all other C(%) characters are left as is.
+    - The substituted path is already quoted for PowerShell so it is safe to use with destinations
+      that contain spaces or backslashes. Do not add quotes of your own around C(%s).
+    - The command is run on the remote Windows host through the PowerShell shell, in the same way
+      M(ansible.windows.win_shell) runs a command. Pipelines and other shell syntax can be used.
+    - If the command exits with a non-zero return code the task fails and O(dest) is left untouched.
+    - The temporary copy of the rendered template is removed once the command has run.
+    - This option is ignored when the task is run in check mode, as the command could have side
+      effects on the remote host.
+    - Unlike M(ansible.builtin.template), the command runs on every non check mode invocation of the
+      task, even when the rendered content already matches O(dest).
+    type: str
+    version_added: '3.9.0'
   variable_end_string:
     description:
     - The string marking the end of a print statement.
@@ -124,6 +142,7 @@ notes:
 - For Linux you can use M(ansible.builtin.template) which uses '\\n' as C(newline_sequence) by default.
 seealso:
 - module: ansible.windows.win_copy
+- module: ansible.windows.win_shell
 - module: ansible.builtin.copy
 - module: ansible.builtin.template
 author:
@@ -148,6 +167,24 @@ EXAMPLES = r'''
     src: unix/config.conf.j2
     dest: C:\share\unix\config.conf
     trim_blocks: true
+
+- name: Render an nginx config, only writing it out once nginx has validated it
+  ansible.windows.win_template:
+    src: nginx.conf.j2
+    dest: C:\nginx\conf\nginx.conf
+    validate: C:\nginx\nginx.exe -t -c %s
+
+- name: Render a JSON file, only writing it out if it parses
+  ansible.windows.win_template:
+    src: app.json.j2
+    dest: C:\Program Files\App\app.json
+    validate: Get-Content -LiteralPath %s -Raw | ConvertFrom-Json | Out-Null
+
+- name: Render a PowerShell script, only writing it out if it has no syntax errors
+  ansible.windows.win_template:
+    src: bootstrap.ps1.j2
+    dest: C:\Temp\bootstrap.ps1
+    validate: $null = [ScriptBlock]::Create((Get-Content -LiteralPath %s -Raw))
 '''
 
 RETURN = r'''

--- a/tests/integration/targets/win_template/tasks/diff_tests.yml
+++ b/tests/integration/targets/win_template/tasks/diff_tests.yml
@@ -1,0 +1,133 @@
+# Tests for the diff output produced by win_template
+# https://github.com/ansible-collections/ansible.windows/issues/16
+
+- name: create diff test directory
+  win_file:
+    path: '{{ remote_tmp_dir }}\diff'
+    state: directory
+
+- block:
+  - name: template with diff and a non-existent destination
+    win_template:
+      src: foo.j2
+      dest: '{{ remote_tmp_dir }}\diff\new.txt'
+    diff: true
+    register: diff_new
+
+  - name: assert template with diff and a non-existent destination
+    assert:
+      that:
+      - diff_new is changed
+      - diff_new.diff.before == ''
+      - diff_new.diff.after == expected_dos
+      - diff_new.diff.after_header | basename == 'foo.j2'
+
+  - name: template with diff and an identical destination
+    win_template:
+      src: foo.j2
+      dest: '{{ remote_tmp_dir }}\diff\new.txt'
+    diff: true
+    register: diff_identical
+
+  - name: assert template with diff and an identical destination
+    assert:
+      that:
+      - diff_identical is not changed
+      - diff_identical.diff is not defined
+
+  - name: create a CRLF destination that differs by a single line
+    win_copy:
+      content: "BEGIN\r\noriginal_value\r\nEND\r\n"
+      dest: '{{ remote_tmp_dir }}\diff\crlf.txt'
+
+  - name: template with diff over an existing CRLF file
+    win_template:
+      src: foo.j2
+      dest: '{{ remote_tmp_dir }}\diff\crlf.txt'
+    diff: true
+    register: diff_crlf
+
+  # Splitting on \n keeps the \r attached to each line so the set difference is only 1 entry when
+  # both sides of the diff use the same line endings. A diff that normalised the rendered content
+  # to LF would report all 3 lines as changed here.
+  - name: assert template with diff over an existing CRLF file
+    assert:
+      that:
+      - diff_crlf is changed
+      - diff_crlf.diff.before == "BEGIN\r\noriginal_value\r\nEND\r\n"
+      - diff_crlf.diff.after == expected_dos
+      - diff_crlf.diff.before_header == remote_tmp_dir ~ '\diff\crlf.txt'
+      - diff_crlf.diff.after_header | basename == 'foo.j2'
+      - (diff_crlf.diff.before.split('\n') | difference(diff_crlf.diff.after.split('\n'))) == ['original_value\r']
+
+  - name: template with diff and a Unix newline_sequence over an existing CRLF file
+    win_template:
+      src: foo.j2
+      dest: '{{ remote_tmp_dir }}\diff\crlf.txt'
+      newline_sequence: '\n'
+    diff: true
+    register: diff_newline_sequence
+
+  # The line endings really do change on disk so every line is expected to be reported as changed,
+  # the diff must reflect the content as it is actually written out.
+  - name: assert template with diff and a Unix newline_sequence over an existing CRLF file
+    assert:
+      that:
+      - diff_newline_sequence is changed
+      - diff_newline_sequence.diff.before == expected_dos
+      - diff_newline_sequence.diff.after == expected_unix
+      - (diff_newline_sequence.diff.before.split('\n') | difference(diff_newline_sequence.diff.after.split('\n')) | length) == 3
+
+  - name: create a CRLF destination for the check mode diff test
+    win_copy:
+      content: "BEGIN\r\noriginal_value\r\nEND\r\n"
+      dest: '{{ remote_tmp_dir }}\diff\check.txt'
+
+  - name: template with diff in check mode
+    win_template:
+      src: foo.j2
+      dest: '{{ remote_tmp_dir }}\diff\check.txt'
+    diff: true
+    check_mode: true
+    register: diff_check_mode
+
+  - name: get result of template with diff in check mode
+    slurp:
+      path: '{{ remote_tmp_dir }}\diff\check.txt'
+    register: diff_check_mode_actual
+
+  - name: assert template with diff in check mode
+    assert:
+      that:
+      - diff_check_mode is changed
+      - diff_check_mode.diff.before == "BEGIN\r\noriginal_value\r\nEND\r\n"
+      - diff_check_mode.diff.after == expected_dos
+      - (diff_check_mode.diff.before.split('\n') | difference(diff_check_mode.diff.after.split('\n'))) == ['original_value\r']
+      - diff_check_mode_actual.content | b64decode == "BEGIN\r\noriginal_value\r\nEND\r\n"
+
+  - name: template with diff in check mode and a non-existent destination
+    win_template:
+      src: foo.j2
+      dest: '{{ remote_tmp_dir }}\diff\check-new.txt'
+    diff: true
+    check_mode: true
+    register: diff_check_mode_new
+
+  - name: get result of template with diff in check mode and a non-existent destination
+    win_stat:
+      path: '{{ remote_tmp_dir }}\diff\check-new.txt'
+    register: diff_check_mode_new_actual
+
+  - name: assert template with diff in check mode and a non-existent destination
+    assert:
+      that:
+      - diff_check_mode_new is changed
+      - diff_check_mode_new.diff.before == ''
+      - diff_check_mode_new.diff.after == expected_dos
+      - not diff_check_mode_new_actual.stat.exists
+
+  always:
+  - name: remove diff test directory
+    win_file:
+      path: '{{ remote_tmp_dir }}\diff'
+      state: absent

--- a/tests/integration/targets/win_template/tasks/main.yml
+++ b/tests/integration/targets/win_template/tasks/main.yml
@@ -304,3 +304,9 @@
     that:
     - template_result_invalid is failed
     - template_result_invalid.msg is search("'undefined_var' is undefined")
+
+- name: run diff tests
+  include_tasks: diff_tests.yml
+
+- name: run validate tests
+  include_tasks: validate_tests.yml

--- a/tests/integration/targets/win_template/tasks/validate_tests.yml
+++ b/tests/integration/targets/win_template/tasks/validate_tests.yml
@@ -1,0 +1,223 @@
+# Tests for the validate option of win_template
+# https://github.com/ansible-collections/ansible.windows/issues/50
+
+- name: create validate test directory
+  win_file:
+    path: '{{ remote_tmp_dir }}\validate'
+    state: directory
+
+- block:
+  - name: template with a validate command that is missing the placeholder
+    win_template:
+      src: foo.j2
+      dest: '{{ remote_tmp_dir }}\validate\no-placeholder.txt'
+      validate: Get-Date
+    register: validate_no_placeholder
+    ignore_errors: true
+
+  - name: get result of template with a validate command that is missing the placeholder
+    win_stat:
+      path: '{{ remote_tmp_dir }}\validate\no-placeholder.txt'
+    register: validate_no_placeholder_actual
+
+  - name: assert template with a validate command that is missing the placeholder
+    assert:
+      that:
+      - validate_no_placeholder is failed
+      - validate_no_placeholder.msg == 'validate must contain %s: Get-Date'
+      - not validate_no_placeholder_actual.stat.exists
+
+  # The command is given the rendered template, not the raw source, so it can only match on the
+  # value of templated_var.
+  - name: template with a successful validate command
+    win_template:
+      src: foo.j2
+      dest: '{{ remote_tmp_dir }}\validate\success.txt'
+      validate: >-
+        if (-not (Select-String -LiteralPath %s -Pattern 'templated_var_loaded' -Quiet)) { exit 1 }
+    register: validate_success
+
+  - name: get result of template with a successful validate command
+    slurp:
+      path: '{{ remote_tmp_dir }}\validate\success.txt'
+    register: validate_success_actual
+
+  - name: assert template with a successful validate command
+    assert:
+      that:
+      - validate_success is changed
+      - validate_success_actual.content | b64decode == expected_dos
+
+  - name: template with a successful validate command again
+    win_template:
+      src: foo.j2
+      dest: '{{ remote_tmp_dir }}\validate\success.txt'
+      validate: >-
+        if (-not (Select-String -LiteralPath %s -Pattern 'templated_var_loaded' -Quiet)) { exit 1 }
+    register: validate_success_again
+
+  - name: assert template with a successful validate command again
+    assert:
+      that:
+      - validate_success_again is not changed
+
+  - name: create an existing destination for the failing validate command
+    win_copy:
+      content: "existing content\r\n"
+      dest: '{{ remote_tmp_dir }}\validate\failure.txt'
+
+  - name: template with a failing validate command
+    win_template:
+      src: foo.j2
+      dest: '{{ remote_tmp_dir }}\validate\failure.txt'
+      validate: >-
+        Test-Path -LiteralPath %s > $null;
+        [Console]::Error.WriteLine("invalid template");
+        exit 3
+    register: validate_failure
+    ignore_errors: true
+
+  - name: get result of template with a failing validate command
+    slurp:
+      path: '{{ remote_tmp_dir }}\validate\failure.txt'
+    register: validate_failure_actual
+
+  - name: assert template with a failing validate command
+    assert:
+      that:
+      - validate_failure is failed
+      - validate_failure is not changed
+      - validate_failure.rc == 3
+      - validate_failure.msg is search('^failed to validate: rc:3 error:')
+      - validate_failure.stderr is search('invalid template')
+      # the destination must be left exactly as it was
+      - validate_failure_actual.content | b64decode == "existing content\r\n"
+
+  - name: template with a failing validate command and a non-existent destination
+    win_template:
+      src: foo.j2
+      dest: '{{ remote_tmp_dir }}\validate\failure-new.txt'
+      validate: Test-Path -LiteralPath %s > $null; exit 1
+    register: validate_failure_new
+    ignore_errors: true
+
+  - name: get result of template with a failing validate command and a non-existent destination
+    win_stat:
+      path: '{{ remote_tmp_dir }}\validate\failure-new.txt'
+    register: validate_failure_new_actual
+
+  - name: assert template with a failing validate command and a non-existent destination
+    assert:
+      that:
+      - validate_failure_new is failed
+      - not validate_failure_new_actual.stat.exists
+
+  - name: create a validate destination directory containing a space
+    win_file:
+      path: '{{ remote_tmp_dir }}\validate\dir with space'
+      state: directory
+
+  # The temporary path given to the validate command is derived from the destination filename and is
+  # quoted for PowerShell, this checks both of those behaviours.
+  - name: template to a destination with spaces and validate
+    win_template:
+      src: foo.j2
+      dest: '{{ remote_tmp_dir }}\validate\dir with space\file with space.txt'
+      validate: >-
+        $file = Get-Item -LiteralPath %s;
+        if ($file.Name -ne 'file with space.txt') { exit 1 }
+    register: validate_spaces
+
+  - name: get result of template to a destination with spaces and validate
+    slurp:
+      path: '{{ remote_tmp_dir }}\validate\dir with space\file with space.txt'
+    register: validate_spaces_actual
+
+  - name: assert template to a destination with spaces and validate
+    assert:
+      that:
+      - validate_spaces is changed
+      - validate_spaces_actual.content | b64decode == expected_dos
+
+  - name: create a validate destination directory for the trailing slash test
+    win_file:
+      path: '{{ remote_tmp_dir }}\validate\dir'
+      state: directory
+
+  # When dest is a directory the rendered template keeps the source filename.
+  - name: template to a directory destination and validate
+    win_template:
+      src: foo.j2
+      dest: '{{ remote_tmp_dir }}\validate\dir\'
+      validate: >-
+        $file = Get-Item -LiteralPath %s;
+        if ($file.Name -ne 'foo.j2') { exit 1 }
+    register: validate_dir
+
+  - name: get result of template to a directory destination and validate
+    slurp:
+      path: '{{ remote_tmp_dir }}\validate\dir\foo.j2'
+    register: validate_dir_actual
+
+  - name: assert template to a directory destination and validate
+    assert:
+      that:
+      - validate_dir is changed
+      - validate_dir_actual.content | b64decode == expected_dos
+
+  # The validate command must not run in check mode, it creates a marker file and exits non-zero so
+  # both the command running and the destination being written can be detected.
+  - name: template with validate in check mode
+    win_template:
+      src: foo.j2
+      dest: '{{ remote_tmp_dir }}\validate\check.txt'
+      validate: >-
+        New-Item -Path "{{ remote_tmp_dir }}\validate\validate-ran.txt" -ItemType File > $null;
+        Test-Path -LiteralPath %s > $null;
+        exit 1
+    check_mode: true
+    register: validate_check_mode
+
+  - name: check whether the validate command ran in check mode
+    win_stat:
+      path: '{{ remote_tmp_dir }}\validate\validate-ran.txt'
+    register: validate_check_mode_marker
+
+  - name: get result of template with validate in check mode
+    win_stat:
+      path: '{{ remote_tmp_dir }}\validate\check.txt'
+    register: validate_check_mode_actual
+
+  - name: assert template with validate in check mode
+    assert:
+      that:
+      - validate_check_mode is changed
+      - validate_check_mode is not failed
+      - not validate_check_mode_marker.stat.exists
+      - not validate_check_mode_actual.stat.exists
+
+  - name: template with validate and backup
+    win_template:
+      src: another_foo.j2
+      dest: '{{ remote_tmp_dir }}\validate\success.txt'
+      backup: true
+      validate: >-
+        if (-not (Select-String -LiteralPath %s -Pattern 'ABC' -Quiet)) { exit 1 }
+    register: validate_backup
+
+  - name: get backup file of template with validate and backup
+    slurp:
+      path: '{{ validate_backup.backup_file }}'
+    register: validate_backup_actual
+
+  - name: assert template with validate and backup
+    assert:
+      that:
+      - validate_backup is changed
+      - validate_backup_actual.content | b64decode == expected_dos
+
+  always:
+  - name: remove validate test directory
+    win_file:
+      path: '{{ remote_tmp_dir }}\validate'
+      state: absent


### PR DESCRIPTION
##### SUMMARY

Adds a `validate` option to `win_template`, mirroring the option of the same name in `ansible.builtin.template`, and adds integration test coverage for diff mode.

`validate` runs a command against the rendered template on the remote host *before* it is placed at `dest`. The rendered file is transferred to a temporary directory on the remote host and the command is run there through the PowerShell shell, with the placeholder `%s` replaced by the path of that temporary file. If the command exits non-zero the task fails with the command output and `dest` is left completely untouched, so an invalid config can never be published.

Design decisions:

- **The substituted path is quoted for PowerShell.** `%s` is replaced with the remote path emitted as a PowerShell single-quoted string literal, so destinations containing spaces or backslashes work without the caller adding quoting of its own. This also means the substituted value cannot terminate the quoting and alter the surrounding command. Every occurrence of `%s` is replaced; all other `%` characters are left as-is.
- **Validation happens against the rendered file in its temporary location**, before the copy step, matching `ansible.builtin.template` semantics rather than validating after the destination has already been written.
- **The command is not run in check mode**, since an arbitrary validation command can have side effects on the remote host.
- **`dest` is not modified on validation failure.** Any existing file is left exactly as it was.

Diff support for `win_template` itself came from the `win_copy` action in #937 and is not re-implemented here; this PR adds the integration coverage that change did not include.

Fixes #50
Refs #16

Jira: ACA-6308

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

win_template

##### ADDITIONAL INFORMATION

Example — refuse to publish an nginx config that nginx itself rejects:

```yaml
- name: Render an nginx config, only writing it out once nginx has validated it
  ansible.windows.win_template:
    src: nginx.conf.j2
    dest: C:\nginx\conf\nginx.conf
    validate: C:\nginx\nginx.exe -t -c %s

- name: Render a JSON file, only writing it out if it parses
  ansible.windows.win_template:
    src: app.json.j2
    dest: C:\Program Files\App\app.json
    validate: Get-Content -LiteralPath %s -Raw | ConvertFrom-Json | Out-Null
```

The second example has a destination containing a space and needs no extra quoting, because `%s` is substituted as an already-quoted PowerShell literal.

If the validation command fails, the task fails with its stdout and stderr and the existing `C:\nginx\conf\nginx.conf` retains its previous contents.

**Test coverage.** The new diff-mode tests cover a non-existent destination, an unchanged destination, an existing CRLF destination, a `newline_sequence` change, and check mode. These specifically guard against the rendered content and the destination being compared with mismatched line endings, which is the failure mode that makes diff output on Windows misleading. The `validate` tests cover a passing command, a failing command leaving `dest` untouched, a destination path containing spaces, and the `validate must contain %s` argument-validation failure.

A changelog fragment is included, scoped to the `validate` option only — the diff work is already covered by the fragment from #937.

Testing performed:

- `ansible-test sanity` — passing
- `ansible-test windows-integration win_template` — passing against Windows Server 2025, PowerShell 5.1
- Idempotency verified: re-running a validated template reports `changed=false`
